### PR TITLE
Move migrators to the context, so they can be configured.

### DIFF
--- a/MyMigrations/GridToBlockListMigrator.cs
+++ b/MyMigrations/GridToBlockListMigrator.cs
@@ -1,10 +1,14 @@
-﻿using uSync.Migrations.Migrators;
+﻿using Umbraco.Cms.Core.Composing;
+
+using uSync.Migrations.Migrators;
 using uSync.Migrations.Migrators.Models;
 using uSync.Migrations.Models;
 
 namespace MyMigrations;
 
 [SyncMigrator(Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.Grid)]
+// [HideFromTypeFinder] // hide from type if you don't want to automatically load this one (you have to replace in a composer)
+// [SyncDefaultMigrator] // set it to default if you do load it and always want it to be the one you use. (can be overriden by preferred)
 internal class GridToBlockListMigrator : SyncPropertyMigratorBase
 {
     /// <summary>

--- a/MyMigrations/MyMigrationComposer.cs
+++ b/MyMigrations/MyMigrationComposer.cs
@@ -32,7 +32,7 @@ public class MySyncMigrationComposer : IComposer
     {
         // if we have a custom migration for the grid, we should 
         // remove the existing one. 
-        builder.SyncPropertyMigrators().Replace<GridMigrator, GridToBlockListMigrator>();
+        // builder.SyncPropertyMigrators().Replace<GridMigrator, GridToBlockListMigrator>();
 
         // our migration will be discovered, if it implements ISyncItemMigrator
 

--- a/MyMigrations/MyMigrationProfile.cs
+++ b/MyMigrations/MyMigrationProfile.cs
@@ -39,7 +39,14 @@ public class MyMigrationProfile : ISyncMigrationProfile
         // load all the handlers just enable the content ones.
         Handlers = _migrationHandlers
                         .Handlers
-                        .Select(x => x.ToHandlerOption(x.Group == uSync.BackOffice.uSyncConstants.Groups.Content)),
+                        .Select(x => x.ToHandlerOption(x.Group == uSync.BackOffice.uSyncConstants.Groups.Content))
+                        .ToList(),
+
+        // for this migrator we want to use our special grid migrator.
+        PreferedMigrators = new Dictionary<string, string>()
+        {
+            { Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.Grid, typeof(GridToBlockListMigrator).Name }
+        },
 
         // eveything beneath is optional... 
 

--- a/uSync.Migrations/Composing/SyncMigrationHandlerCollection.cs
+++ b/uSync.Migrations/Composing/SyncMigrationHandlerCollection.cs
@@ -1,5 +1,7 @@
 ﻿using Umbraco.Cms.Core.Composing;
 
+using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Extensions;
 using uSync.Migrations.Handlers;
 
 namespace uSync.Migrations.Composing;
@@ -17,4 +19,10 @@ public class SyncMigrationHandlerCollection : BuilderCollectionBase<ISyncMigrati
     { }
 
     public IEnumerable<ISyncMigrationHandler> Handlers => this;
+
+    public IList<HandlerOption> SelectGroup(string group)
+        => Handlers
+            .Select(x => x.ToHandlerOption(group == "" || x.Group == group))
+            .ToList();
+
 }

--- a/uSync.Migrations/Composing/SyncPropertyMigratorCollectionBuilder.cs
+++ b/uSync.Migrations/Composing/SyncPropertyMigratorCollectionBuilder.cs
@@ -29,6 +29,11 @@ public class SyncPropertyMigratorCollection
         }
     }
 
+    // TODO: [KJ] - Someway of working out what a default migrator is, so we can return only unique migrators by default.
+    public IList<ISyncPropertyMigrator> GetDefaultMigrators()
+        => _lookup.Values.ToList();
+
+
     public bool TryGet(string editorAlias, out ISyncPropertyMigrator? item) => _lookup.TryGetValue(editorAlias, out item);
 
     public ISyncPropertyMigrator? Get(string editorAlias) => _lookup.TryGetValue(editorAlias, out var migrator) == true ? migrator : default;

--- a/uSync.Migrations/Composing/SyncPropertyMigratorCollectionBuilder.cs
+++ b/uSync.Migrations/Composing/SyncPropertyMigratorCollectionBuilder.cs
@@ -1,6 +1,8 @@
 ﻿using Umbraco.Cms.Core.Composing;
+using Umbraco.Extensions;
 
 using uSync.Migrations.Migrators;
+using uSync.Migrations.Models;
 
 namespace uSync.Migrations.Composing;
 
@@ -13,39 +15,56 @@ public class SyncPropertyMigratorCollectionBuilder
 public class SyncPropertyMigratorCollection
     : BuilderCollectionBase<ISyncPropertyMigrator>
 {
-    private readonly Dictionary<string, ISyncPropertyMigrator> _lookup;
-
     public SyncPropertyMigratorCollection(Func<IEnumerable<ISyncPropertyMigrator>> items)
         : base(items)
-    {
-        _lookup = new Dictionary<string, ISyncPropertyMigrator>(StringComparer.OrdinalIgnoreCase);
+    { }
 
-        foreach (var item in this)
+    public IList<MigratorEditorPair> GetPreferedMigratorList(IDictionary<string, string> preferedMigrators)
+    {
+        var migrators = this.ToList();
+        var defaultMigrators = GetDefaults();
+
+        var editors = new List<MigratorEditorPair>();
+        foreach (var migrator in migrators)
         {
-            foreach (var alias in item.Editors)
+            foreach (var editor in migrator.Editors)
             {
-                _ = _lookup.TryAdd(alias, item);
+                if (preferedMigrators != null && preferedMigrators.ContainsKey(editor))
+                {
+                    var syncMigrator = migrators.FirstOrDefault(x => x.GetType().Name == preferedMigrators[editor]) ?? migrator;
+                    editors.Add(new MigratorEditorPair(editor, syncMigrator));
+                }
+                else
+                {
+                    if (defaultMigrators.ContainsKey(editor))
+                    {
+                        // there is a default for this one, so its the only one we add.
+                        editors.Add(new MigratorEditorPair(editor, defaultMigrators[editor]));
+                    }
+                    else
+                    {
+                        // we just add what ever this is 
+                        editors.Add(new MigratorEditorPair(editor, migrator));
+                    }
+                }
             }
         }
+
+        // remove duplicates (we might add prefered or default multiple times).
+        return editors.DistinctBy(x => $"{x.EditorAlias}_{x.Migrator.GetType().Name}").ToList();
     }
 
-    // TODO: [KJ] - Someway of working out what a default migrator is, so we can return only unique migrators by default.
-    public IList<ISyncPropertyMigrator> GetDefaultMigrators()
-        => _lookup.Values.ToList();
-
-
-    public bool TryGet(string editorAlias, out ISyncPropertyMigrator? item) => _lookup.TryGetValue(editorAlias, out item);
-
-    public ISyncPropertyMigrator? Get(string editorAlias) => _lookup.TryGetValue(editorAlias, out var migrator) == true ? migrator : default;
-
-    public ISyncVariationPropertyMigrator? GetVariantMigrator(string editorAlias)
+    private IDictionary<string, ISyncPropertyMigrator> GetDefaults()
     {
-        if (_lookup.TryGetValue(editorAlias, out var migrator)
-            && migrator is ISyncVariationPropertyMigrator variantMigrator)
+        var defaults = new Dictionary<string, ISyncPropertyMigrator>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in this.Where(x => x.GetType().GetCustomAttribute<SyncDefaultMigratorAttribute>(false) != null))
         {
-            return variantMigrator;
+            foreach (var editor in item.Editors)
+            {
+                defaults[editor] = item;
+            }
         }
-
-        return null;
+        return defaults;
     }
+
 }

--- a/uSync.Migrations/Configuration/CoreProfiles/ContentMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/ContentMigrationProfile.cs
@@ -9,10 +9,14 @@ public class ContentMigrationProfile : ISyncMigrationProfile
     public int Order => 110;
 
     private readonly SyncMigrationHandlerCollection _migrationHandlers;
+    private readonly SyncPropertyMigratorCollection _migrators;
 
-    public ContentMigrationProfile(SyncMigrationHandlerCollection migrationHandlers)
+    public ContentMigrationProfile(
+        SyncMigrationHandlerCollection migrationHandlers,
+        SyncPropertyMigratorCollection migrators)
     {
         _migrationHandlers = migrationHandlers;
+        _migrators = migrators;
     }
 
     public string Name => "Content";
@@ -24,8 +28,7 @@ public class ContentMigrationProfile : ISyncMigrationProfile
     public MigrationOptions Options => new MigrationOptions
     {
         Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
-        Handlers = _migrationHandlers
-            .Handlers
-            .Select(x => x.ToHandlerOption(x.Group == BackOffice.uSyncConstants.Groups.Content))
+        Migrators = _migrators.GetDefaultMigrators(),
+        Handlers = _migrationHandlers.SelectGroup(BackOffice.uSyncConstants.Groups.Content),
     };
 }

--- a/uSync.Migrations/Configuration/CoreProfiles/ContentMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/ContentMigrationProfile.cs
@@ -28,7 +28,6 @@ public class ContentMigrationProfile : ISyncMigrationProfile
     public MigrationOptions Options => new MigrationOptions
     {
         Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
-        Migrators = _migrators.GetDefaultMigrators(),
         Handlers = _migrationHandlers.SelectGroup(BackOffice.uSyncConstants.Groups.Content),
     };
 }

--- a/uSync.Migrations/Configuration/CoreProfiles/EverythingMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/EverythingMigrationProfile.cs
@@ -9,10 +9,14 @@ public class EverythingMigrationProfile : ISyncMigrationProfile
     public int Order => 120;
 
     private readonly SyncMigrationHandlerCollection _migrationHandlers;
+    private readonly SyncPropertyMigratorCollection _migrators;
 
-    public EverythingMigrationProfile(SyncMigrationHandlerCollection migrationHandlers)
+    public EverythingMigrationProfile(
+        SyncMigrationHandlerCollection migrationHandlers,
+        SyncPropertyMigratorCollection migrators)
     {
         _migrationHandlers = migrationHandlers;
+        _migrators = migrators;
     }
 
     public string Name => "Everything";
@@ -24,8 +28,7 @@ public class EverythingMigrationProfile : ISyncMigrationProfile
     public MigrationOptions Options => new MigrationOptions
     {
         Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
-        Handlers = _migrationHandlers
-            .Handlers
-            .Select(x => x.ToHandlerOption(true)),
+        Migrators = _migrators.GetDefaultMigrators(),
+        Handlers = _migrationHandlers.SelectGroup("")
     };
 }

--- a/uSync.Migrations/Configuration/CoreProfiles/EverythingMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/EverythingMigrationProfile.cs
@@ -28,7 +28,6 @@ public class EverythingMigrationProfile : ISyncMigrationProfile
     public MigrationOptions Options => new MigrationOptions
     {
         Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
-        Migrators = _migrators.GetDefaultMigrators(),
         Handlers = _migrationHandlers.SelectGroup("")
     };
 }

--- a/uSync.Migrations/Configuration/CoreProfiles/SettingsMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/SettingsMigrationProfile.cs
@@ -9,10 +9,14 @@ public class SettingsMigrationProfile : ISyncMigrationProfile
     public int Order => 101;
 
     private readonly SyncMigrationHandlerCollection _migrationHandlers;
+    private readonly SyncPropertyMigratorCollection _migrators;
 
-    public SettingsMigrationProfile(SyncMigrationHandlerCollection migrationHandlers)
+    public SettingsMigrationProfile(
+        SyncMigrationHandlerCollection migrationHandlers,
+        SyncPropertyMigratorCollection migrators)
     {
         _migrationHandlers = migrationHandlers;
+        _migrators = migrators;
     }
 
     public string Name => "Settings";
@@ -24,8 +28,7 @@ public class SettingsMigrationProfile : ISyncMigrationProfile
     public MigrationOptions Options => new MigrationOptions
     {
         Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
-        Handlers = _migrationHandlers
-            .Handlers
-            .Select(x => x.ToHandlerOption(x.Group == BackOffice.uSyncConstants.Groups.Settings)),
+        Migrators = _migrators.GetDefaultMigrators(),
+        Handlers = _migrationHandlers.SelectGroup(BackOffice.uSyncConstants.Groups.Settings)
     };
 }

--- a/uSync.Migrations/Configuration/CoreProfiles/SettingsMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/SettingsMigrationProfile.cs
@@ -28,7 +28,6 @@ public class SettingsMigrationProfile : ISyncMigrationProfile
     public MigrationOptions Options => new MigrationOptions
     {
         Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
-        Migrators = _migrators.GetDefaultMigrators(),
         Handlers = _migrationHandlers.SelectGroup(BackOffice.uSyncConstants.Groups.Settings)
     };
 }

--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -1,6 +1,8 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
+using uSync.Migrations.Migrators;
+
 namespace uSync.Migrations.Configuration.Models;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
@@ -12,7 +14,9 @@ public class MigrationOptions
 
     public string MigrationType { get; set; }
 
-    public IEnumerable<HandlerOption> Handlers { get; set; }
+    public IList<HandlerOption> Handlers { get; set; }
+
+    public IList<ISyncPropertyMigrator> Migrators { get; set; }
 
     public bool BlockListViews { get; set; } = true;
 

--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -1,8 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-using uSync.Migrations.Migrators;
-
 namespace uSync.Migrations.Configuration.Models;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
@@ -16,7 +14,7 @@ public class MigrationOptions
 
     public IList<HandlerOption> Handlers { get; set; }
 
-    public IList<ISyncPropertyMigrator> Migrators { get; set; }
+    public IDictionary<string, string> PreferedMigrators { get; set; }
 
     public bool BlockListViews { get; set; } = true;
 

--- a/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
+++ b/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
@@ -21,6 +21,7 @@ internal class SyncMigrationConfigurationService : ISyncMigrationConfigurationSe
     private readonly ILogger<SyncMigrationConfigurationService> _logger;
     private readonly ISyncMigrationService _migrationService;
     private readonly SyncMigrationProfileCollection _syncMigrationProfiles;
+    private readonly SyncPropertyMigratorCollection _migrators;
 
     public SyncMigrationConfigurationService(
         IHostEnvironment hostEnvironment,
@@ -87,12 +88,13 @@ internal class SyncMigrationConfigurationService : ISyncMigrationConfigurationSe
                     foreach (var profile in config.Profiles)
                     {
                         var configuredHandlers = profile.Options.Handlers.Select(x => x.Name);
+                        profile.Options.Migrators = _migrators.GetDefaultMigrators();
                         profile.Options.Handlers = _migrationService.GetHandlers()
                             .Select(x => new HandlerOption
                             {
                                 Name = x.ItemType,
                                 Include = configuredHandlers.InvariantContains(x.ItemType)
-                            });
+                            }).ToList();
                     }
 
                     return config;

--- a/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
+++ b/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
@@ -88,7 +88,6 @@ internal class SyncMigrationConfigurationService : ISyncMigrationConfigurationSe
                     foreach (var profile in config.Profiles)
                     {
                         var configuredHandlers = profile.Options.Handlers.Select(x => x.Name);
-                        profile.Options.Migrators = _migrators.GetDefaultMigrators();
                         profile.Options.Handlers = _migrationService.GetHandlers()
                             .Select(x => new HandlerOption
                             {

--- a/uSync.Migrations/Handlers/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/ContentBaseMigrationHandler.cs
@@ -22,7 +22,6 @@ internal class ContentBaseMigrationHandler<TEntity>
     public string Group => uSync.BackOffice.uSyncConstants.Groups.Content;
 
     private readonly IEventAggregator _eventAggregator;
-    private readonly SyncPropertyMigratorCollection _migrators;
     private readonly ISyncMigrationFileService _migrationFileService;
     private readonly IShortStringHelper _shortStringHelper;
 
@@ -31,12 +30,10 @@ internal class ContentBaseMigrationHandler<TEntity>
     public ContentBaseMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        SyncPropertyMigratorCollection contentPropertyMigrators,
         IShortStringHelper shortStringHelper)
     {
         _eventAggregator = eventAggregator;
         _migrationFileService = migrationFileService;
-        _migrators = contentPropertyMigrators;
         _shortStringHelper = shortStringHelper;
     }
 
@@ -179,7 +176,7 @@ internal class ContentBaseMigrationHandler<TEntity>
         // convert the property .
 
         var migrationProperty = new SyncMigrationContentProperty(editorAlias, property.Value);
-        var migrator = _migrators.GetVariantMigrator(editorAlias);
+        var migrator = context.TryGetVariantMigrator(editorAlias);
         if (migrator != null && itemType == "Content")
         {
             // it might be the case that the property needs to be split into variants. 
@@ -290,9 +287,12 @@ internal class ContentBaseMigrationHandler<TEntity>
 
     private string MigrateContentValue(SyncMigrationContentProperty migrationProperty, SyncMigrationContext context)
     {
+        if (migrationProperty == null) return string.Empty;
+
         if (string.IsNullOrWhiteSpace(migrationProperty?.EditorAlias)) return migrationProperty.Value;
 
-        if (_migrators.TryGet(migrationProperty?.EditorAlias, out var migrator) == true)
+        var migrator = context.TryGetMigrator(migrationProperty?.EditorAlias);
+        if (migrator != null)
         {
             return migrator?.GetContentValue(migrationProperty, context) ?? migrationProperty.Value;
         }

--- a/uSync.Migrations/Handlers/ContentMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/ContentMigrationHandler.cs
@@ -13,9 +13,8 @@ internal class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, I
     public ContentMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        SyncPropertyMigratorCollection migrators,
         IShortStringHelper shortStringHelper)
-        : base(eventAggregator, migrationFileService, migrators, shortStringHelper)
+        : base(eventAggregator, migrationFileService, shortStringHelper)
     { }
 
     public string ItemType => nameof(Content);

--- a/uSync.Migrations/Handlers/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/ContentTypeBaseMigrationHandler.cs
@@ -19,16 +19,13 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity>
 
     private readonly IEventAggregator _eventAggregator;
     private readonly ISyncMigrationFileService _migrationFileService;
-    private readonly SyncPropertyMigratorCollection _migrators;
 
     public ContentTypeBaseMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService,
-        SyncPropertyMigratorCollection migrators)
+        ISyncMigrationFileService migrationFileService)
     {
         _eventAggregator = eventAggregator;
         _migrationFileService = migrationFileService;
-        _migrators = migrators;
     }
 
     public void PrepareContext(string sourceFolder, SyncMigrationContext context)

--- a/uSync.Migrations/Handlers/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/ContentTypeMigrationHandler.cs
@@ -15,9 +15,8 @@ internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<Con
     public ContentTypeMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        SyncPropertyMigratorCollection migrators,
         IFileService fileService)
-        : base(eventAggregator, migrationFileService, migrators)
+        : base(eventAggregator, migrationFileService)
     {
         _fileService = fileService;
     }

--- a/uSync.Migrations/Handlers/MediaMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/MediaMigrationHandler.cs
@@ -13,9 +13,8 @@ internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISync
     public MediaMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        SyncPropertyMigratorCollection migrators,
         IShortStringHelper shortStringHelper)
-        : base(eventAggregator, migrationFileService, migrators, shortStringHelper)
+        : base(eventAggregator, migrationFileService, shortStringHelper)
     {
         _ignoredProperties.UnionWith(new[]
         {

--- a/uSync.Migrations/Handlers/MediaTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/MediaTypeMigrationHandler.cs
@@ -1,7 +1,6 @@
 ﻿using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
-using uSync.Migrations.Composing;
 using uSync.Migrations.Models;
 using uSync.Migrations.Services;
 
@@ -11,9 +10,8 @@ internal class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<Media
 {
     public MediaTypeMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService,
-        SyncPropertyMigratorCollection migrators)
-        : base(eventAggregator, migrationFileService, migrators)
+        ISyncMigrationFileService migrationFileService)
+        : base(eventAggregator, migrationFileService)
     { }
 
     public string Group => uSync.BackOffice.uSyncConstants.Groups.Settings;

--- a/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
@@ -13,12 +13,8 @@ namespace uSync.Migrations.Migrators;
 [SyncMigrator("Our.Umbraco.NestedContent")]
 public class NestedContentMigrator : SyncPropertyMigratorBase
 {
-    Lazy<SyncPropertyMigratorCollection> _migrators;
-
-    public NestedContentMigrator(Lazy<SyncPropertyMigratorCollection> migrators)
-    {
-        _migrators = migrators;
-    }
+    public NestedContentMigrator()
+    { }
 
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => UmbConstants.PropertyEditors.Aliases.NestedContent;
@@ -41,8 +37,8 @@ public class NestedContentMigrator : SyncPropertyMigratorBase
             {
                 var editorAlias = context.GetEditorAlias(row.ContentTypeAlias, property.Key);
                 if (editorAlias == null) continue;
-
-                var migrator = _migrators.Value.Get(editorAlias.OriginalEditorAlias);
+                
+                var migrator = context.TryGetMigrator(editorAlias.OriginalEditorAlias);
                 if (migrator != null)
                 {
                     row.RawPropertyValues[property.Key] = migrator.GetContentValue(new SyncMigrationContentProperty(row.ContentTypeAlias, property.Value.ToString()), context);

--- a/uSync.Migrations/Migrators/SyncMigratorAttribute.cs
+++ b/uSync.Migrations/Migrators/SyncMigratorAttribute.cs
@@ -32,4 +32,4 @@ public class SyncMigratorAttribute : Attribute
 ///  multiple migrators for a type, but only picking one in a 'normal' migration.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-internal class SyncDefaultMigratorAttribute : Attribute { }
+public class SyncDefaultMigratorAttribute : Attribute { }

--- a/uSync.Migrations/Migrators/SyncMigratorAttribute.cs
+++ b/uSync.Migrations/Migrators/SyncMigratorAttribute.cs
@@ -22,3 +22,14 @@ public class SyncMigratorAttribute : Attribute
         ConfigurationType = configurationType;
     }
 }
+
+/// <summary>
+///  When there are multiple migrators for a alias, the default one will win. an error is thrown if 
+///  there are multiple default migrators. 
+/// </summary>
+/// <remarks>
+///  default migrators can be replaced when loading a profile - but we needed a way of having 
+///  multiple migrators for a type, but only picking one in a 'normal' migration.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+internal class SyncDefaultMigratorAttribute : Attribute { }

--- a/uSync.Migrations/Models/MigratorEditorPair.cs
+++ b/uSync.Migrations/Models/MigratorEditorPair.cs
@@ -1,0 +1,16 @@
+﻿using uSync.Migrations.Migrators;
+
+namespace uSync.Migrations.Models;
+
+public class MigratorEditorPair
+{
+    public MigratorEditorPair(string editorAlias, ISyncPropertyMigrator migrator)
+    {
+        EditorAlias = editorAlias;
+        Migrator = migrator;
+    }
+
+    public string EditorAlias { get; set; }
+    public ISyncPropertyMigrator Migrator { get; set; }
+
+}

--- a/uSync.Migrations/Models/SyncMigrationContext.cs
+++ b/uSync.Migrations/Models/SyncMigrationContext.cs
@@ -9,31 +9,7 @@ namespace uSync.Migrations.Models;
 /// </summary>
 public class SyncMigrationContext
 {
-    private Dictionary<string, ISyncPropertyMigrator> _migrators { get; set; }
-
-    public ISyncPropertyMigrator? TryGetMigrator(string? editorAlias)
-        => string.IsNullOrEmpty(editorAlias) 
-            ? null 
-            : _migrators.TryGetValue(editorAlias, out var migrator) == true ? migrator : null;
-
-    public void AddMigrator(ISyncPropertyMigrator migrator)
-    {
-        foreach(var editor in migrator.Editors)
-        {
-            _migrators.TryAdd(editor, migrator);
-        }
-    }
-
-    public ISyncVariationPropertyMigrator? TryGetVariantMigrator(string editorAlias)
-    {
-        if (_migrators.TryGetValue(editorAlias, out var migrator) 
-            && migrator is ISyncVariationPropertyMigrator variationPropertyMigrator)
-        {
-            return variationPropertyMigrator;
-        }
-
-        return null;
-    }
+    private Dictionary<string, ISyncPropertyMigrator> _migrators { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     private HashSet<string> _blockedTypes = new(StringComparer.OrdinalIgnoreCase);
 
@@ -254,6 +230,37 @@ public class SyncMigrationContext
     public string GetDataTypeVariation(Guid guid)
         => _dataTypeVariations?.TryGetValue(guid, out var variation) == true
             ? variation : "Nothing";
+
+
+    /// <summary>
+    ///  get the migrator for a given editorAlias
+    /// </summary>
+    public ISyncPropertyMigrator? TryGetMigrator(string? editorAlias)
+        => string.IsNullOrEmpty(editorAlias)
+            ? null
+            : _migrators.TryGetValue(editorAlias, out var migrator) == true ? migrator : null;
+
+    /// <summary>
+    ///  Add a migrator for a given editorAlias
+    /// </summary>
+    public void AddPropertyMigration(string editorAlias, ISyncPropertyMigrator migrator)
+    {
+        _migrators.TryAdd(editorAlias, migrator);
+    }
+
+    /// <summary>
+    ///  get the variant version of a migrator (if there is one)
+    /// </summary>
+    public ISyncVariationPropertyMigrator? TryGetVariantMigrator(string editorAlias)
+    {
+        if (_migrators.TryGetValue(editorAlias, out var migrator)
+            && migrator is ISyncVariationPropertyMigrator variationPropertyMigrator)
+        {
+            return variationPropertyMigrator;
+        }
+
+        return null;
+    }
 }
 
 public class EditorAliasInfo

--- a/uSync.Migrations/Services/SyncMigrationService.cs
+++ b/uSync.Migrations/Services/SyncMigrationService.cs
@@ -165,10 +165,7 @@ internal class SyncMigrationService : ISyncMigrationService
             .ForEach(kvp =>
                 kvp.Value?.ForEach(value => context.AddIgnoredProperty(kvp.Key, value)));
 
-        // load the migrators into the context - if they are defined in options
-        // they can be overridden. 
-        var migrators = options.Migrators ?? _migrators.GetDefaultMigrators();
-        migrators.ForEach(x => context.AddMigrator(x));
+        AddMigrators(context, options.PreferedMigrators);
 
         // let the handlers run through their prep (populate all the lookups)
         GetHandlers()?
@@ -177,5 +174,14 @@ internal class SyncMigrationService : ISyncMigrationService
             .ForEach(x => x.PrepareMigrations(migrationId, sourceRoot, context));
 
         return context;
+    }
+
+    private void AddMigrators(SyncMigrationContext context, IDictionary<string,string> preferedMigrators)
+    {
+        var preferedList = _migrators.GetPreferedMigratorList(preferedMigrators);
+        foreach(var item in preferedList)
+        {
+            context.AddPropertyMigration(item.EditorAlias, item.Migrator);
+        }
     }
 }

--- a/uSync.Migrations/wwwroot/uSyncMigrations/migrate.html
+++ b/uSync.Migrations/wwwroot/uSyncMigrations/migrate.html
@@ -98,7 +98,7 @@
                                 label="Do it, Do it now!"
                                 button-style="success btn-large"
                                 icon="icon-smiley"
-                                disabled="vm.working || vm.sourceValid == false"
+                                disabled="vm.working || vm.sourceValid == false || vm.validation.success == false"
                                 state="vm.state">
                     </umb-button>
                     <div><small><em>(create the migrated uSync files)</em></small></div>


### PR DESCRIPTION
Move Migrators to the context, - so they can be configured by a profile. 

Idea is you can have all the migrators loaded, and then have the profiles decide which ones to use, eg. grid -> grid or grid -> blocklist. 

.eg 

you might go something like this in your `ISyncMigrationProfile`

```cs
Migrators = _migrators.GetDefault()
               .Replace<GridMigrator>(typeof(GridToBlockListMigrator))
               .Replace<NestedContentMigrator>(typeof(NestedContentBlockListMigrator));
```
(n.b I am making the syntax up as a i go in this PR)

need to think of the best way to present this to people, but also the best way to work out programmatically which migrator is the 'default' so when we say get us all the migrators with no config, we get the right ones. 

