### PR TITLE
Added `MigrationId` to `SyncMigrationContext`

### DIFF
--- a/uSync.Migrations/Models/SyncMigrationContext.cs
+++ b/uSync.Migrations/Models/SyncMigrationContext.cs
@@ -13,6 +13,13 @@ public class SyncMigrationContext
     private Dictionary<string, string> _propertyTypes { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<string, Guid> _templateKeys { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
+    public SyncMigrationContext(Guid migrationId)
+    {
+        MigrationId = migrationId;
+    }
+
+    public Guid MigrationId { get; }
+
     public void AddTemplateKey(string templateAlias, Guid templateKey)
          => _ = _templateKeys.TryAdd(templateAlias, templateKey);
 

--- a/uSync.Migrations/Services/SyncMigrationService.cs
+++ b/uSync.Migrations/Services/SyncMigrationService.cs
@@ -32,12 +32,12 @@ public class SyncMigrationService
         var migrationId = Guid.NewGuid();
         var sourceRoot = _migrationFileService.GetMigrationSource("data");
         var migrationRoot = Path.Combine(sourceRoot, migrationId.ToString());
+        var migrationContext = PrepareContext(migrationId, sourceRoot, options);
 
         var itemTypes = options.Handlers.Where(x => x.Include).Select(x => x.Name);
 
         var handlers = GetHandlers(itemTypes);
 
-        var migrationContext = PrepareContext(migrationId, sourceRoot, options);
 
         var results = MigrateFromDisk(migrationId, sourceRoot, migrationContext, handlers);
 
@@ -84,7 +84,7 @@ public class SyncMigrationService
 
     private SyncMigrationContext PrepareContext(Guid migrationId, string root, MigrationOptions options)
     {
-        var context = new SyncMigrationContext();
+        var context = new SyncMigrationContext(migrationId);
 
         if (options.BlockListViews)
         {


### PR DESCRIPTION
My reason for this was that I need to save out some ad-hoc uSync XML files - these were NestedContent items that I wanted as nodes in the Content tree, (I'd swapped out the property-editor from NC to a MNTP, so migrated the data as a list of `Udi`s - I can tell you more if you want?).

Anyway, to do this I needed the `migrationId` (`Guid)` to find where to save the XML file to.

e.g. if I'm doing this from a `SyncMigratingNotification`, I'd inject the `SyncMigrationFileService` and in my handler code/logic, make a call to `_migrationFileService.SaveMigrationFile(notification.Context.MigrationId, myXml, "Content");` which would save the XML in the correct place and copy it over to the "v9" folder with the rest of the migrated files.

Hope this makes sense? Happy to explain further.