### PR TITLE
ContentBase - empty `<Template />`

### DIFF
--- a/uSync.Migrations/Handlers/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/ContentBaseMigrationHandler.cs
@@ -120,9 +120,15 @@ internal class ContentBaseMigrationHandler<TEntity>
 
             info.Add(new XElement("Published", new XAttribute("Default", published)));
             info.Add(new XElement("Schedule"));
-            info.Add(new XElement("Template",
-                new XAttribute("Key", context.GetTemplateKey(template)),
-                template));
+
+            if (string.IsNullOrWhiteSpace(template) == false)
+            {
+                info.Add(new XElement("Template", new XAttribute("Key", context.GetTemplateKey(template)), template));
+            }
+            else
+            {
+                info.Add(new XElement("Template"));
+            }
         }
 
         var propertiesList = new XElement("Properties");


### PR DESCRIPTION
Added check if Template's key was empty.

If the key is `Guid.Empty`, then omit the `Key` attribute and value.

I believe this is what uSync Core appears to do, well, it aligned with what I had in the existing content XML files.