### PR TITLE
Marks internal `ISyncPropertyMigrator` classes as public

### DIFF
--- a/uSync.Migrations/Migrators/Community/SwitcherToTrueFalseMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/SwitcherToTrueFalseMigrator.cs
@@ -7,7 +7,7 @@ using uSync.Migrations.Models;
 namespace uSync.Migrations.Migrators;
 
 [SyncMigrator("Our.Umbraco.Switcher")]
-internal class SwitcherToTrueFalseMigrator : SyncPropertyMigratorBase
+public class SwitcherToTrueFalseMigrator : SyncPropertyMigratorBase
 {
     public override string GetEditorAlias(SyncMigrationDataTypeProperty propertyModel, SyncMigrationContext context)
         => UmbConstants.PropertyEditors.Aliases.Boolean;

--- a/uSync.Migrations/Migrators/Community/TerratypeToOpenStreetmapMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/TerratypeToOpenStreetmapMigrator.cs
@@ -7,7 +7,7 @@ using uSync.Migrations.Models;
 namespace uSync.Migrations.Migrators;
 
 [SyncMigrator("Terratype")]
-internal class TerratypeToOpenStreetmapMigrator : SyncPropertyMigratorBase
+public class TerratypeToOpenStreetmapMigrator : SyncPropertyMigratorBase
 {
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => "Bergmania.OpenStreetMap";

--- a/uSync.Migrations/Migrators/Community/UmbracoFormsMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/UmbracoFormsMigrator.cs
@@ -5,7 +5,7 @@ using uSync.Migrations.Models;
 namespace uSync.Migrations.Migrators.Community;
 
 [SyncMigrator("UmbracoForms.FormPicker")]
-internal class UmbracoFormsMigrator : SyncPropertyMigratorBase
+public class UmbracoFormsMigrator : SyncPropertyMigratorBase
 {
     public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => dataTypeProperty.PreValues.ConvertPreValuesToJson(true);

--- a/uSync.Migrations/Migrators/Core/CheckboxListMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/CheckboxListMigrator.cs
@@ -8,7 +8,7 @@ using uSync.Migrations.Models;
 namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.CheckBoxList)]
-internal class CheckboxListMigrator : SyncPropertyMigratorBase
+public class CheckboxListMigrator : SyncPropertyMigratorBase
 {
     public override string GetDatabaseType(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => nameof(ValueStorageType.Nvarchar);

--- a/uSync.Migrations/Migrators/Core/DatePickerMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/DatePickerMigrator.cs
@@ -4,5 +4,5 @@ namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.DateTime, typeof(DateTimeConfiguration), IsDefaultAlias = true)]
 [SyncMigrator("Umbraco.Date")]
-internal class DatePickerMigrator : SyncPropertyMigratorBase
+public class DatePickerMigrator : SyncPropertyMigratorBase
 { }

--- a/uSync.Migrations/Migrators/Core/DropdownMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/DropdownMigrator.cs
@@ -11,7 +11,7 @@ namespace uSync.Migrations.Migrators;
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.DropDownListFlexible, IsDefaultAlias = true)]
 [SyncMigrator("Umbraco.DropDown")]
 [SyncMigrator("Umbraco.DropDownMultiple")]
-internal class DropdownMigrator : SyncPropertyMigratorBase
+public class DropdownMigrator : SyncPropertyMigratorBase
 {
     public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
     {

--- a/uSync.Migrations/Migrators/Core/LabelMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/LabelMigrator.cs
@@ -7,7 +7,7 @@ using uSync.Migrations.Models;
 namespace uSync.Migrations.Migrators;
 
 [SyncMigrator("Umbraco.NoEdit")]
-internal class LabelMigrator : SyncPropertyMigratorBase
+public class LabelMigrator : SyncPropertyMigratorBase
 {
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => UmbConstants.PropertyEditors.Aliases.Label;

--- a/uSync.Migrations/Migrators/Core/ListViewMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/ListViewMigrator.cs
@@ -1,5 +1,5 @@
 ﻿namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.ListView)]
-internal class ListViewMigrator : SyncPropertyMigratorBase
+public class ListViewMigrator : SyncPropertyMigratorBase
 { }

--- a/uSync.Migrations/Migrators/Core/MediaPickerMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/MediaPickerMigrator.cs
@@ -15,7 +15,7 @@ namespace uSync.Migrations.Migrators;
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.MediaPicker)]
 [SyncMigrator("Umbraco.MediaPicker2")]
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.MultipleMediaPicker)]
-internal class MediaPickerMigrator : SyncPropertyMigratorBase
+public class MediaPickerMigrator : SyncPropertyMigratorBase
 {
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => UmbConstants.PropertyEditors.Aliases.MediaPicker3;

--- a/uSync.Migrations/Migrators/Core/MemberPickerMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/MemberPickerMigrator.cs
@@ -2,5 +2,5 @@
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.MemberPicker, IsDefaultAlias = true)]
 [SyncMigrator("Umbraco.MemberPicker2")]
-internal class MemberPickerMigrator : SyncPropertyMigratorBase
+public class MemberPickerMigrator : SyncPropertyMigratorBase
 { }

--- a/uSync.Migrations/Migrators/Core/MultiNodeTreePickerMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/MultiNodeTreePickerMigrator.cs
@@ -10,7 +10,7 @@ namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.MultiNodeTreePicker, IsDefaultAlias = true)]
 [SyncMigrator("Umbraco.MultiNodeTreePicker2")]
-internal class MultiNodeTreePickerMigrator : SyncPropertyMigratorBase
+public class MultiNodeTreePickerMigrator : SyncPropertyMigratorBase
 {
     public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
     {

--- a/uSync.Migrations/Migrators/Core/MultipleTextStringMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/MultipleTextStringMigrator.cs
@@ -3,5 +3,5 @@
 namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.MultipleTextstring, typeof(MultipleTextStringConfiguration))]
-internal class MultipleTextStringMigrator : SyncPropertyMigratorBase
+public class MultipleTextStringMigrator : SyncPropertyMigratorBase
 { }

--- a/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
@@ -11,7 +11,7 @@ namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.NestedContent, typeof(NestedContentConfiguration), IsDefaultAlias = true)]
 [SyncMigrator("Our.Umbraco.NestedContent")]
-internal class NestedContentMigrator : SyncPropertyMigratorBase
+public class NestedContentMigrator : SyncPropertyMigratorBase
 {
     Lazy<SyncPropertyMigratorCollection> _migrators;
 

--- a/uSync.Migrations/Migrators/Core/RadioButtonListMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/RadioButtonListMigrator.cs
@@ -7,7 +7,7 @@ using uSync.Migrations.Models;
 namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.RadioButtonList)]
-internal class RadioButtonListMigrator : SyncPropertyMigratorBase
+public class RadioButtonListMigrator : SyncPropertyMigratorBase
 {
     public override string GetDatabaseType(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => nameof(ValueStorageType.Nvarchar);

--- a/uSync.Migrations/Migrators/Core/RelatedLinksMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/RelatedLinksMigrator.cs
@@ -14,7 +14,7 @@ namespace uSync.Migrations.Migrators;
 
 [SyncMigrator("Umbraco.RelatedLinks")]
 [SyncMigrator("Umbraco.RelatedLinks2")]
-internal class RelatedLinksMigrator : SyncPropertyMigratorBase
+public class RelatedLinksMigrator : SyncPropertyMigratorBase
 {
     private readonly JsonSerializerSettings _serializerSettings;
 

--- a/uSync.Migrations/Migrators/Core/RichTextBoxMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/RichTextBoxMigrator.cs
@@ -4,5 +4,5 @@ namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.TinyMce, typeof(RichTextConfiguration), IsDefaultAlias = true)]
 [SyncMigrator("Umbraco.TinyMCEv3")]
-internal class RichTextBoxMigrator : SyncPropertyMigratorBase
+public class RichTextBoxMigrator : SyncPropertyMigratorBase
 { }

--- a/uSync.Migrations/Migrators/Core/SliderMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/SliderMigrator.cs
@@ -7,7 +7,7 @@ using uSync.Migrations.Models;
 namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.Slider)]
-internal class SliderMigrator : SyncPropertyMigratorBase
+public class SliderMigrator : SyncPropertyMigratorBase
 {
     public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
     {

--- a/uSync.Migrations/Migrators/Core/TrueFalseMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/TrueFalseMigrator.cs
@@ -3,5 +3,5 @@
 namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.Boolean, typeof(TrueFalseConfiguration))]
-internal class TrueFalseMigrator : SyncPropertyMigratorBase
+public class TrueFalseMigrator : SyncPropertyMigratorBase
 { }

--- a/uSync.Migrations/Migrators/Core/UploadFieldMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/UploadFieldMigrator.cs
@@ -3,5 +3,5 @@
 namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.UploadField, typeof(FileUploadConfiguration))]
-internal class UploadFieldMigrator : SyncPropertyMigratorBase
+public class UploadFieldMigrator : SyncPropertyMigratorBase
 { }


### PR DESCRIPTION
If we wanted to replace any of the built-in `ISyncPropertyMigrator` classes in 3rd-party, they'll need to be marked as public.
