### PR TITLE
Make sure we use Path.DirectorySeparatorChar as needed.

### DIFF
--- a/uSync.Migrations/Services/SyncMigrationFileService.cs
+++ b/uSync.Migrations/Services/SyncMigrationFileService.cs
@@ -38,7 +38,7 @@ internal class SyncMigrationFileService : ISyncMigrationFileService
         _uSyncConfig = uSyncConfig;
 
         // gets us the folder above where uSync saves stuff (usually uSync/v9 so this returns uSync); 
-        var uSyncPhysicalPath = _webHostEnvironment.MapPathContentRoot(_uSyncConfig.GetRootFolder()).TrimEnd('\\');
+        var uSyncPhysicalPath = _webHostEnvironment.MapPathContentRoot(_uSyncConfig.GetRootFolder()).TrimEnd(Path.DirectorySeparatorChar);
         _uSyncRoot = Path.GetDirectoryName(uSyncPhysicalPath) ?? _webHostEnvironment.MapPathContentRoot("uSync");
     }
 


### PR DESCRIPTION
Checking path stuff is OS independent.