### PR TITLE
Adds ID/Key lookup to `SyncMigrationContext`

### DIFF
--- a/uSync.Migrations/Handlers/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/ContentBaseMigrationHandler.cs
@@ -307,11 +307,20 @@ internal class ContentBaseMigrationHandler<TEntity>
         {
             var source = XElement.Load(file);
             var key = source.Attribute("guid").ValueOrDefault(Guid.Empty);
-            var alias = source.Attribute("nodeName").ValueOrDefault(string.Empty);
-
-            if (key != Guid.Empty && string.IsNullOrWhiteSpace(alias) == false)
+            if (key != Guid.Empty)
             {
-                context.AddContentKey(key, alias);
+                var id = source.Attribute("id").ValueOrDefault(0);
+                var alias = source.Attribute("nodeName").ValueOrDefault(string.Empty);
+
+                if (id > 0)
+                {
+                    context.AddKey(id, key);
+                }
+
+                if (string.IsNullOrWhiteSpace(alias) == false)
+                {
+                    context.AddContentKey(key, alias);
+                }
             }
         }
     }

--- a/uSync.Migrations/Models/SyncMigrationContext.cs
+++ b/uSync.Migrations/Models/SyncMigrationContext.cs
@@ -34,6 +34,8 @@ public class SyncMigrationContext
     private Dictionary<string, EditorAliasInfo> _propertyTypes { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<string, Guid> _templateKeys { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
+    private Dictionary<int, Guid> _idKeyMap { get; set; } = new();
+
     public SyncMigrationContext(Guid migrationId)
     {
         MigrationId = migrationId;
@@ -224,6 +226,18 @@ public class SyncMigrationContext
     public string GetDataTypeVariation(Guid guid)
         => _dataTypeVariations?.TryGetValue(guid, out var variation) == true
             ? variation : "Nothing";
+
+    /// <summary>
+    /// Adds the `int` ID (from the v7 CMS) with the corresponding `Guid` key.
+    /// </summary>
+    public void AddKey(int id, Guid key)
+        => _idKeyMap.TryAdd(id, key);
+
+    /// <summary>
+    /// Retrieves the `Guid` key from the `int` ID reference (from the v7 CMS).
+    /// </summary>
+    public Guid GetKey(int id)
+        => _idKeyMap?.TryGetValue(id, out var key) == true ? key : Guid.Empty;
 }
 
 public class EditorAliasInfo


### PR DESCRIPTION
A proposed suggestion for idea #40. Totally open for feedback, refactoring or even rejection! 😅 

Adds (another) dictionary lookup to the `SyncMigrationContext` for ID/Key lookups. I'm not sure if there'll be performance concerns around this?

From looking at uSync v7 XML files, only Content and Media have the "id" attribute, so I've only added this to the `ContentBaseMigrationHandler` code.
