### PR TITLE
Make context disposable.

### DIFF
--- a/uSync.Migrations/Models/SyncMigrationContext.cs
+++ b/uSync.Migrations/Models/SyncMigrationContext.cs
@@ -7,7 +7,7 @@ namespace uSync.Migrations.Models;
 /// <summary>
 ///  A uSync migration context, lets us keep a whole list of things in memory while we do the migration.
 /// </summary>
-public class SyncMigrationContext
+public class SyncMigrationContext : IDisposable
 {
     private Dictionary<string, ISyncPropertyMigrator> _migrators { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
@@ -275,6 +275,8 @@ public class SyncMigrationContext
     public Guid GetKey(int id)
         => _idKeyMap?.TryGetValue(id, out var key) == true ? key : Guid.Empty;
 
+    public void Dispose()
+    { }
 }
 
 public class EditorAliasInfo


### PR DESCRIPTION
Not 100% sure how we should dispose of the dictionaries or lists here. 

there is some debate over settings lists and dictionaries to null actually slows down garbage collection. 

Also, i think we don't have any unmanaged resources inside the lists and dictionaries so they will be freed by the garbage collector?

the context is local to the `MigrateFiles` call so once we are outside of that then the scope is gone, and it should all be freed up? 

- So, this PR adds disposable and a using statement, but i am not sure we can actually make any difference with them? 

