### PR TITLE
Change attributes on editornotes, so they both load 

### DIFF
--- a/uSync.Migrations/Migrators/Community/uEditorNotesToContentmentEditorNotes.cs
+++ b/uSync.Migrations/Migrators/Community/uEditorNotesToContentmentEditorNotes.cs
@@ -1,7 +1,5 @@
 using Newtonsoft.Json.Linq;
 
-using Umbraco.Cms.Core.Composing;
-
 using uSync.Migrations.Extensions;
 using uSync.Migrations.Migrators.Models;
 using uSync.Migrations.Models;
@@ -9,7 +7,6 @@ using uSync.Migrations.Models;
 namespace uSync.Migrations.Migrators.Community
 {
     [SyncMigrator("tooorangey.EditorNotes")]
-    [HideFromTypeFinder]
     public class uEditorNotesToContentmentEditorNotesMigrator : SyncPropertyMigratorBase
     {
         public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)

--- a/uSync.Migrations/Migrators/Community/uEditorNotesTouEditorNotes.cs
+++ b/uSync.Migrations/Migrators/Community/uEditorNotesTouEditorNotes.cs
@@ -1,10 +1,5 @@
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Umbraco.Cms.Core.PropertyEditors;
+
 using uSync.Migrations.Extensions;
 using uSync.Migrations.Migrators.Models;
 using uSync.Migrations.Models;
@@ -12,6 +7,7 @@ using uSync.Migrations.Models;
 namespace uSync.Migrations.Migrators.Community
 {
     [SyncMigrator("tooorangey.EditorNotes")]
+    [SyncDefaultMigrator]
     public class uEditorNotesTouEditorNotesMigrator : SyncPropertyMigratorBase
     {
         //alias is the same


### PR DESCRIPTION
Changed the attributes on the two editor notes migrators, so they both load
but one is default -

this means they can then be "preferred" in a profile without having to replace one of them. 
