### PR TITLE
profiles - keep them lazy loaded but in order

### DIFF
--- a/MyMigrations/MyMigrationProfile.cs
+++ b/MyMigrations/MyMigrationProfile.cs
@@ -29,6 +29,8 @@ public class MyMigrationProfile : ISyncMigrationProfile
 
     public string Description => "My Custom migration with changes";
 
+    public int Order => 10;
+
     public MigrationOptions Options => new()
     {
         // write out to the same folder each time.

--- a/uSync.Migrations/Composing/SyncMigrationProfileCollectionBuilder.cs
+++ b/uSync.Migrations/Composing/SyncMigrationProfileCollectionBuilder.cs
@@ -18,6 +18,6 @@ public class SyncMigrationProfileCollection : BuilderCollectionBase<ISyncMigrati
         : base(items)
     { }
 
-    public IEnumerable<ISyncMigrationProfile> Profiles => this;
+    public IEnumerable<ISyncMigrationProfile> Profiles => this.OrderBy(x => x.Order);
 }
 

--- a/uSync.Migrations/Configuration/CoreProfiles/ContentMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/ContentMigrationProfile.cs
@@ -6,9 +6,10 @@ using uSync.Migrations.Extensions;
 
 namespace uSync.Migrations.Configuration.CoreProfiles;
 
-[Weight(110)]
 public class ContentMigrationProfile : ISyncMigrationProfile
 {
+    public int Order => 110;
+
     private readonly SyncMigrationHandlerCollection _migrationHandlers;
 
     public ContentMigrationProfile(SyncMigrationHandlerCollection migrationHandlers)

--- a/uSync.Migrations/Configuration/CoreProfiles/EverythingMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/EverythingMigrationProfile.cs
@@ -6,9 +6,10 @@ using uSync.Migrations.Extensions;
 
 namespace uSync.Migrations.Configuration.CoreProfiles;
 
-[Weight(120)]
 public class EverythingMigrationProfile : ISyncMigrationProfile
 {
+    public int Order => 120;
+
     private readonly SyncMigrationHandlerCollection _migrationHandlers;
 
     public EverythingMigrationProfile(SyncMigrationHandlerCollection migrationHandlers)
@@ -29,4 +30,5 @@ public class EverythingMigrationProfile : ISyncMigrationProfile
                         .Handlers
                         .Select(x => x.ToHandlerOption(true))
     };
+
 }

--- a/uSync.Migrations/Configuration/CoreProfiles/SettingsMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/SettingsMigrationProfile.cs
@@ -6,9 +6,10 @@ using uSync.Migrations.Extensions;
 
 namespace uSync.Migrations.Configuration.CoreProfiles;
 
-[Weight(101)]
 public class SettingsMigrationProfile : ISyncMigrationProfile
 {
+    public int Order => 101;
+
     private readonly SyncMigrationHandlerCollection _migrationHandlers;
 
     public SettingsMigrationProfile(SyncMigrationHandlerCollection migrationHandlers)

--- a/uSync.Migrations/Configuration/Models/ISyncMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/Models/ISyncMigrationProfile.cs
@@ -8,6 +8,8 @@ namespace uSync.Migrations.Configuration.Models;
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public interface ISyncMigrationProfile : IDiscoverable
 {
+    int Order { get; }
+
     string Name { get; }
     string Icon { get; }
     string Description { get; }

--- a/uSync.Migrations/Configuration/Models/MigrationProfile.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationProfile.cs
@@ -16,6 +16,8 @@ public class MigrationProfile : ISyncMigrationProfile
     public string Icon { get; set; }
     public string Description { get; set; }
 
+    public int Order { get; set; } = 100;
+
     public MigrationOptions Options { get; set; }
         = new MigrationOptions();
 }

--- a/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
+++ b/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using Umbraco.Cms.Core.Extensions;
 using Umbraco.Extensions;
 
+using uSync.Core;
 using uSync.Migrations.Composing;
 using uSync.Migrations.Configuration.Models;
 using uSync.Migrations.Services;
@@ -50,7 +51,8 @@ internal class SyncMigrationConfigurationService : ISyncMigrationConfigurationSe
 
             if (custom.Remove != null && custom.Remove.Length > 0)
             {
-                info.Profiles = info.Profiles.Where(x => !custom.Remove.InvariantContains(x.Name)).ToList();
+                info.Profiles = info.Profiles.Where(x => !custom.Remove.InvariantContains(x.Name))
+                    .ToList();
             }
 
             if (custom.Profiles != null && custom.Profiles.Count > 0)
@@ -59,6 +61,7 @@ internal class SyncMigrationConfigurationService : ISyncMigrationConfigurationSe
             }
         }
 
+        info.Profiles = info.Profiles.OrderBy(x => x.Order).ToList();
         return info;
     }
 


### PR DESCRIPTION
Keeps them in order - but lazy load them - this isn't as 'neat' as weighted, but i didn't want to load profiles and the associated code, unless you actually go near the migrations dashboard. 