### PR TITLE
Organise the profile loading into a service + via code

### DIFF
--- a/uSync.Migrations/Composing/SyncMigrationHandlerCollection.cs
+++ b/uSync.Migrations/Composing/SyncMigrationHandlerCollection.cs
@@ -1,4 +1,6 @@
 ﻿using Umbraco.Cms.Core.Composing;
+
+using uSync.Migrations.Configuration.Models;
 using uSync.Migrations.Handlers;
 
 namespace uSync.Migrations.Composing;
@@ -16,4 +18,13 @@ public class SyncMigrationHandlerCollection : BuilderCollectionBase<ISyncMigrati
     { }
 
     public IEnumerable<ISyncMigrationHandler> Handlers => this;
+}
+
+public class SyncMigrationProfileCollection : BuilderCollectionBase<ISyncMigrationProfile>
+{
+    public SyncMigrationProfileCollection(Func<IEnumerable<ISyncMigrationProfile>> items)
+        : base(items)
+    { }
+
+    public IEnumerable<ISyncMigrationProfile> Profiles => this;
 }

--- a/uSync.Migrations/Composing/SyncMigrationProfileCollectionBuilder.cs
+++ b/uSync.Migrations/Composing/SyncMigrationProfileCollectionBuilder.cs
@@ -1,0 +1,11 @@
+﻿using Umbraco.Cms.Core.Composing;
+
+using uSync.Migrations.Configuration.Models;
+
+namespace uSync.Migrations.Composing;
+
+public class SyncMigrationProfileCollectionBuilder
+    : LazyCollectionBuilderBase<SyncMigrationProfileCollectionBuilder, SyncMigrationProfileCollection, ISyncMigrationProfile>
+{
+    protected override SyncMigrationProfileCollectionBuilder This => this;
+}

--- a/uSync.Migrations/Composing/SyncMigrationsComposer.cs
+++ b/uSync.Migrations/Composing/SyncMigrationsComposer.cs
@@ -2,6 +2,9 @@
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
+
+using uSync.Migrations.Configuration;
+using uSync.Migrations.Configuration.Models;
 using uSync.Migrations.Handlers;
 using uSync.Migrations.Migrators;
 using uSync.Migrations.Notifications;
@@ -23,7 +26,12 @@ public class SyncMigrationsComposer : IComposer
             .WithCollectionBuilder<SyncMigrationHandlerCollectionBuilder>()
                 .Add(() => builder.TypeLoader.GetTypes<ISyncMigrationHandler>());
 
+        builder
+            .WithCollectionBuilder<SyncMigrationProfileCollectionBuilder>()
+                .Add(() => builder.TypeLoader.GetTypes<ISyncMigrationProfile>());
+
         builder.Services.AddTransient<SyncMigrationService>();
+        builder.Services.AddTransient<SyncMigrationConfigurationService>();
 
         builder.AddNotificationHandler<ServerVariablesParsingNotification, SyncMigrationsServerVariablesParsingNotificationHandler>();
 

--- a/uSync.Migrations/Configuration/CoreProfiles/ContentMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/ContentMigrationProfile.cs
@@ -1,0 +1,29 @@
+﻿using uSync.Migrations.Composing;
+using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Extensions;
+
+namespace uSync.Migrations.Configuration.CoreProfiles;
+
+public class ContentMigrationProfile : ISyncMigrationProfile
+{
+    private readonly SyncMigrationHandlerCollection _migrationHandlers;
+
+    public ContentMigrationProfile(SyncMigrationHandlerCollection migrationHandlers)
+    {
+        _migrationHandlers = migrationHandlers;
+    }
+
+    public string Name => "Content";
+
+    public string Icon => "icon-documents color-purple";
+
+    public string Description => "Migrate all the content";
+
+    public MigrationOptions Options => new MigrationOptions
+    {
+        Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
+        Handlers = _migrationHandlers
+                        .Handlers
+                        .Select(x => x.ToHandlerOption(x.Group == BackOffice.uSyncConstants.Groups.Content))
+    };
+}

--- a/uSync.Migrations/Configuration/CoreProfiles/EverythingMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/EverythingMigrationProfile.cs
@@ -1,0 +1,29 @@
+﻿using uSync.Migrations.Composing;
+using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Extensions;
+
+namespace uSync.Migrations.Configuration.CoreProfiles;
+
+public class EverythingMigrationProfile : ISyncMigrationProfile
+{
+    private readonly SyncMigrationHandlerCollection _migrationHandlers;
+
+    public EverythingMigrationProfile(SyncMigrationHandlerCollection migrationHandlers)
+    {
+        _migrationHandlers = migrationHandlers;
+    }
+
+    public string Name => "Everything";
+
+    public string Icon => "icon-paper-plane color-orange";
+
+    public string Description => "Migrate everything";
+
+    public MigrationOptions Options => new MigrationOptions
+    {
+        Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
+        Handlers = _migrationHandlers
+                        .Handlers
+                        .Select(x => x.ToHandlerOption(true))
+    };
+}

--- a/uSync.Migrations/Configuration/CoreProfiles/SettingsMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/SettingsMigrationProfile.cs
@@ -1,0 +1,29 @@
+﻿using uSync.Migrations.Composing;
+using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Extensions;
+
+namespace uSync.Migrations.Configuration.CoreProfiles;
+
+public class SettingsMigrationProfile : ISyncMigrationProfile
+{
+    private readonly SyncMigrationHandlerCollection _migrationHandlers;
+
+    public SettingsMigrationProfile(SyncMigrationHandlerCollection migrationHandlers)
+    {
+        _migrationHandlers = migrationHandlers;
+    }
+
+    public string Name => "Settings";
+
+    public string Icon => "icon-settings-alt color-blue";
+
+    public string Description => "Migrate all the settings";
+
+    public MigrationOptions Options => new MigrationOptions
+    {
+        Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
+        Handlers = _migrationHandlers
+                        .Handlers
+                        .Select(x => x.ToHandlerOption(x.Group == BackOffice.uSyncConstants.Groups.Settings))
+    };
+}

--- a/uSync.Migrations/Configuration/MigrationProfilesCollection.cs
+++ b/uSync.Migrations/Configuration/MigrationProfilesCollection.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace uSync.Migrations.Configuration;
+internal class MigrationProfilesCollection
+{
+}

--- a/uSync.Migrations/Configuration/Models/ISyncMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/Models/ISyncMigrationProfile.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+using Umbraco.Cms.Core.Composing;
+
+namespace uSync.Migrations.Configuration.Models;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public interface ISyncMigrationProfile : IDiscoverable
+{
+    string Name { get; }
+    string Icon { get; }
+    string Description { get; }
+    MigrationOptions Options { get; }
+}

--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -1,35 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace uSync.Migrations.Models;
-
-
-[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-public class MigrationProfileInfo
-{
-    public List<MigrationProfile> Profiles { get; set; }
-
-    public bool HasCustom { get; set; }
-}
-
-[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-public class MigratrionProfileConfig
-{
-    public string[] Remove { get; set; }
-    public List<MigrationProfile> Profiles { get; set; }
-}
-
-
-[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-public class MigrationProfile
-{
-    public string Name { get; set; }
-    public string Icon { get; set; }
-    public string Description { get; set; }
-
-    public MigrationOptions Options { get; set; }
-        = new MigrationOptions();
-}
+namespace uSync.Migrations.Configuration.Models;
 
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]

--- a/uSync.Migrations/Configuration/Models/MigrationProfile.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationProfile.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+using Umbraco.Cms.Core.Composing;
+
+namespace uSync.Migrations.Configuration.Models;
+
+/// <summary>
+///  this is the model used when we load from disk ?
+/// </summary>
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+[HideFromTypeFinder]
+public class MigrationProfile : ISyncMigrationProfile
+{
+    public string Name { get; set; }
+    public string Icon { get; set; }
+    public string Description { get; set; }
+
+    public MigrationOptions Options { get; set; }
+        = new MigrationOptions();
+}

--- a/uSync.Migrations/Configuration/Models/MigrationProfileInfo.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationProfileInfo.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace uSync.Migrations.Configuration.Models;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class MigrationProfileInfo
+{
+    public List<ISyncMigrationProfile> Profiles { get; set; }
+
+    public bool HasCustom { get; set; }
+}

--- a/uSync.Migrations/Configuration/Models/MigratrionProfileConfig.cs
+++ b/uSync.Migrations/Configuration/Models/MigratrionProfileConfig.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace uSync.Migrations.Configuration.Models;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class MigratrionProfileConfig
+{
+    public string[] Remove { get; set; }
+    public List<MigrationProfile> Profiles { get; set; }
+}

--- a/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
+++ b/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using Newtonsoft.Json;
+
+using Umbraco.Cms.Core.Extensions;
+using Umbraco.Extensions;
+
+using uSync.Migrations.Composing;
+using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Configuration;
+
+/// <summary>
+///  Service for handling reading/craeting config.
+/// </summary>
+public class SyncMigrationConfigurationService
+{
+    private readonly ILogger<SyncMigrationConfigurationService> _logger;
+    private readonly IHostEnvironment _hostEnvironment;
+    private readonly SyncMigrationService _migrationService;
+    private readonly SyncMigrationProfileCollection _syncMigrationProfiles;
+
+    public SyncMigrationConfigurationService(
+        IHostEnvironment hostEnvironment,
+        SyncMigrationService migrationService,
+        SyncMigrationProfileCollection syncMigrationProfiles)
+    {
+        _hostEnvironment = hostEnvironment;
+        _migrationService = migrationService;
+        _syncMigrationProfiles = syncMigrationProfiles;
+    }
+
+    public MigrationProfileInfo GetProfiles()
+    {
+        var info = GetCoreInfo();
+
+        // if we have more or less than three its custom.
+        if (info.Profiles.Count != 3)
+        {
+            info.HasCustom = true;
+        }
+
+        // Load these from disk (/usync/profiles.json ???)
+        var custom = GetLocalProfiles();
+        if (custom != null)
+        {
+            info.HasCustom = true;
+
+            if (custom.Remove != null && custom.Remove.Length > 0)
+            {
+                info.Profiles = info.Profiles.Where(x => !custom.Remove.InvariantContains(x.Name)).ToList();
+            }
+
+            if (custom.Profiles != null && custom.Profiles.Count > 0)
+            {
+                info.Profiles.AddRange(custom.Profiles);
+            }
+        }
+
+        return info;
+    }
+
+    private MigrationProfileInfo GetCoreInfo()
+        => new MigrationProfileInfo
+        {
+            Profiles = _syncMigrationProfiles.ToList()
+        };
+    
+
+
+    private MigratrionProfileConfig? GetLocalProfiles()
+    {
+        try
+        {
+            var profileFile = _hostEnvironment.MapPathContentRoot("~/uSync/profiles.json");
+
+            if (System.IO.File.Exists(profileFile))
+            {
+                var content = System.IO.File.ReadAllText(profileFile);
+                var config = JsonConvert.DeserializeObject<MigratrionProfileConfig>(content);
+
+                if (config != null)
+                {
+                    foreach (var profile in config.Profiles)
+                    {
+                        var configuredHandlers = profile.Options.Handlers.Select(x => x.Name);
+                        profile.Options.Handlers = _migrationService.GetHandlers()
+                            .Select(x => new HandlerOption
+                            {
+                                Name = x.ItemType,
+                                Include = configuredHandlers.InvariantContains(x.ItemType)
+                            });
+                    }
+
+                    return config;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load profiles.json");
+        }
+
+        return null;
+
+
+    }
+}

--- a/uSync.Migrations/Controllers/uSyncMigrationsController.cs
+++ b/uSync.Migrations/Controllers/uSyncMigrationsController.cs
@@ -8,6 +8,9 @@ using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Web.BackOffice.Controllers;
 using Umbraco.Extensions;
 
+using uSync.Migrations.Composing;
+using uSync.Migrations.Configuration;
+using uSync.Migrations.Configuration.Models;
 using uSync.Migrations.Models;
 using uSync.Migrations.Services;
 
@@ -16,17 +19,14 @@ namespace uSync.Migrations.Controllers;
 public class uSyncMigrationsController : UmbracoAuthorizedApiController
 {
     private readonly SyncMigrationService _migrationService;
-    private readonly IHostEnvironment _hostEnvironment;
-    private readonly ILogger<uSyncMigrationsController> _logger;
+    private readonly SyncMigrationConfigurationService _profileConfigService;
 
     public uSyncMigrationsController(
         SyncMigrationService migrationService,
-        IHostEnvironment hostingEnvironment,
-        ILogger<uSyncMigrationsController> logger)
+        SyncMigrationConfigurationService profileConfigService)
     {
         _migrationService = migrationService;
-        _hostEnvironment = hostingEnvironment;
-        _logger = logger;
+        _profileConfigService = profileConfigService;
     }
 
     [HttpGet]
@@ -55,126 +55,7 @@ public class uSyncMigrationsController : UmbracoAuthorizedApiController
         return _migrationService.MigrateFiles(options);
     }
 
-    public static string _dateMask = "yyyyMMdd_HHmm";
-
     [HttpGet]
-    public MigrationProfileInfo GetProfiles()
-    {
-        var info = GetCoreInfo();
-
-        // Load these from disk (/usync/profiles.json ???)
-        var custom = GetLocalProfiles();
-        if (custom != null)
-        {
-            info.HasCustom = true;
-
-            if (custom.Remove != null && custom.Remove.Length > 0)
-            {
-                info.Profiles = info.Profiles.Where(x => !custom.Remove.InvariantContains(x.Name)).ToList();
-            }
-
-            if (custom.Profiles != null && custom.Profiles.Count > 0)
-            {
-                info.Profiles.AddRange(custom.Profiles);
-            }
-        }
-
-        return info;
-    }
-
-    private MigrationProfileInfo GetCoreInfo()
-    {
-        return new MigrationProfileInfo
-        {
-            Profiles = new List<MigrationProfile>
-            {
-                new MigrationProfile
-                {
-                    Name = "Settings",
-                    Icon = "icon-settings-alt color-blue",
-                    Description = "Migrate all the settings",
-                    Options = new MigrationOptions
-                    {
-                        Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now.ToString(_dateMask)}",
-                        Handlers = _migrationService.GetHandlers()
-                            .Select(x => new HandlerOption
-                            {
-                                Name = x.ItemType,
-                                Include = x.Group == BackOffice.uSyncConstants.Groups.Settings
-                            })
-                    }
-                },
-                new MigrationProfile {
-                    Name = "Content",
-                    Icon = "icon-documents color-purple",
-                    Description = "Migrate all the content",
-                    Options = new MigrationOptions
-                    {
-                        Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now.ToString(_dateMask)}",
-                        Handlers = _migrationService.GetHandlers()
-                            .Select(x => new HandlerOption
-                            {
-                                Name = x.ItemType,
-                                Include = x.Group == BackOffice.uSyncConstants.Groups.Content
-                            })
-                    }
-                },
-                new MigrationProfile
-                {
-                    Name = "Everything",
-                    Description = "Migrate everything",
-                    Icon = "icon-paper-plane color-orange",
-                    Options = new MigrationOptions
-                    {
-                        Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now.ToString(_dateMask)}",
-                        Handlers = _migrationService.GetHandlers()
-                            .Select(x => new HandlerOption
-                            {
-                                Name = x.ItemType,
-                                Include = true
-                            })
-                    }
-                }
-            }
-        };
-    }
-
-
-    private MigratrionProfileConfig? GetLocalProfiles()
-    {
-        try
-        {
-            var profileFile = _hostEnvironment.MapPathContentRoot("~/uSync/profiles.json");
-
-            if (System.IO.File.Exists(profileFile))
-            {
-                var content = System.IO.File.ReadAllText(profileFile);
-                var config = JsonConvert.DeserializeObject<MigratrionProfileConfig>(content);
-
-                if (config != null) 
-                {
-                    foreach (var profile in config.Profiles)
-                    {
-                        var configuredHandlers = profile.Options.Handlers.Select(x => x.Name);
-                        profile.Options.Handlers = _migrationService.GetHandlers()
-                            .Select(x => new HandlerOption
-                            {
-                                Name = x.ItemType,
-                                Include = configuredHandlers.InvariantContains(x.ItemType)
-                            });
-                    }
-
-                    return config;
-                }
-            }
-        }
-        catch(Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to load profiles.json");
-        }
-
-        return null;
-
-
-    }
+    public MigrationProfileInfo GetProfiles() 
+        => _profileConfigService.GetProfiles();
 }

--- a/uSync.Migrations/Extensions/SyncMigrationHandlersExtensions.cs
+++ b/uSync.Migrations/Extensions/SyncMigrationHandlersExtensions.cs
@@ -1,0 +1,9 @@
+﻿using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Handlers;
+
+namespace uSync.Migrations.Extensions;
+public static class SyncMigrationHandlersExtensions
+{
+    public static HandlerOption ToHandlerOption(this ISyncMigrationHandler handler, bool include)
+        => new HandlerOption { Name = handler.ItemType, Include = include };
+}

--- a/uSync.Migrations/Handlers/ISyncMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/ISyncMigrationHandler.cs
@@ -1,8 +1,10 @@
-﻿using uSync.Migrations.Models;
+﻿using Umbraco.Cms.Core.Composing;
+
+using uSync.Migrations.Models;
 
 namespace uSync.Migrations.Handlers;
 
-public interface ISyncMigrationHandler
+public interface ISyncMigrationHandler : IDiscoverable
 {
     public string Group { get; }
 

--- a/uSync.Migrations/Services/SyncMigrationService.cs
+++ b/uSync.Migrations/Services/SyncMigrationService.cs
@@ -2,6 +2,7 @@
 using Umbraco.Extensions;
 using uSync.BackOffice.Configuration;
 using uSync.Migrations.Composing;
+using uSync.Migrations.Configuration.Models;
 using uSync.Migrations.Handlers;
 using uSync.Migrations.Models;
 

--- a/uSync.Migrations/uSync.Migrations.csproj
+++ b/uSync.Migrations/uSync.Migrations.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.0.0" />
 		<PackageReference Include="Umbraco.Cms.Web.Website" Version="10.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-		<PackageReference Include="uSync.BackOffice" Version="10.3.1-build.20221112.7" />
+		<PackageReference Include="uSync.BackOffice" Version="10.3.1-build.20221113.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/uSyncMigrationSite/uSyncMigrationSite.csproj
+++ b/uSyncMigrationSite/uSyncMigrationSite.csproj
@@ -4,11 +4,11 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
-
+	
 	<ItemGroup>
 		<PackageReference Include="Umbraco.Cms" Version="10.2.1" />
 		<PackageReference Include="Umbraco.TheStarterKit" Version="10.0.0" />
-		<PackageReference Include="uSync" Version="10.3.1-build.20221112.7" />
+		<PackageReference Include="uSync" Version="10.3.1-build.20221113.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Move the loading of the profiles into the `SyncMigrationConfigurationService` out of the ApiController.

### Add Via code
Also add a SyncMigrationProfile collection so that if you implement `ISyncMigrationProfile` then you can add to the profiles on the migration page via code. 

```cs
public interface ISyncMigrationProfile : IDiscoverable
{
    string Name { get; }
    string Icon { get; }
    string Description { get; }
    MigrationOptions Options { get; }
}
```

this will make config by code a thing (especially helpful when we add, the exclusions patterns in #13 