### PR TITLE
Adds support for newer Media Types

### DIFF
--- a/uSync.Migrations/Handlers/MediaMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/MediaMigrationHandler.cs
@@ -24,6 +24,21 @@ internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISync
             UmbConstants.Conventions.Media.Height,
             UmbConstants.Conventions.Media.Width,
         });
+
+        _mediaTypeAliasForFileExtension.Union(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "docx", UmbConstants.Conventions.MediaTypes.ArticleAlias },
+            { "doc", UmbConstants.Conventions.MediaTypes.ArticleAlias },
+            { "pdf", UmbConstants.Conventions.MediaTypes.ArticleAlias },
+            { "mp3", UmbConstants.Conventions.MediaTypes.AudioAlias },
+            { "weba", UmbConstants.Conventions.MediaTypes.AudioAlias },
+            { "oga", UmbConstants.Conventions.MediaTypes.AudioAlias },
+            { "opus", UmbConstants.Conventions.MediaTypes.AudioAlias },
+            { "svg", UmbConstants.Conventions.MediaTypes.VectorGraphicsAlias },
+            { "mp4", UmbConstants.Conventions.MediaTypes.VideoAlias },
+            { "ogv", UmbConstants.Conventions.MediaTypes.VideoAlias },
+            { "webm", UmbConstants.Conventions.MediaTypes.VideoAlias },
+        });
     }
 
     public string ItemType => nameof(Media);


### PR DESCRIPTION
Umbraco 8.14 introduced new default Media Types: https://umbraco.com/blog/umbraco-814-release/

This feature will check the Media node's `umbracoExtension` property value and set the corresponding Media Type alias.

---

I wasn't 100% happy having `_mediaTypeAliasForFileExtension` in the `ContentBaseMigrationHandler`, but unsure where else to have it.