### PR TITLE
v8 and Shared migration code.

### DIFF
--- a/uSync.Migrations/Composing/SyncPropertyMigratorCollectionBuilder.cs
+++ b/uSync.Migrations/Composing/SyncPropertyMigratorCollectionBuilder.cs
@@ -19,7 +19,7 @@ public class SyncPropertyMigratorCollection
         : base(items)
     { }
 
-    public IList<MigratorEditorPair> GetPreferredMigratorList(IDictionary<string, string> preferredMigrators)
+    public IList<MigratorEditorPair> GetPreferredMigratorList(IDictionary<string, string>? preferredMigrators)
     {
         var migrators = this.ToList();
         var defaultMigrators = GetDefaults();

--- a/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
@@ -21,7 +21,7 @@ internal class BlockMigrationProfile : ISyncMigrationProfile
 
     public string Icon => "icon-brick color-green";
 
-    public string Description => "Convert to block list and block grids (Experimental!)";
+    public string Description => "Convert to block list (Experimental!)";
 
     public MigrationOptions Options => new MigrationOptions
     {

--- a/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
@@ -2,10 +2,10 @@
 
 using uSync.Migrations.Composing;
 using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Migrators.Optional;
 
 namespace uSync.Migrations.Configuration.CoreProfiles;
 
-[HideFromTypeFinder]
 internal class BlockMigrationProfile : ISyncMigrationProfile
 {
     private readonly SyncMigrationHandlerCollection _migrationHandlers;
@@ -19,16 +19,20 @@ internal class BlockMigrationProfile : ISyncMigrationProfile
 
     public string Name => "To Blocks";
 
-    public string Icon => "icon-block color-green";
+    public string Icon => "icon-brick color-green";
 
-    public string Description => "Convert to block list and block grids";
+    public string Description => "Convert to block list and block grids (Experimental!)";
 
     public MigrationOptions Options => new MigrationOptions
     {
         Source = "uSync/v9",
         Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
         Handlers = _migrationHandlers.SelectGroup(8, string.Empty),
-        SourceVersion = 8
+        SourceVersion = 8,
+        PreferredMigrators = new Dictionary<string, string>
+        {
+            { Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.NestedContent, nameof(NestedToBlockListMigrator) }
+        }
     };
 
 }

--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -11,11 +11,11 @@ public class MigrationOptions
 
     public int SourceVersion { get; set; } = 7;
 
-    public string MigrationType { get; set; }
+    public string? MigrationType { get; set; }
 
-    public IList<HandlerOption> Handlers { get; set; }
+    public IList<HandlerOption>? Handlers { get; set; }
 
-    public IDictionary<string, string> PreferredMigrators { get; set; }
+    public IDictionary<string, string>? PreferredMigrators { get; set; }
 
     public bool BlockListViews { get; set; } = true;
 
@@ -24,20 +24,20 @@ public class MigrationOptions
     /// <summary>
     ///  items that you want to block by type
     /// </summary>
-    public Dictionary<string, List<string>> BlockedItems { get; set; }
+    public Dictionary<string, List<string>>? BlockedItems { get; set; }
 
     /// <summary>
     ///  Blocked properties use (alias of somethign to block.) syntax?. 
     /// </summary>
-    public List<string> IgnoredProperties { get; set; }
+    public List<string>? IgnoredProperties { get; set; }
 
-    public Dictionary<string, List<string>> IgnoredPropertiesByContentType { get; set; }
+    public Dictionary<string, List<string>>? IgnoredPropertiesByContentType { get; set; }
 }
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class HandlerOption
 {
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 
     public bool Include { get; set; } = true;
 }

--- a/uSync.Migrations/Configuration/Models/MigrationProfile.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationProfile.cs
@@ -14,11 +14,11 @@ public class MigrationProfile : ISyncMigrationProfile
 {
     public int Version { get; set; } = 7;
 
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 
-    public string Icon { get; set; }
+    public string Icon { get; set; } = "icon-star";
 
-    public string Description { get; set; }
+    public string Description { get; set; } = "Loaded from disk";
 
     public int Order { get; set; } = 100;
 

--- a/uSync.Migrations/Configuration/Models/MigrationProfileInfo.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationProfileInfo.cs
@@ -7,6 +7,7 @@ namespace uSync.Migrations.Configuration.Models;
 public class MigrationProfileInfo
 {
     public List<ISyncMigrationProfile> Profiles { get; set; }
+        = new List<ISyncMigrationProfile>();
 
     public bool HasCustom { get; set; }
 }

--- a/uSync.Migrations/Configuration/Models/MigratrionProfileConfig.cs
+++ b/uSync.Migrations/Configuration/Models/MigratrionProfileConfig.cs
@@ -6,7 +6,8 @@ namespace uSync.Migrations.Configuration.Models;
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class MigratrionProfileConfig
 {
-    public string[] Remove { get; set; }
+    public string[]? Remove { get; set; } 
 
     public List<MigrationProfile> Profiles { get; set; }
+        = new List<MigrationProfile>();
 }

--- a/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
+++ b/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
@@ -21,7 +21,6 @@ internal class SyncMigrationConfigurationService : ISyncMigrationConfigurationSe
     private readonly ILogger<SyncMigrationConfigurationService> _logger;
     private readonly ISyncMigrationService _migrationService;
     private readonly SyncMigrationProfileCollection _syncMigrationProfiles;
-    private readonly SyncPropertyMigratorCollection _migrators;
 
     public SyncMigrationConfigurationService(
         IHostEnvironment hostEnvironment,
@@ -87,7 +86,11 @@ internal class SyncMigrationConfigurationService : ISyncMigrationConfigurationSe
                 {
                     foreach (var profile in config.Profiles)
                     {
-                        var configuredHandlers = profile.Options.Handlers.Select(x => x.Name);
+                        if (profile == null || profile.Options == null) continue;
+
+                        var configuredHandlers = profile.Options.Handlers?.Select(x => x.Name);
+                        if (configuredHandlers == null) continue;
+
                         profile.Options.Handlers = _migrationService.GetHandlers(profile.Version)
                             .Select(x => new HandlerOption
                             {

--- a/uSync.Migrations/Extensions/PreValueExtensions.cs
+++ b/uSync.Migrations/Extensions/PreValueExtensions.cs
@@ -35,7 +35,7 @@ public static class PreValueExtensions
         }
     }
 
-    public static object MapPreValues(this object? config, IEnumerable<PreValue> preValues)
+    public static object? MapPreValues(this object? config, IEnumerable<PreValue> preValues)
     {
         if (config == null) return null;
 
@@ -58,10 +58,11 @@ public static class PreValueExtensions
         return config;
     }
 
-    public static object MapPreValues(this object config, IEnumerable<PreValue> preValues, Dictionary<string, string> mappings)
+    public static object MapPreValues(this object config, IEnumerable<PreValue>? preValues, Dictionary<string, string> mappings)
     {
-        var properties = config.GetType().GetProperties();
+        if (preValues == null) return config;
 
+        var properties = config.GetType().GetProperties();
         foreach (var value in preValues)
         {
             if (mappings.ContainsKey(value.Alias))
@@ -81,19 +82,20 @@ public static class PreValueExtensions
 
         return config;
     }    
-    public static object ConvertPreValuesToJson(this IEnumerable<PreValue> preValues, bool uppercase)
+    public static object ConvertPreValuesToJson(this IEnumerable<PreValue>? preValues, bool uppercase)
     {
         return preValues.ConvertPreValuesToJson(uppercase, null);
     }
-    public static object ConvertPreValuesToJson(this IEnumerable<PreValue> preValues, bool uppercase, Dictionary<string, string> mappings)
+    public static object ConvertPreValuesToJson(this IEnumerable<PreValue>? preValues, bool uppercase, Dictionary<string, string>? mappings)
     {
         var config = new JObject();
-        bool hasMappings = mappings != null && mappings.Any();
+        if (preValues == null) return config;
+
         foreach (var preValue in preValues)
         {
             var alias = preValue.Alias;
             // look for mappings
-            if (hasMappings)
+            if (mappings != null && mappings.Count > 0)
             {
                 // then we need to ignore any properties that aren't in the mappings
                 if (mappings.ContainsKey(alias))
@@ -133,7 +135,7 @@ public static class PreValueExtensions
                 }
 
             }
-            catch (Exception ex)
+            catch
             {
                 // here - something went wrong ?
             }

--- a/uSync.Migrations/Handlers/Eight/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentBaseMigrationHandler.cs
@@ -1,0 +1,56 @@
+﻿using System.Xml.Linq;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+
+using uSync.Core;
+using uSync.Migrations.Handlers.Shared;
+using uSync.Migrations.Models;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Eight;
+internal class ContentBaseMigrationHandler<TEntity> : SharedContentBaseHandler<TEntity>
+    where TEntity : ContentBase
+{
+    public ContentBaseMigrationHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService,
+        IShortStringHelper shortStringHelper) : base(eventAggregator, migrationFileService, shortStringHelper)
+    { }
+
+    protected override string GetContentType(XElement source)
+        => source.Element("Info")?.Element("ContentType").ValueOrDefault(string.Empty) ?? string.Empty;
+
+    protected override int GetId(XElement source) => -1;
+
+    protected override string GetNewContentType(string contentType, XElement source) => contentType;
+
+    protected override Guid GetParent(XElement source)
+        => source.Element("Info")?.Element("Parent")?.Attribute("Key").ValueOrDefault(Guid.Empty) ?? Guid.Empty;
+
+    protected override string GetPath(string alias, Guid parent, SyncMigrationContext context)
+        => context.GetContentPath(parent) + "/" + alias.ToSafeAlias(_shortStringHelper);
+
+    protected override IEnumerable<XElement>? GetProperties(XElement source)
+        => source.Element("Properties")?.Elements() ?? Enumerable.Empty<XElement>();
+
+    protected override XElement GetBaseXml(XElement source, Guid parent, string contentType, int level, SyncMigrationContext context)
+    {
+        var target = new XElement(source.Name.LocalName,
+                        new XAttribute("Key", source.GetKey()),
+                        new XAttribute("Alias", source.GetAlias()),
+                        new XAttribute("Level", source.GetLevel()));
+
+        var sourceInfo = source.Element("Info");
+        if (sourceInfo != null)
+        {
+            var targetInfo = XElement.Parse(sourceInfo.ToString());
+            target.Add(targetInfo);
+        }
+
+        return target;        
+    }
+
+}

--- a/uSync.Migrations/Handlers/Eight/ContentMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentMigrationHandler.cs
@@ -4,10 +4,10 @@ using Umbraco.Cms.Core.Strings;
 
 using uSync.Migrations.Services;
 
-namespace uSync.Migrations.Handlers.Seven;
+namespace uSync.Migrations.Handlers.Eight;
 
-[SyncMigrationHandler(BackOfficeConstants.Groups.Content, uSyncMigrations.Priorities.Content,
-    SourceVersion = 7,
+[SyncMigrationHandler(BackOfficeConstants.Groups.Content, uSyncMigrations.Priorities.Content, 
+    SourceVersion = 8,
     SourceFolderName = "Content",
     TargetFolderName = "Content")]
 internal class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, ISyncMigrationHandler

--- a/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
@@ -1,0 +1,53 @@
+﻿using System.Xml.Linq;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+using uSync.Migrations.Handlers.Shared;
+using uSync.Migrations.Models;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Eight;
+internal class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseHandler<TEntity>
+    where TEntity : ContentTypeBase
+{
+    public ContentTypeBaseMigrationHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+    { }
+
+    protected override void UpdatePropertyXml(XElement newProperty)
+    {
+        // for v8 the properties should match what we are expecting ?
+    }
+
+    /// <summary>
+    ///  for v8 we clone these into the new file.
+    /// </summary>
+    protected override void UpdateInfoSection(XElement? info, XElement target, Guid key, SyncMigrationContext context)
+    {
+        if (info == null) return;
+        target.Add(XElement.Parse(info.ToString()));
+    }
+
+
+    protected override void UpdateStructure(XElement source, XElement target)
+    {
+        var sourceStructure = source.Element("Structure");
+        if (sourceStructure != null)
+            target.Add(XElement.Parse(sourceStructure.ToString()));
+    }
+
+    protected override void UpdateTabs(XElement source, XElement target)
+    {
+        var sourceTabs = source.Element("Tabs");
+        if (sourceTabs != null)
+            target.Add(XElement.Parse(sourceTabs.ToString()));
+    }
+
+    protected override void CheckVariations(XElement target)
+    {
+        // for v8 we are assuming variations are sound (for now!)
+    }
+
+}

--- a/uSync.Migrations/Handlers/Eight/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeMigrationHandler.cs
@@ -1,0 +1,18 @@
+﻿using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Eight;
+
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.ContentTypes, 
+    SourceVersion = 8,
+    SourceFolderName = "ContentTypes",
+    TargetFolderName = "ContentTypes")]
+internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<ContentType>, ISyncMigrationHandler
+{
+    public ContentTypeMigrationHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+    {  }
+}

--- a/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
@@ -23,13 +23,16 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
         IDataTypeService dataTypeService) : base(eventAggregator, migrationFileService, dataTypeService)
     { }
 
+    protected override string GetEditorAlias(XElement source)
+        => source.Element("Info")?.Element("EditorAlias").ValueOrDefault(string.Empty) ?? string.Empty;
+
     protected override string GetDatabaseType(XElement source)
         => source.Element("Info")?.Element("DatabaseType").ValueOrDefault(string.Empty) ?? string.Empty;
 
-    protected override string GetDocTypeFolder(XElement source)
+    protected override string GetDataTypeFolder(XElement source)
         => source.Element("Info")?.Element("Folder").ValueOrDefault(string.Empty) ?? string.Empty;
 
-    protected override string GetDocTypeName(XElement source)
+    protected override string GetDataTypeName(XElement source)
         => source.Element("Info")?.Element(uSyncConstants.Xml.Name).ValueOrDefault(string.Empty) ?? string.Empty;
 
     protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty(string editorAlias, string database, XElement source)

--- a/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Newtonsoft.Json.Linq;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
 
@@ -54,7 +56,7 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
     }
 
     protected override object? MakeEmptyLabelConfig(SyncMigrationDataTypeProperty dataTypeProperty)
-        => dataTypeProperty.ConfigAsString;
+        => JToken.Parse(dataTypeProperty.ConfigAsString ?? "");
 
     // v8 behavior is - if we don't know about it, we leave it alone.
     private string? GetXmlConfig(XElement source) 
@@ -70,6 +72,6 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
 
     // v8 behavior is - if we don't know about it, we leave it alone.
     protected override object? GetDataTypeConfig(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-        => migrator?.GetConfigValues(dataTypeProperty, context) ?? dataTypeProperty.ConfigAsString;
+        => migrator?.GetConfigValues(dataTypeProperty, context) ?? MakeEmptyLabelConfig(dataTypeProperty);
 
 }

--- a/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
@@ -1,0 +1,60 @@
+﻿using System.Xml.Linq;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Services;
+
+using uSync.Core;
+using uSync.Migrations.Handlers.Shared;
+using uSync.Migrations.Migrators;
+using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Models;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Eight;
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.DataTypes, 
+    SourceVersion = 8,
+    SourceFolderName = "DataTypes",
+    TargetFolderName = "DataTypes")]
+internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationHandler
+{
+    public DataTypeMigrationHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService,
+        IDataTypeService dataTypeService) : base(eventAggregator, migrationFileService, dataTypeService)
+    { }
+
+    protected override string GetDatabaseType(XElement source)
+        => source.Element("Info")?.Element("DatabaseType").ValueOrDefault(string.Empty) ?? string.Empty;
+
+    protected override string GetDocTypeFolder(XElement source)
+        => source.Element("Info")?.Element("Folder").ValueOrDefault(string.Empty) ?? string.Empty;
+
+    protected override string GetDocTypeName(XElement source)
+        => source.Element("Info")?.Element(uSyncConstants.Xml.Name).ValueOrDefault(string.Empty) ?? string.Empty;
+
+    protected override object? GetDataTypeConfig(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => migrator?.GetConfigValues(dataTypeProperty, context);
+
+    protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty(string editorAlias, string database, XElement source)
+        => new SyncMigrationDataTypeProperty(editorAlias, database, GetXmlConfig(source));
+
+    protected override ReplacementDataTypeInfo? GetReplacementInfo(string editorAlias, string databaseType, XElement source, SyncMigrationContext context)
+    {
+        // replacements
+        //
+        var migrator = context.TryGetMigrator(editorAlias);
+        if (migrator != null && migrator is ISyncReplacablePropertyMigrator replacablePropertyMigrator)
+        {
+            return replacablePropertyMigrator.GetReplacementEditorId(
+                new SyncMigrationDataTypeProperty(editorAlias, databaseType, GetXmlConfig(source)),
+                context);
+        }
+
+        return null;
+    }
+
+    protected override object? MakeEmptyLabelConfig(SyncMigrationDataTypeProperty dataTypeProperty)
+        => dataTypeProperty.ConfigAsString;
+    private string? GetXmlConfig(XElement source) 
+        => source.Element("Config").ValueOrDefault(string.Empty);
+}

--- a/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
@@ -32,9 +32,6 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
     protected override string GetDocTypeName(XElement source)
         => source.Element("Info")?.Element(uSyncConstants.Xml.Name).ValueOrDefault(string.Empty) ?? string.Empty;
 
-    protected override object? GetDataTypeConfig(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-        => migrator?.GetConfigValues(dataTypeProperty, context);
-
     protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty(string editorAlias, string database, XElement source)
         => new SyncMigrationDataTypeProperty(editorAlias, database, GetXmlConfig(source));
 
@@ -55,6 +52,21 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
 
     protected override object? MakeEmptyLabelConfig(SyncMigrationDataTypeProperty dataTypeProperty)
         => dataTypeProperty.ConfigAsString;
+
+    // v8 behavior is - if we don't know about it, we leave it alone.
     private string? GetXmlConfig(XElement source) 
         => source.Element("Config").ValueOrDefault(string.Empty);
+
+    // v8 behavior is - if we don't know about it, we leave it alone.
+    protected override string GetNewEditorAlias(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => migrator?.GetEditorAlias(dataTypeProperty, context) ?? dataTypeProperty.EditorAlias;
+
+    // v8 behavior is - if we don't know about it, we leave it alone.
+    protected override string GetNewDatabaseType(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => migrator?.GetDatabaseType(dataTypeProperty, context) ?? dataTypeProperty.DatabaseType;
+
+    // v8 behavior is - if we don't know about it, we leave it alone.
+    protected override object? GetDataTypeConfig(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => migrator?.GetConfigValues(dataTypeProperty, context) ?? dataTypeProperty.ConfigAsString;
+
 }

--- a/uSync.Migrations/Handlers/Eight/DictionaryMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/DictionaryMigrationHandler.cs
@@ -1,0 +1,20 @@
+﻿using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+using uSync.Migrations.Handlers.Shared;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Eight;
+
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Dictionary, 
+    SourceVersion = 8,
+    SourceFolderName = "Dictionary",
+    TargetFolderName = "Dictionary")]
+internal class DictionaryMigrationHandler : SharedHandlerBase<DictionaryItem>, ISyncMigrationHandler
+{
+    public DictionaryMigrationHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+    {
+    }
+}

--- a/uSync.Migrations/Handlers/Eight/LanguageMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/LanguageMigrationHandler.cs
@@ -1,0 +1,22 @@
+﻿using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+using uSync.Migrations.Handlers.Shared;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Eight;
+
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Languages, 
+    SourceVersion = 8,
+    SourceFolderName = "Languages",
+    TargetFolderName = "Languages")]
+internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigrationHandler
+{
+    public LanguageMigrationHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService) 
+        : base(eventAggregator, migrationFileService)
+    { }
+}
+
+

--- a/uSync.Migrations/Handlers/Eight/MacroMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/MacroMigrationHandler.cs
@@ -1,0 +1,19 @@
+﻿using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+using uSync.Migrations.Handlers.Shared;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Eight;
+
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Macros,
+    SourceVersion = 8,
+    SourceFolderName = "Macros",
+    TargetFolderName = "Macros")]
+internal class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationHandler
+{
+    public MacroMigrationHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+    { }
+}

--- a/uSync.Migrations/Handlers/Eight/MediaMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/MediaMigrationHandler.cs
@@ -1,0 +1,21 @@
+﻿using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Strings;
+
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Eight;
+
+[SyncMigrationHandler(BackOfficeConstants.Groups.Content, uSyncMigrations.Priorities.Media, 
+    SourceVersion = 8,
+    SourceFolderName = "Media",
+    TargetFolderName = "Media")]
+internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISyncMigrationHandler
+{
+    public MediaMigrationHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService,
+        IShortStringHelper shortStringHelper) 
+        : base(eventAggregator, migrationFileService, shortStringHelper)
+    { }
+}

--- a/uSync.Migrations/Handlers/Eight/MediaTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/MediaTypeMigrationHandler.cs
@@ -3,17 +3,17 @@ using Umbraco.Cms.Core.Models;
 
 using uSync.Migrations.Services;
 
-namespace uSync.Migrations.Handlers.Seven;
+namespace uSync.Migrations.Handlers.Eight;
 
 [SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.MediaTypes, 
-    SourceVersion = 7,
-    SourceFolderName = "MediaType",
+    SourceVersion = 8,
+    SourceFolderName = "MediaTypes",
     TargetFolderName = "MediaTypes")]
 internal class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<MediaType>, ISyncMigrationHandler
 {
     public MediaTypeMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService)
-        : base(eventAggregator, migrationFileService)
-    { }
+        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+    {
+    }
 }

--- a/uSync.Migrations/Handlers/Eight/TemplateMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/TemplateMigrationHandler.cs
@@ -1,0 +1,21 @@
+﻿using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Services;
+
+using uSync.Migrations.Handlers.Shared;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Eight;
+
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Templates,
+    SourceVersion = 8,
+    SourceFolderName = "Templates",
+    TargetFolderName = "Templates")]
+internal class TemplateMigrationHandler : SharedTemplateHandler, ISyncMigrationHandler
+{
+    public TemplateMigrationHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService,
+        IFileService fileService) 
+        : base(eventAggregator, migrationFileService, fileService)
+    { } 
+}

--- a/uSync.Migrations/Handlers/Seven/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentBaseMigrationHandler.cs
@@ -2,34 +2,28 @@
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
 using uSync.Core;
-using uSync.Migrations.Migrators;
-using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Handlers.Shared;
 using uSync.Migrations.Models;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
 
-internal abstract class ContentBaseMigrationHandler<TEntity> : MigrationHandlerBase<TEntity>
-    where TEntity : IEntity
+internal abstract class ContentBaseMigrationHandler<TEntity> : SharedContentBaseHandler<TEntity>
+    where TEntity : ContentBase
 {
-    private readonly IShortStringHelper _shortStringHelper;
-
-    protected readonly HashSet<string> _ignoredProperties = new(StringComparer.OrdinalIgnoreCase);
-    protected readonly Dictionary<string, string> _mediaTypeAliasForFileExtension = new(StringComparer.OrdinalIgnoreCase);
-
     public ContentBaseMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         IShortStringHelper shortStringHelper)
-        : base(eventAggregator, migrationFileService)
-    {
-        _shortStringHelper = shortStringHelper;
-    }
+        : base(eventAggregator, migrationFileService, shortStringHelper)
+    { }
+
+    protected override int GetId(XElement source)
+        => source.Attribute("id").ValueOrDefault(0);
 
     protected override (string alias, Guid key) GetAliasAndKey(XElement source)
        => (
@@ -37,66 +31,58 @@ internal abstract class ContentBaseMigrationHandler<TEntity> : MigrationHandlerB
             key: source.Attribute("guid").ValueOrDefault(Guid.Empty)
         );
 
-    protected override void PrepareFile(XElement source, SyncMigrationContext context)
+    protected override Guid GetParent(XElement source)
+        => source.Attribute("parentGUID").ValueOrDefault(Guid.Empty);
+
+    protected override string GetContentType(XElement source)
+        => source.Attribute("nodeTypeAlias").ValueOrDefault(string.Empty);
+
+    protected override string GetPath(string alias, Guid parent, SyncMigrationContext context)
+        => context.GetContentPath(parent) + "/" + alias.ToSafeAlias(_shortStringHelper);
+
+    protected override IEnumerable<XElement>? GetProperties(XElement source)
+        => source.Elements();
+
+    protected override string GetNewContentType(string contentType, XElement source)
     {
-        var (alias, key) = GetAliasAndKey(source);
-
-        if (key != Guid.Empty)
-        {
-            var id = source.Attribute("id").ValueOrDefault(0);
-            if (id > 0)
-            {
-                context.AddKey(id, key);
-            }
-
-            if (string.IsNullOrWhiteSpace(alias) == false)
-            {
-                context.AddContentKey(key, alias);
-            }
-        }
-    }
-
-    protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
-    {
-        var (alias, key) = GetAliasAndKey(source);
-
-        var parent = source.Attribute("parentGUID").ValueOrDefault(Guid.Empty);
-        var contentType = source.Attribute("nodeTypeAlias").ValueOrDefault(string.Empty);
-        var template = source.Attribute("templateAlias").ValueOrDefault(string.Empty);
-        var published = source.Attribute("published").ValueOrDefault(false);
-        var createdDate = source.Attribute("updated").ValueOrDefault(DateTime.Now);
-        var sortOrder = source.Attribute("sortOrder").ValueOrDefault(0);
-
-        var path = context.GetContentPath(parent) + "/" + alias.ToSafeAlias(_shortStringHelper);
-
-        // content is blocked by path (e.g home/about-us)
-        if (context.IsBlocked(ItemType, path)) return null;
-
-        context.AddContentPath(key, path);
-
         if (ItemType == nameof(Media) && _mediaTypeAliasForFileExtension.Count > 0)
         {
             var fileExtension = source.Element(UmbConstants.Conventions.Media.Extension)?.ValueOrDefault(string.Empty) ?? string.Empty;
             if (string.IsNullOrWhiteSpace(fileExtension) == false && _mediaTypeAliasForFileExtension.TryGetValue(fileExtension, out var newMediaTypeAlias) == true)
             {
-                contentType = newMediaTypeAlias;
+                return newMediaTypeAlias;
             }
         }
 
+        return contentType;
+    }
+   
+
+    protected override XElement GetBaseXml(XElement source, Guid parent, string contentType, int level, SyncMigrationContext context)
+    {
+        var (alias, key) = GetAliasAndKey(source);
+
+        var template = source.Attribute("templateAlias").ValueOrDefault(string.Empty);
+        var published = source.Attribute("published").ValueOrDefault(false);
+        var createdDate = source.Attribute("updated").ValueOrDefault(DateTime.Now);
+        var sortOrder = source.Attribute("sortOrder").ValueOrDefault(0);
+
+        var path = GetPath(alias, parent, context);
+
         var target = new XElement(ItemType,
-
-            new XAttribute("Key", key),
-            new XAttribute("Alias", alias),
-            new XAttribute("Level", level),
-
-            new XElement("Info",
-                new XElement("Parent", new XAttribute("Key", parent), context.GetContentAlias(parent)),
-                new XElement("Path", path),
-                new XElement("Trashed", false),
-                new XElement("ContentType", contentType),
-                new XElement("CreateDate", createdDate.ToString("s")),
-                new XElement("NodeName", new XAttribute("Default", alias)),
-                new XElement("SortOrder", sortOrder)));
+                        new XAttribute("Key", key),
+                        new XAttribute("Alias", alias),
+                        new XAttribute("Level", level),
+                        new XElement("Info",
+                            new XElement("Parent", new XAttribute("Key", parent), context.GetContentAlias(parent)),
+                            new XElement("Path", path),
+                            new XElement("Trashed", false),
+                            new XElement("ContentType", contentType),
+                            new XElement("CreateDate", createdDate.ToString("s")),
+                            new XElement("NodeName", new XAttribute("Default", alias)),
+                            new XElement("SortOrder", sortOrder)
+                        )
+                    );
 
         if (ItemType == nameof(Content))
         {
@@ -116,154 +102,6 @@ internal abstract class ContentBaseMigrationHandler<TEntity> : MigrationHandlerB
                 }
             }
         }
-
-        var propertiesList = new XElement("Properties");
-
-        foreach (var property in source.Elements())
-        {
-            if (_ignoredProperties.Contains(property.Name.LocalName))
-            {
-                continue;
-            }
-
-            if (context.IsIgnoredProperty(contentType, property.Name.LocalName))
-            {
-                continue;
-            }
-
-            var newProperty = ContentBaseMigrationHandler<TEntity>.ConvertPropertyValue(ItemType, contentType, property, context);
-            if (newProperty != null)
-            {
-                propertiesList.Add(newProperty);
-            }
-        }
-
-        target.Add(propertiesList);
-
-        // check we have language title / and published statuses
-        ContentBaseMigrationHandler<TEntity>.EnsureLanguageTitles(target);
-
         return target;
-    }
-
-    private static XElement ConvertPropertyValue(string itemType, string contentType, XElement property, SyncMigrationContext context)
-    {
-        var editorAlias = context.GetEditorAlias(contentType, property.Name.LocalName)?.OriginalEditorAlias ?? string.Empty;
-
-        // convert the property .
-
-        var migrationProperty = new SyncMigrationContentProperty(editorAlias, property.Value);
-        var migrator = context.TryGetVariantMigrator(editorAlias);
-        if (migrator != null && itemType == "Content")
-        {
-            // it might be the case that the property needs to be split into variants. 
-            // if this is the case a ISyncVariationPropertyEditor will exist and it can 
-            // split a single value into a collection split by culture
-            var vortoElement = ContentBaseMigrationHandler<TEntity>.GetVariedValueNode(migrator, property.Name.LocalName, migrationProperty, context);
-            if (vortoElement != null) return vortoElement;
-        }
-
-        // or this value doesn't need to be split by variation
-        // and we can 'just' migrate it on its own.
-        var migratedValue = ContentBaseMigrationHandler<TEntity>.MigrateContentValue(migrationProperty, context);
-        return new XElement(property.Name.LocalName,
-                    new XElement("Value", new XCData(migratedValue)));
-    }
-
-    /// <summary>
-    ///  special case, spit a vorto value into multiple cultures, 
-    ///  and return them back as a blob of xml values
-    /// </summary>
-    private static XElement? GetVariedValueNode(ISyncVariationPropertyMigrator migrator, string propertyName, SyncMigrationContentProperty migrationProperty, SyncMigrationContext context)
-    {
-        // Get varied elements from the migrator.
-        var attempt = migrator.GetVariedElements(migrationProperty, context);
-        if (attempt.Success && attempt.Result != null)
-        {
-            // this returns an object which tells us what datatype to use
-            // and a dictionary of cultuire / values we can migrate. 
-
-            var newProperty = new XElement(propertyName);
-
-            // get editor alias from dtdguid
-            var variantEditorAlias = context.GetDataTypeFromDefinition(attempt.Result.DtdGuid);
-            if (variantEditorAlias != null)
-            {
-                foreach (var variation in attempt.Result.Values)
-                {
-                    var variationProperty = new SyncMigrationContentProperty(variantEditorAlias, variation.Value);
-
-                    var migratedValue = ContentBaseMigrationHandler<TEntity>.MigrateContentValue(variationProperty, context);
-
-                    newProperty.Add(new XElement("Value",
-                        new XAttribute("Culture", variation.Key),
-                        new XCData(migratedValue)));
-                }
-            }
-
-            return newProperty;
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    ///  at the end - if we have added vorto values, we also need
-    ///  to add nodename titles for the languages. 
-    /// </summary>
-    /// <param name="node"></param>
-    private static void EnsureLanguageTitles(XElement node)
-    {
-        var propertiesNode = node.Element("Properties");
-        if (propertiesNode == null) return;
-
-        var nodeNameNode = node.Element("Info")?.Element("NodeName");
-        if (nodeNameNode == null) return;
-
-        var languages = new List<string>();
-
-        foreach (var property in propertiesNode.Elements())
-        {
-            foreach (var value in property.Elements())
-            {
-                var culture = value.Attribute("Culture").ValueOrDefault(string.Empty).ToLower();
-                if (!string.IsNullOrWhiteSpace(culture)
-                    && !languages.Contains(culture))
-                {
-                    languages.Add(culture);
-                }
-            }
-        }
-
-        if (languages.Count > 0)
-        {
-            var defaultName = nodeNameNode.Attribute("Default").ValueOrDefault(string.Empty);
-            var publishedNode = node.Element("Info")?.Element("Published");
-            var publishedValue = publishedNode?.Attribute("Default").ValueOrDefault(false) ?? false;
-
-            foreach (var language in languages)
-            {
-                nodeNameNode.Add(new XElement("Name",
-                    new XAttribute("Culture", language), defaultName));
-
-                publishedNode?.Add(new XElement("Published",
-                        new XAttribute("Culture", language), publishedValue));
-            }
-        }
-    }
-
-    private static string MigrateContentValue(SyncMigrationContentProperty migrationProperty, SyncMigrationContext context)
-    {
-        if (migrationProperty == null) return string.Empty;
-
-        if (string.IsNullOrWhiteSpace(migrationProperty.EditorAlias)) return migrationProperty.Value;
-
-        var migrator = context.TryGetMigrator(migrationProperty.EditorAlias);
-        if (migrator != null)
-        {
-            return migrator?.GetContentValue(migrationProperty, context) ?? migrationProperty.Value;
-        }
-
-        return migrationProperty.Value;
     }
 }

--- a/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -1,16 +1,17 @@
 ﻿using System.Xml.Linq;
 
 using Umbraco.Cms.Core.Events;
-using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Models;
 
 using uSync.Core;
+using uSync.Migrations.Handlers.Shared;
 using uSync.Migrations.Models;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
 
-internal abstract class ContentTypeBaseMigrationHandler<TEntity> : MigrationHandlerBase<TEntity>
-    where TEntity : IEntity
+internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseHandler<TEntity>
+    where TEntity : ContentTypeBase
 {
     public ContentTypeBaseMigrationHandler(
         IEventAggregator eventAggregator,
@@ -24,65 +25,7 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : MigrationHand
             key: source.Element("Info")?.Element("Key")?.ValueOrDefault(Guid.Empty) ?? Guid.Empty
         );
 
-    protected override void PrepareFile(XElement source, SyncMigrationContext context)
-    {
-        var (contentTypeAlias, key) = GetAliasAndKey(source);
-        context.AddContentTypeKey(contentTypeAlias, key);
-
-        var compositions = source.Element("Info")?.Element("Compositions")?.Elements("Composition")?.Select(x => x.Value) ?? Enumerable.Empty<string>();
-        context.AddContentTypeCompositions(contentTypeAlias, compositions);
-
-        var properties = source.Element("GenericProperties")?.Elements("GenericProperty") ?? Enumerable.Empty<XElement>();
-
-        foreach (var property in properties)
-        {
-            var editorAlias = property.Element("Type").ValueOrDefault(string.Empty);
-            var definition = property.Element("Definition").ValueOrDefault(Guid.Empty);
-            var alias = property.Element("Alias")?.ValueOrDefault(string.Empty) ?? string.Empty;
-
-            context.AddContentProperty(contentTypeAlias, alias,
-                    editorAlias, context.GetDataTypeFromDefinition(definition));
-
-            //
-            // for now we are doing this just for media folders, but it might be
-            // that all list view properties should be ignored ??
-            if (contentTypeAlias.Equals("Folder") && editorAlias.Equals("Umbraco.ListView"))
-            {
-                context.AddIgnoredProperty(contentTypeAlias, alias);
-            }
-        }
-    }
-
-    protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
-    {
-        var info = source.Element("Info");
-        if (info == null) return null;
-
-        var (alias, key) = GetAliasAndKey(source);
-
-        var target = new XElement(ItemType,
-            new XAttribute(uSyncConstants.Xml.Key, key),
-            new XAttribute(uSyncConstants.Xml.Alias, alias),
-            new XAttribute(uSyncConstants.Xml.Level, level));
-
-        // update info element. 
-        ContentTypeBaseMigrationHandler<TEntity>.UpdateInfoSection(info, target, key, context);
-
-        // structure
-        UpdateStructure(source, target);
-
-        // properties. 
-        ContentTypeBaseMigrationHandler<TEntity>.UpdateProperties(source, target, alias, context);
-
-        // tabs
-        UpdateTabs(source, target);
-
-        ContentTypeBaseMigrationHandler<TEntity>.CheckVariations(target);
-
-        return target;
-    }
-
-    private static void UpdateTabs(XElement source, XElement target)
+    protected override void UpdateTabs(XElement source, XElement target)
     {
         var tabs = source.Element("Tabs");
         if (tabs != null)
@@ -99,75 +42,20 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : MigrationHand
         }
     }
 
-    private static void UpdateProperties(
-        XElement source,
-        XElement target,
-        string contentTypeAlias,
-        SyncMigrationContext context)
+    protected override void UpdatePropertyXml(XElement newProperty)
     {
-        var properties = source.Element("GenericProperties");
+        newProperty.Add(new XElement("MandatoryMessage", string.Empty));
+        newProperty.Add(new XElement("ValidationRegExpMessage", string.Empty));
+        newProperty.Add(new XElement("LabelOnTop", false));
 
-        var newProperties = new XElement("GenericProperties");
-        if (properties != null)
-        {
-            foreach (var property in properties.Elements("GenericProperty"))
-            {
-                var name = property.Element("Name").ValueOrDefault(string.Empty);
-
-                if (context.IsIgnoredProperty(contentTypeAlias, name))
-                {
-                    continue;
-                }
-
-                var newProperty = XElement.Parse(property.ToString());
-
-                // update the datatype we are using (this might be new). 
-                ContentTypeBaseMigrationHandler<TEntity>.UpdatePropertyEditor(contentTypeAlias, newProperty, context);
-
-                newProperty.Add(new XElement("MandatoryMessage", string.Empty));
-                newProperty.Add(new XElement("ValidationRegExpMessage", string.Empty));
-                newProperty.Add(new XElement("LabelOnTop", false));
-
-                var tabNode = newProperty.Element("Tab");
-                tabNode?.Add(new XAttribute("Alias", tabNode.ValueOrDefault(string.Empty)));
-
-                newProperties.Add(newProperty);
-            }
-        }
-
-        target.Add(newProperties);
-    }
-
-    /// <summary>
-    ///  Get the editor Alias for this property (it might have updated)
-    /// </summary>
-    /// <param name="newProperty"></param>
-    private static void UpdatePropertyEditor(string contentTypeAlias, XElement newProperty, SyncMigrationContext context)
-    {
-        var propertyAlias = newProperty.Element("Alias").ValueOrDefault(string.Empty);
-
-        var updatedType = context.GetEditorAlias(contentTypeAlias, propertyAlias)?.UpdatedEditorAlias ?? propertyAlias;
-        newProperty.CreateOrSetElement("Type", updatedType);
-
-        var definitionElement = newProperty.Element("Definition");
-        if (definitionElement == null) return;
-
-        var definition = definitionElement.ValueOrDefault(Guid.Empty);
-        if (definition != Guid.Empty)
-        {
-            definitionElement.Value = context.GetReplacementDataType(definition).ToString();
-            newProperty.CreateOrSetElement("Variations", context.GetDataTypeVariation(definition));
-        }
-        else
-        {
-            newProperty.CreateOrSetElement("Variations", "Nothing");
-        }
+        var tabNode = newProperty.Element("Tab");
+        tabNode?.Add(new XAttribute("Alias", tabNode.ValueOrDefault(string.Empty)));
     }
 
     /// <summary>
     ///  update the info section, with the new things that are in v8+ that have no equivalent in v7
     /// </summary>
-    private static void UpdateInfoSection(XElement? info, XElement target, Guid key, SyncMigrationContext context)
+    protected override void UpdateInfoSection(XElement? info, XElement target, Guid key, SyncMigrationContext context)
     {
         if (info == null) return;
 
@@ -184,14 +72,14 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : MigrationHand
     /// <summary>
     ///  update the structure (allowed nodes)
     /// </summary>
-    private static void UpdateStructure(XElement source, XElement target)
+    protected override void UpdateStructure(XElement source, XElement target)
     {
         var sourceStructure = source.Element("Structure");
         if (sourceStructure != null)
             target.Add(XElement.Parse(sourceStructure.ToString()));
     }
 
-    private static void CheckVariations(XElement target)
+    protected override void CheckVariations(XElement target)
     {
         if (target.Element("Info") == null) return;
 

--- a/uSync.Migrations/Handlers/Seven/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeMigrationHandler.cs
@@ -6,7 +6,8 @@ using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
 
-[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.ContentTypes, 7,
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.ContentTypes,
+    SourceVersion = 7,
     SourceFolderName = "DocumentType",
     TargetFolderName = "ContentTypes")]
 internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<ContentType>, ISyncMigrationHandler

--- a/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Xml.Linq;
 
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
@@ -72,16 +73,6 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
         return new SyncMigrationDataTypeProperty(editorAlias, database, preValues);
     }
 
-    protected override object? GetDataTypeConfig(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-    {
-        return dataTypeProperty.PreValues != null
-            ? migrator?.GetConfigValues(dataTypeProperty, context)
-            ?? MakeEmptyLabelConfig(dataTypeProperty)
-            : MakeEmptyLabelConfig(dataTypeProperty);
-    }
-    protected override object? MakeEmptyLabelConfig(SyncMigrationDataTypeProperty dataTypeProperty)
-        => dataTypeProperty.PreValues?.ConvertPreValuesToJson(false);
-
     private static IList<PreValue> GetPreValues(XElement source)
     {
         var items = new List<PreValue>();
@@ -144,4 +135,20 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
 
         return messages;
     }
+
+    protected override string GetNewEditorAlias(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => migrator?.GetEditorAlias(dataTypeProperty, context) ?? UmbConstants.PropertyEditors.Aliases.Label;
+
+    protected override string GetNewDatabaseType(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => migrator?.GetDatabaseType(dataTypeProperty, context) ?? ValueTypes.String;
+
+    protected override object? GetDataTypeConfig(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+    {
+        return dataTypeProperty.PreValues != null
+            ? migrator?.GetConfigValues(dataTypeProperty, context)
+            ?? MakeEmptyLabelConfig(dataTypeProperty)
+            : MakeEmptyLabelConfig(dataTypeProperty);
+    }
+    protected override object? MakeEmptyLabelConfig(SyncMigrationDataTypeProperty dataTypeProperty)
+        => dataTypeProperty.PreValues?.ConvertPreValuesToJson(false);
 }

--- a/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
@@ -70,6 +70,8 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
     protected override string GetDatabaseType(XElement source)
         => source.Attribute("DatabaseType").ValueOrDefault(string.Empty);
 
+    protected override int GetLevel(XElement source, int level) => level;
+
     protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty(string editorAlias, string database, XElement source)
     {
         var preValues = GetPreValues(source);

--- a/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
@@ -38,7 +38,7 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
 
     protected override (string alias, Guid key) GetAliasAndKey(XElement source)
         => (
-            alias: source.Attribute("Id").ValueOrDefault(string.Empty),
+            alias: source.Attribute("Name").ValueOrDefault(string.Empty),
             key: source.Attribute("Key").ValueOrDefault(Guid.Empty)
         );
 
@@ -58,10 +58,13 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
         return null;
     }
 
-    protected override string GetDocTypeName(XElement source)
+    protected override string GetEditorAlias(XElement source)
+        => source.Attribute("Id").ValueOrDefault(string.Empty);
+
+    protected override string GetDataTypeName(XElement source)
         => source.Attribute("Name").ValueOrDefault(string.Empty);
 
-    protected override string GetDocTypeFolder(XElement source)
+    protected override string GetDataTypeFolder(XElement source)
         => source.Attribute("Folder").ValueOrDefault(string.Empty);
 
     protected override string GetDatabaseType(XElement source)
@@ -106,7 +109,8 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
             try
             {
                 var source = XElement.Load(file);
-                var (editorAlias, key) = GetAliasAndKey(source);
+                var (alias, key) = GetAliasAndKey(source);
+                var editorAlias = GetEditorAlias(source);
 
                 var name = source.Attribute("Name").ValueOrDefault(string.Empty);
                 var databaseType = source.Attribute("DatabaseType").ValueOrDefault(string.Empty);

--- a/uSync.Migrations/Handlers/Seven/DictionaryMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/DictionaryMigrationHandler.cs
@@ -6,24 +6,23 @@ using Umbraco.Cms.Core.Notifications;
 using Umbraco.Extensions;
 
 using uSync.Core;
+using uSync.Migrations.Handlers.Shared;
 using uSync.Migrations.Models;
 using uSync.Migrations.Notifications;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
 
-[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Dictionary, 7,
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Dictionary, 
+    SourceVersion = 7,
     SourceFolderName = "DictionaryItem",
     TargetFolderName = "Dictionary")]
-internal class DictionaryMigrationHandler : MigrationHandlerBase<DictionaryItem>, ISyncMigrationHandler
+internal class DictionaryMigrationHandler : SharedHandlerBase<DictionaryItem>, ISyncMigrationHandler
 {
     public DictionaryMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService)
         : base(eventAggregator, migrationFileService)
-    { }
-
-    protected override void PrepareFile(XElement source, SyncMigrationContext context)
     { }
 
     /// <summary>

--- a/uSync.Migrations/Handlers/Seven/LanguageMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/LanguageMigrationHandler.cs
@@ -7,14 +7,16 @@ using Umbraco.Cms.Core.Services;
 
 using uSync.Core;
 using uSync.Migrations.Extensions;
+using uSync.Migrations.Handlers.Shared;
 using uSync.Migrations.Models;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
 
-[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Languages, 7,
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Languages, 
+    SourceVersion = 7,
     SourceFolderName = "Languages", TargetFolderName = "Languages")]
-internal class LanguageMigrationHandler : MigrationHandlerBase<Language>, ISyncMigrationHandler
+internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigrationHandler
 {
     private readonly ILocalizationService _localizationService;
 
@@ -26,9 +28,6 @@ internal class LanguageMigrationHandler : MigrationHandlerBase<Language>, ISyncM
     {
         _localizationService = localizationService;
     }
-
-    protected override void PrepareFile(XElement source, SyncMigrationContext context)
-    { }
 
     protected override (string alias, Guid key) GetAliasAndKey(XElement source)
     {

--- a/uSync.Migrations/Handlers/Seven/MacroMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/MacroMigrationHandler.cs
@@ -4,14 +4,17 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
 using uSync.Core;
+using uSync.Migrations.Handlers.Shared;
 using uSync.Migrations.Models;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
 
-[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Macros, 7,
-    SourceFolderName = "Macro", TargetFolderName = "Macros")]
-internal class MacroMigrationHandler : MigrationHandlerBase<Macro>, ISyncMigrationHandler
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Macros, 
+    SourceVersion = 7,
+    SourceFolderName = "Macro",
+    TargetFolderName = "Macros")]
+internal class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationHandler
 {
     public MacroMigrationHandler(
         IEventAggregator eventAggregator,
@@ -19,13 +22,10 @@ internal class MacroMigrationHandler : MigrationHandlerBase<Macro>, ISyncMigrati
         : base(eventAggregator, migrationFileService)
     { }
 
-    protected override void PrepareFile(XElement source, SyncMigrationContext context)
-    { }
-
     protected override (string alias, Guid key) GetAliasAndKey(XElement source)
         => (
             alias: source.Element("alias").ValueOrDefault(string.Empty),
-            key: source.Element("key").ValueOrDefault(Guid.Empty)
+            key: source.Element("Key").ValueOrDefault(Guid.Empty)
         );
 
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)

--- a/uSync.Migrations/Handlers/Seven/MediaMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/MediaMigrationHandler.cs
@@ -2,12 +2,12 @@
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Strings;
 
-using uSync.Migrations.Handlers.Seven;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
 
-[SyncMigrationHandler(BackOfficeConstants.Groups.Content, uSyncMigrations.Priorities.Media, 7,
+[SyncMigrationHandler(BackOfficeConstants.Groups.Content, uSyncMigrations.Priorities.Media, 
+    SourceVersion = 7,
     SourceFolderName = "Media",
     TargetFolderName = "Media")]
 internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISyncMigrationHandler

--- a/uSync.Migrations/Handlers/Seven/TemplateMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/TemplateMigrationHandler.cs
@@ -1,44 +1,27 @@
 ﻿using System.Xml.Linq;
 
 using Umbraco.Cms.Core.Events;
-using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 
 using uSync.Core;
+using uSync.Migrations.Handlers.Shared;
 using uSync.Migrations.Models;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
 
-[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Templates, 7,
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Templates,
+    SourceVersion = 7,
     SourceFolderName = "Template",
     TargetFolderName = "Templates")]
-internal class TemplateMigrationHandler : MigrationHandlerBase<Template>,  ISyncMigrationHandler
+internal class TemplateMigrationHandler : SharedTemplateHandler,  ISyncMigrationHandler
 {
-    private readonly IFileService _fileService;
-
     public TemplateMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         IFileService fileService)
-        : base(eventAggregator, migrationFileService)
-    {
-        _fileService = fileService;
-    }
-
-    public override void Prepare(SyncMigrationContext context)
-    {
-        foreach (var template in _fileService.GetTemplates())
-        {
-            context.AddTemplateKey(template.Alias, template.Key);
-        }
-    }
-
-    protected override void PrepareFile(XElement source, SyncMigrationContext context)
-    {
-        var (alias, key) = GetAliasAndKey(source);
-        context.AddTemplateKey(alias, key);
-    }
+        : base(eventAggregator, migrationFileService, fileService)
+    { }
 
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
     {

--- a/uSync.Migrations/Handlers/Shared/SharedContentBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentBaseHandler.cs
@@ -1,0 +1,234 @@
+﻿using System.Xml.Linq;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Strings;
+
+using uSync.Core;
+using uSync.Migrations.Migrators;
+using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Models;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Shared;
+internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TEntity>
+    where TEntity : ContentBase
+{
+    protected readonly IShortStringHelper _shortStringHelper;
+    
+    protected readonly HashSet<string> _ignoredProperties = new(StringComparer.OrdinalIgnoreCase);
+    protected readonly Dictionary<string, string> _mediaTypeAliasForFileExtension = new(StringComparer.OrdinalIgnoreCase);
+
+    public SharedContentBaseHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService,
+        IShortStringHelper shortStringHelper) : base(eventAggregator, migrationFileService)
+    {
+        _shortStringHelper = shortStringHelper;
+    }
+
+    protected abstract int GetId(XElement source);
+
+    protected override void PrepareFile(XElement source, SyncMigrationContext context)
+    {
+        var (alias, key) = GetAliasAndKey(source);
+
+        if (key != Guid.Empty)
+        {
+            var id = GetId(source);
+            if (id > 0)
+            {
+                context.AddKey(id, key);
+            }
+
+            if (string.IsNullOrWhiteSpace(alias) == false)
+            {
+                context.AddContentKey(key, alias);
+            }
+        }
+    }
+
+    protected abstract XElement GetBaseXml(XElement source, Guid parent, string contentType, int level, SyncMigrationContext context);
+
+    protected abstract Guid GetParent(XElement source);
+
+    protected abstract string GetContentType(XElement source);
+
+    protected abstract string GetPath(string alias, Guid parent, SyncMigrationContext context);
+
+    protected abstract IEnumerable<XElement>? GetProperties(XElement source);
+
+    protected abstract string GetNewContentType(string contentType, XElement source);
+
+    protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
+    {
+        var (alias, key) = GetAliasAndKey(source);
+
+        var parent = GetParent(source);
+        var contentType = GetContentType(source);
+
+        var path = GetPath(alias, parent, context);
+        context.AddContentPath(key, path);
+
+        // media might update this 
+        contentType = GetNewContentType(contentType, source);
+
+        var target = GetBaseXml(source, parent, contentType, level, context);
+
+        var propertiesList = new XElement("Properties");
+
+        var properties = GetProperties(source) ?? Enumerable.Empty<XElement>();
+        foreach (var property in properties)
+        {
+            if (_ignoredProperties.Contains(property.Name.LocalName))
+            {
+                continue;
+            }
+
+            if (context.IsIgnoredProperty(contentType, property.Name.LocalName))
+            {
+                continue;
+            }
+
+            var newProperty = ConvertPropertyValue(ItemType, contentType, property, context);
+            if (newProperty != null)
+            {
+                propertiesList.Add(newProperty);
+            }
+        }
+
+        target.Add(propertiesList);
+
+        // check we have language title / and published statuses
+        EnsureLanguageTitles(target);
+
+        return target;
+    }
+
+    protected virtual XElement ConvertPropertyValue(string itemType, string contentType, XElement property, SyncMigrationContext context)
+    {
+        var editorAlias = context.GetEditorAlias(contentType, property.Name.LocalName)?.OriginalEditorAlias ?? string.Empty;
+
+        // convert the property .
+
+        var migrationProperty = new SyncMigrationContentProperty(editorAlias, property.Value);
+        var migrator = context.TryGetVariantMigrator(editorAlias);
+        if (migrator != null && itemType == "Content")
+        {
+            // it might be the case that the property needs to be split into variants. 
+            // if this is the case a ISyncVariationPropertyEditor will exist and it can 
+            // split a single value into a collection split by culture
+            var vortoElement = GetVariedValueNode(migrator, property.Name.LocalName, migrationProperty, context);
+            if (vortoElement != null) return vortoElement;
+        }
+
+        // or this value doesn't need to be split by variation
+        // and we can 'just' migrate it on its own.
+        var migratedValue = MigrateContentValue(migrationProperty, context);
+        return new XElement(property.Name.LocalName,
+                    new XElement("Value", new XCData(migratedValue)));
+    }
+
+    /// <summary>
+    ///  special case, spit a vorto value into multiple cultures, 
+    ///  and return them back as a blob of xml values
+    /// </summary>
+    protected virtual XElement? GetVariedValueNode(ISyncVariationPropertyMigrator migrator, string propertyName, SyncMigrationContentProperty migrationProperty, SyncMigrationContext context)
+    {
+        // Get varied elements from the migrator.
+        var attempt = migrator.GetVariedElements(migrationProperty, context);
+        if (attempt.Success && attempt.Result != null)
+        {
+            // this returns an object which tells us what datatype to use
+            // and a dictionary of cultuire / values we can migrate. 
+
+            var newProperty = new XElement(propertyName);
+
+            // get editor alias from dtdguid
+            var variantEditorAlias = context.GetDataTypeFromDefinition(attempt.Result.DtdGuid);
+            if (variantEditorAlias != null)
+            {
+                foreach (var variation in attempt.Result.Values)
+                {
+                    var variationProperty = new SyncMigrationContentProperty(variantEditorAlias, variation.Value);
+
+                    var migratedValue = MigrateContentValue(variationProperty, context);
+
+                    newProperty.Add(new XElement("Value",
+                        new XAttribute("Culture", variation.Key),
+                        new XCData(migratedValue)));
+                }
+            }
+
+            return newProperty;
+        }
+
+        return null;
+    }
+
+    protected virtual string MigrateContentValue(SyncMigrationContentProperty migrationProperty, SyncMigrationContext context)
+    {
+        if (migrationProperty == null) return string.Empty;
+
+        if (string.IsNullOrWhiteSpace(migrationProperty.EditorAlias)) return migrationProperty.Value;
+
+        var migrator = context.TryGetMigrator(migrationProperty.EditorAlias);
+        if (migrator != null)
+        {
+            return migrator?.GetContentValue(migrationProperty, context) ?? migrationProperty.Value;
+        }
+
+        return migrationProperty.Value;
+    }
+
+    /// <summary>
+    ///  something we probibly only need to do for v7 - but ensure we have 
+    ///  all the right cultures in the title (nodename) as we do in the properties.
+    /// </summary>
+    /// <remarks>
+    ///  v7 needs this when vorto splits something up, in v8 we don't so in theory
+    ///  this should be fine, but this could act as a 'fix' in a v8 migration if 
+    ///  something was missing.
+    /// </remarks>
+
+    protected virtual void EnsureLanguageTitles(XElement node)
+    {
+        var propertiesNode = node.Element("Properties");
+        if (propertiesNode == null) return;
+
+        var nodeNameNode = node.Element("Info")?.Element("NodeName");
+        if (nodeNameNode == null) return;
+
+        var languages = new List<string>();
+
+        foreach (var property in propertiesNode.Elements())
+        {
+            foreach (var value in property.Elements())
+            {
+                var culture = value.Attribute("Culture").ValueOrDefault(string.Empty).ToLower();
+                if (!string.IsNullOrWhiteSpace(culture)
+                    && !languages.Contains(culture))
+                {
+                    languages.Add(culture);
+                }
+            }
+        }
+
+        if (languages.Count > 0)
+        {
+            var defaultName = nodeNameNode.Attribute("Default").ValueOrDefault(string.Empty);
+            var publishedNode = node.Element("Info")?.Element("Published");
+            var publishedValue = publishedNode?.Attribute("Default").ValueOrDefault(false) ?? false;
+
+            foreach (var language in languages)
+            {
+                nodeNameNode.Add(new XElement("Name",
+                    new XAttribute("Culture", language), defaultName));
+
+                publishedNode?.Add(new XElement("Published",
+                        new XAttribute("Culture", language), publishedValue));
+            }
+        }
+    }
+
+}

--- a/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -1,0 +1,137 @@
+﻿using System.Xml.Linq;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+
+using uSync.Core;
+using uSync.Migrations.Models;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Shared;
+internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBase<TEntity>
+    where TEntity : ContentTypeBase
+{
+    protected SharedContentTypeBaseHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+    { }
+
+    protected override void PrepareFile(XElement source, SyncMigrationContext context)
+    {
+        var (contentTypeAlias, key) = GetAliasAndKey(source);
+        context.AddContentTypeKey(contentTypeAlias, key);
+
+        var compositions = source.Element("Info")?.Element("Compositions")?.Elements("Composition")?.Select(x => x.Value) ?? Enumerable.Empty<string>();
+        context.AddContentTypeCompositions(contentTypeAlias, compositions);
+
+        var properties = source.Element("GenericProperties")?.Elements("GenericProperty") ?? Enumerable.Empty<XElement>();
+
+        foreach (var property in properties)
+        {
+            var editorAlias = property.Element("Type").ValueOrDefault(string.Empty);
+            var definition = property.Element("Definition").ValueOrDefault(Guid.Empty);
+            var alias = property.Element("Alias")?.ValueOrDefault(string.Empty) ?? string.Empty;
+
+            context.AddContentProperty(contentTypeAlias, alias,
+                    editorAlias, context.GetDataTypeFromDefinition(definition));
+
+            //
+            // for now we are doing this just for media folders, but it might be
+            // that all list view properties should be ignored ??
+            if (contentTypeAlias.Equals("Folder") && editorAlias.Equals("Umbraco.ListView"))
+            {
+                context.AddIgnoredProperty(contentTypeAlias, alias);
+            }
+        }
+    }
+
+    protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
+    {
+        var info = source.Element("Info");
+        if (info == null) return null;
+
+        var (alias, key) = GetAliasAndKey(source);
+
+        var target = new XElement(ItemType,
+            new XAttribute(uSyncConstants.Xml.Key, key),
+            new XAttribute(uSyncConstants.Xml.Alias, alias),
+            new XAttribute(uSyncConstants.Xml.Level, source.GetLevel()));
+
+        // update info element. 
+        UpdateInfoSection(info, target, key, context);
+
+        // structure
+        UpdateStructure(source, target);
+
+        // properties. 
+        UpdateProperties(source, target, alias, context);
+
+        // tabs
+        UpdateTabs(source, target);
+
+        CheckVariations(target);
+
+        return target;
+
+    }
+
+    protected abstract void UpdateInfoSection(XElement? info, XElement target, Guid key, SyncMigrationContext context);
+    protected abstract void UpdateStructure(XElement source, XElement target);
+    protected abstract void UpdateTabs(XElement source, XElement target);
+    protected abstract void CheckVariations(XElement target);
+
+    protected virtual void UpdateProperties(XElement source, XElement target, string alias, SyncMigrationContext context)
+    {
+        var properties = source.Element("GenericProperties");
+
+        var newProperties = new XElement("GenericProperties");
+        if (properties != null)
+        {
+            foreach (var property in properties.Elements("GenericProperty"))
+            {
+                var name = property.Element("Name").ValueOrDefault(string.Empty);
+
+                if (context.IsIgnoredProperty(alias, name))
+                {
+                    continue;
+                }
+
+                var newProperty = XElement.Parse(property.ToString());
+
+                // update the datatype we are using (this might be new). 
+                UpdatePropertyEditor(alias, newProperty, context);
+
+                UpdatePropertyXml(newProperty);
+
+                newProperties.Add(newProperty);
+            }
+        }
+
+        target.Add(newProperties);
+    }
+
+    protected virtual void UpdatePropertyEditor(string alias, XElement newProperty, SyncMigrationContext context)
+    {
+        var propertyAlias = newProperty.Element("Alias").ValueOrDefault(string.Empty);
+
+        var updatedType = context.GetEditorAlias(alias, propertyAlias)?.UpdatedEditorAlias ?? propertyAlias;
+        newProperty.CreateOrSetElement("Type", updatedType);
+
+        var definitionElement = newProperty.Element("Definition");
+        if (definitionElement == null) return;
+
+        var definition = definitionElement.ValueOrDefault(Guid.Empty);
+        if (definition != Guid.Empty)
+        {
+            definitionElement.Value = context.GetReplacementDataType(definition).ToString();
+            newProperty.CreateOrSetElement("Variations", context.GetDataTypeVariation(definition));
+        }
+        else
+        {
+            newProperty.CreateOrSetElement("Variations", "Nothing");
+        }
+    }
+    protected abstract void UpdatePropertyXml(XElement newProperty);
+
+
+}

--- a/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -60,16 +60,30 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
         // update info element. 
         UpdateInfoSection(info, target, key, context);
 
-        // structure
-        UpdateStructure(source, target);
+        if (ItemType == nameof(ContentType))
+        {
+            // structure
+            UpdateStructure(source, target);
+        }
 
         // properties. 
         UpdateProperties(source, target, alias, context);
 
+
+        if (ItemType != nameof(ContentType))
+        {
+            // odd usync thing, in media/member structure is after properties. 
+            UpdateStructure(source, target);
+        }
+
+
         // tabs
         UpdateTabs(source, target);
 
-        CheckVariations(target);
+        if (ItemType == nameof(ContentType))
+        {
+            CheckVariations(target);
+        }
 
         return target;
 
@@ -121,15 +135,19 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
         if (definitionElement == null) return;
 
         var definition = definitionElement.ValueOrDefault(Guid.Empty);
+        var variationValue = "Nothing";
+
         if (definition != Guid.Empty)
         {
             definitionElement.Value = context.GetReplacementDataType(definition).ToString();
-            newProperty.CreateOrSetElement("Variations", context.GetDataTypeVariation(definition));
+            variationValue = context.GetDataTypeVariation(definition);
         }
-        else
+
+        if (ItemType == nameof(ContentType))
         {
-            newProperty.CreateOrSetElement("Variations", "Nothing");
+            newProperty.CreateOrSetElement("Variations", variationValue);
         }
+
     }
     protected abstract void UpdatePropertyXml(XElement newProperty);
 

--- a/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
@@ -48,7 +48,9 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
 
     protected override void PrepareFile(XElement source, SyncMigrationContext context)
     {
-        var (editorAlias, dtd) = GetAliasAndKey(source);
+        var (alias, dtd) = GetAliasAndKey(source);
+        var editorAlias = GetEditorAlias(source);
+
         if (dtd == Guid.Empty || string.IsNullOrEmpty(editorAlias)) return;
 
         var databaseType = GetDatabaseType(source);
@@ -71,9 +73,9 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
         context.AddDataTypeDefinition(dtd, editorAlias);
     }
 
-
-    protected abstract string GetDocTypeName(XElement source);
-    protected abstract string GetDocTypeFolder(XElement source);
+    protected abstract string GetEditorAlias(XElement source);
+    protected abstract string GetDataTypeName(XElement source);
+    protected abstract string GetDataTypeFolder(XElement source);
 
     protected abstract SyncMigrationDataTypeProperty GetMigrationDataTypeProperty(string editorAlias, string database, XElement source);
     protected abstract object? GetDataTypeConfig(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context);
@@ -85,6 +87,7 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
     {
         var (alias, key) = GetAliasAndKey(source);
+        var editorAlias = GetEditorAlias(source);   
 
         if (context.GetReplacementDataType(key) != key)
         {
@@ -92,17 +95,17 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
             return null;
         }
 
-        var name = GetDocTypeName(source);
-        var folder = GetDocTypeFolder(source);
+        var name = GetDataTypeName(source);
+        var folder = GetDataTypeFolder(source);
         var databaseType = GetDatabaseType(source);
 
-        var migrator = context.TryGetMigrator(alias);
+        var migrator = context.TryGetMigrator(editorAlias);
         if (migrator is null)
         {
             // no migrator. 
         }
 
-        var dataTypeProperty = GetMigrationDataTypeProperty(alias, databaseType, source);
+        var dataTypeProperty = GetMigrationDataTypeProperty(editorAlias, databaseType, source);
         var newEditorAlias = GetNewEditorAlias(migrator, dataTypeProperty, context);
         var newDatabaseType = GetNewDatabaseType(migrator, dataTypeProperty, context);
         var newConfig = GetDataTypeConfig(migrator, dataTypeProperty, context) ?? MakeEmptyLabelConfig(dataTypeProperty);

--- a/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json;
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
 
 using uSync.Core;
@@ -80,6 +79,9 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
     protected abstract object? GetDataTypeConfig(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context);
     protected abstract object? MakeEmptyLabelConfig(SyncMigrationDataTypeProperty dataTypeProperty);
 
+    protected abstract string GetNewEditorAlias(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context);
+    protected abstract string GetNewDatabaseType(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context);
+
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
     {
         var (alias, key) = GetAliasAndKey(source);
@@ -101,9 +103,8 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
         }
 
         var dataTypeProperty = GetMigrationDataTypeProperty(alias, databaseType, source);
-        var newEditorAlias = migrator?.GetEditorAlias(dataTypeProperty, context) ?? UmbConstants.PropertyEditors.Aliases.Label;
-        var newDatabaseType = migrator?.GetDatabaseType(dataTypeProperty, context) ?? ValueTypes.String;
-
+        var newEditorAlias = GetNewEditorAlias(migrator, dataTypeProperty, context);
+        var newDatabaseType = GetNewDatabaseType(migrator, dataTypeProperty, context);
         var newConfig = GetDataTypeConfig(migrator, dataTypeProperty, context) ?? MakeEmptyLabelConfig(dataTypeProperty);
 
         return MakeMigratedXml(key, name, level, newEditorAlias, newDatabaseType, folder, newConfig);

--- a/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
@@ -84,6 +84,8 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
     protected abstract string GetNewEditorAlias(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context);
     protected abstract string GetNewDatabaseType(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context);
 
+    protected virtual int GetLevel(XElement source, int level) => source.GetLevel();
+
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
     {
         var (alias, key) = GetAliasAndKey(source);
@@ -110,7 +112,7 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
         var newDatabaseType = GetNewDatabaseType(migrator, dataTypeProperty, context);
         var newConfig = GetDataTypeConfig(migrator, dataTypeProperty, context) ?? MakeEmptyLabelConfig(dataTypeProperty);
 
-        return MakeMigratedXml(key, name, level, newEditorAlias, newDatabaseType, folder, newConfig);
+        return MakeMigratedXml(key, name, GetLevel(source, level), newEditorAlias, newDatabaseType, folder, newConfig);
     }
 
     protected virtual XElement MakeMigratedXml(

--- a/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
@@ -1,0 +1,141 @@
+﻿using System.Xml.Linq;
+
+using Newtonsoft.Json;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+
+using uSync.Core;
+using uSync.Migrations.Migrators;
+using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Models;
+using uSync.Migrations.Serialization;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Shared;
+internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
+{
+    protected readonly IDataTypeService _dataTypeService;
+    protected readonly JsonSerializerSettings _jsonSerializerSettings;
+
+
+    public SharedDataTypeHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService,
+        IDataTypeService dataTypeService)
+        : base(eventAggregator, migrationFileService)
+    {
+        _dataTypeService = dataTypeService;
+        _jsonSerializerSettings = new JsonSerializerSettings()
+        {
+            ContractResolver = new SyncMigrationsContractResolver(),
+            Formatting = Formatting.Indented,
+        };
+
+    }
+
+    public override void Prepare(SyncMigrationContext context)
+    {
+        foreach (var datatype in _dataTypeService.GetAll())
+        {
+            context.AddDataTypeDefinition(datatype.Key, datatype.EditorAlias);
+        }
+    }
+
+    protected abstract string GetDatabaseType(XElement source);
+    protected abstract ReplacementDataTypeInfo? GetReplacementInfo(string editorAlias, string databaseType, XElement source, SyncMigrationContext context);
+
+    protected override void PrepareFile(XElement source, SyncMigrationContext context)
+    {
+        var (editorAlias, dtd) = GetAliasAndKey(source);
+        if (dtd == Guid.Empty || string.IsNullOrEmpty(editorAlias)) return;
+
+        var databaseType = GetDatabaseType(source);
+
+        // replacements
+        var replacementInfo = GetReplacementInfo(editorAlias, databaseType, source, context);
+
+        if (replacementInfo != null)
+        {
+            context.AddReplacementDataType(dtd, replacementInfo.Key);
+            context.AddDataTypeDefinition(dtd, replacementInfo.EditorAlias);
+
+            if (string.IsNullOrWhiteSpace(replacementInfo.Variation) == false)
+            {
+                context.AddDataTypeVariation(dtd, replacementInfo.Variation);
+            }
+        }
+
+        // add alias, (won't update if replacement was added)
+        context.AddDataTypeDefinition(dtd, editorAlias);
+    }
+
+
+    protected abstract string GetDocTypeName(XElement source);
+    protected abstract string GetDocTypeFolder(XElement source);
+
+    protected abstract SyncMigrationDataTypeProperty GetMigrationDataTypeProperty(string editorAlias, string database, XElement source);
+    protected abstract object? GetDataTypeConfig(ISyncPropertyMigrator? migrator, SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context);
+    protected abstract object? MakeEmptyLabelConfig(SyncMigrationDataTypeProperty dataTypeProperty);
+
+    protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
+    {
+        var (alias, key) = GetAliasAndKey(source);
+
+        if (context.GetReplacementDataType(key) != key)
+        {
+            // this data type has been replaced and isn't to be migrated
+            return null;
+        }
+
+        var name = GetDocTypeName(source);
+        var folder = GetDocTypeFolder(source);
+        var databaseType = GetDatabaseType(source);
+
+        var migrator = context.TryGetMigrator(alias);
+        if (migrator is null)
+        {
+            // no migrator. 
+        }
+
+        var dataTypeProperty = GetMigrationDataTypeProperty(alias, databaseType, source);
+        var newEditorAlias = migrator?.GetEditorAlias(dataTypeProperty, context) ?? UmbConstants.PropertyEditors.Aliases.Label;
+        var newDatabaseType = migrator?.GetDatabaseType(dataTypeProperty, context) ?? ValueTypes.String;
+
+        var newConfig = GetDataTypeConfig(migrator, dataTypeProperty, context) ?? MakeEmptyLabelConfig(dataTypeProperty);
+
+        return MakeMigratedXml(key, name, level, newEditorAlias, newDatabaseType, folder, newConfig);
+    }
+
+    protected virtual XElement MakeMigratedXml(
+        Guid key, string name, int level, string newEditorAlias,
+        string newDatabaseType, string folder, object? config)
+    {
+
+        // now we write the new xml. 
+        var target = new XElement("DataType",
+            new XAttribute(uSyncConstants.Xml.Key, key),
+            new XAttribute(uSyncConstants.Xml.Alias, name),
+            new XAttribute(uSyncConstants.Xml.Level, level),
+            new XElement(uSyncConstants.Xml.Info,
+                new XElement(uSyncConstants.Xml.Name, name),
+                new XElement("EditorAlias", newEditorAlias),
+                new XElement("DatabaseType", newDatabaseType)));
+
+        if (string.IsNullOrWhiteSpace(folder) == false)
+        {
+            target.Element(uSyncConstants.Xml.Info)?.Add(new XElement("Folder", folder));
+        }
+
+        if (config != null)
+        {
+            target.Add(new XElement("Config",
+                new XCData(JsonConvert.SerializeObject(config, _jsonSerializerSettings))));
+        }
+
+        return target;
+    }
+
+}

--- a/uSync.Migrations/Handlers/Shared/SharedHandlerBase.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedHandlerBase.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models.Entities;
+
+using uSync.Core;
+using uSync.Migrations.Models;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Shared;
+
+/// <summary>
+///  shared base for v7 and v8 migrators
+/// </summary>
+/// <remarks>
+///  the default behaviour of shared migrators is that of v8 (because that is 
+///  consistant - so less repeated code)
+///  
+///  v7 migrators override the default behavors, to do the migrations.
+/// </remarks>
+internal abstract class SharedHandlerBase<TObject> :MigrationHandlerBase<TObject>
+    where TObject : IEntity
+{
+    protected SharedHandlerBase(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService) 
+        : base(eventAggregator, migrationFileService)
+    { }
+
+    /// <summary>
+    ///  default for shared is v8 behavoir. 
+    /// </summary>
+    /// <param name="source"></param>
+    /// <param name="context"></param>
+    protected override void PrepareFile(XElement source, SyncMigrationContext context)
+    { }
+
+    /// <summary>
+    ///  alias and key - v8 we have methods that get these values consitantly. 
+    /// </summary>
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source)
+        => (alias: source.GetAlias(), key: source.GetKey());
+
+    /// <summary>
+    ///  the default in v8 is just to pass the file from source to target.
+    /// </summary>
+    /// <remarks>
+    ///  for the 'basics' like languages etc, this is a copy, when we migrate 
+    ///  the complex things (e.g content) we override this even for v8
+    /// </remarks>
+    protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
+        => source;
+}

--- a/uSync.Migrations/Handlers/Shared/SharedTemplateHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedTemplateHandler.cs
@@ -1,0 +1,38 @@
+﻿using System.Xml.Linq;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+using uSync.Migrations.Models;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Handlers.Shared;
+
+/// <summary>
+///  stuff that is the same in v7 and v8 template migrations.
+/// </summary>
+internal abstract class SharedTemplateHandler : SharedHandlerBase<Template>
+{
+    protected readonly IFileService _fileService;
+
+    protected SharedTemplateHandler(
+        IEventAggregator eventAggregator,
+        ISyncMigrationFileService migrationFileService,
+        IFileService fileService) : base(eventAggregator, migrationFileService)
+    {
+        _fileService = fileService;
+    }
+
+    public override void Prepare(SyncMigrationContext context)
+    {
+        _fileService.GetTemplates().ToList()
+            .ForEach(template => context.AddTemplateKey(template.Alias, template.Key));
+    }
+
+    protected override void PrepareFile(XElement source, SyncMigrationContext context)
+    {
+        var (alias, key) = GetAliasAndKey(source);
+        context.AddTemplateKey(alias, key);
+    }
+}

--- a/uSync.Migrations/Handlers/SyncMigrationHandlerAttribute.cs
+++ b/uSync.Migrations/Handlers/SyncMigrationHandlerAttribute.cs
@@ -1,11 +1,10 @@
 ﻿namespace uSync.Migrations.Handlers;
 internal class SyncMigrationHandlerAttribute : Attribute
 {
-    public SyncMigrationHandlerAttribute(string group, int priority, int sourceVersion)
+    public SyncMigrationHandlerAttribute(string group, int priority)
     {
         Group = group;
         Priority = priority;
-        SourceVersion = sourceVersion;
     }
 
     public string Group { get; set; }

--- a/uSync.Migrations/Migrators/Community/StackedContentToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/StackedContentToBlockListMigrator.cs
@@ -26,9 +26,9 @@ public class StackedContentToBlockListMigrator : SyncPropertyMigratorBase
 
     public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
     {
-        var contentTypes = dataTypeProperty.PreValues.GetPreValueOrDefault("contentTypes", "[]");
-        var maxItems = dataTypeProperty.PreValues.GetPreValueOrDefault("maxItems", 0);
-        var singleItemMode = dataTypeProperty.PreValues.GetPreValueOrDefault("singleItemMode", 0);
+        var contentTypes = dataTypeProperty.PreValues?.GetPreValueOrDefault("contentTypes", "[]") ?? "[]";
+        var maxItems = dataTypeProperty.PreValues?.GetPreValueOrDefault("maxItems", 0) ?? 0;
+        var singleItemMode = dataTypeProperty.PreValues?.GetPreValueOrDefault("singleItemMode", 0) ?? 0;
 
         var blocks = JsonConvert
             .DeserializeObject<List<StackedContentConfigurationBlock>>(contentTypes)?

--- a/uSync.Migrations/Migrators/Community/TerratypeToOpenStreetmapMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/TerratypeToOpenStreetmapMigrator.cs
@@ -17,7 +17,7 @@ public class TerratypeToOpenStreetmapMigrator : SyncPropertyMigratorBase
         var config = new JObject();
 
         config.Add("allowClear", true);
-        config.Add("defaultPosition", GetPosition(dataTypeProperty.PreValues.GetPreValueOrDefault("definition", string.Empty)));
+        config.Add("defaultPosition", GetPosition(dataTypeProperty.PreValues?.GetPreValueOrDefault("definition", string.Empty) ?? string.Empty));
         config.Add("showCoordinates", false);
         config.Add("showSearch", false);
         config.Add("tileLayer", "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png");

--- a/uSync.Migrations/Migrators/ISyncPropertyMigrator.cs
+++ b/uSync.Migrations/Migrators/ISyncPropertyMigrator.cs
@@ -10,6 +10,8 @@ public interface ISyncPropertyMigrator : IDiscoverable
 {
     string[] Editors { get; }
 
+    int[] Versions { get; }
+
     public string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context);
 
     public string GetDatabaseType(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context);

--- a/uSync.Migrations/Migrators/Models/ReplacementDataTypeInfo.cs
+++ b/uSync.Migrations/Migrators/Models/ReplacementDataTypeInfo.cs
@@ -14,5 +14,5 @@ public class ReplacementDataTypeInfo
     /// <summary>
     ///  is the replacement to a varied value - if so varies by what?
     /// </summary>
-    public string Variation { get; set; }
+    public string Variation { get; set; } = string.Empty;
 }

--- a/uSync.Migrations/Migrators/Models/SyncMigrationDataTypeProperty.cs
+++ b/uSync.Migrations/Migrators/Models/SyncMigrationDataTypeProperty.cs
@@ -13,7 +13,16 @@ public sealed class SyncMigrationDataTypeProperty : SyncMigrationPropertyBase
         PreValues = new ReadOnlyCollection<PreValue>(preValues);
     }
 
+    public SyncMigrationDataTypeProperty(string editorAlias, string databaseType, string? config)
+        : base(editorAlias) 
+    {
+        DatabaseType = databaseType;
+        ConfigAsString = config;
+    }
+
     public string DatabaseType { get; private set; }
 
-    public IReadOnlyCollection<PreValue> PreValues { get; private set; }
+    public IReadOnlyCollection<PreValue>? PreValues { get; private set; }
+
+    public string? ConfigAsString { get; private set; }
 }

--- a/uSync.Migrations/Migrators/SyncMigratorAttribute.cs
+++ b/uSync.Migrations/Migrators/SyncMigratorAttribute.cs
@@ -33,3 +33,24 @@ public class SyncMigratorAttribute : Attribute
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 public class SyncDefaultMigratorAttribute : Attribute { }
+
+
+/// <summary>
+///  When you want to specifically support a version you can add a SyncMigratorVersion attribute
+/// </summary>
+/// <remarks>
+///  if the attribute is not present then the migrator will assume it supports v7. 
+///  but you use the attribute you have to specifiy all versions you support. 
+///  the version is passed in the Context so you can choose to do diffrent things per version
+/// </remarks>
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class SyncMigratorVersionAttribute : Attribute
+{
+    public int[] Versions { get; set; }
+
+    public SyncMigratorVersionAttribute(params int[] versions)
+    {
+        Versions = versions;
+    }
+}

--- a/uSync.Migrations/Migrators/SyncPropertyMigratorBase.cs
+++ b/uSync.Migrations/Migrators/SyncPropertyMigratorBase.cs
@@ -14,6 +14,8 @@ public abstract class SyncPropertyMigratorBase : ISyncPropertyMigrator
 
     public virtual string[] Editors { get; private set; }
 
+    public virtual int[] Versions { get; private set; }
+
     protected SyncPropertyMigratorBase()
     {
         // read the attribute
@@ -43,9 +45,17 @@ public abstract class SyncPropertyMigratorBase : ISyncPropertyMigrator
         {
             throw new InvalidOperationException($"Migrators inheriting from {nameof(SyncPropertyMigratorBase)} must contain at least one ${nameof(SyncMigratorAttribute)}");
         }
+
+        var versionAttributes = this.GetType().GetCustomAttributes<SyncMigratorVersionAttribute>(false);
+        if (versionAttributes != null && versionAttributes.Any())
+        {
+            Versions = versionAttributes.SelectMany(x => x.Versions).ToArray();
+        }
+        else
+        {
+            Versions = new[] { 7 };
+        }
     }
-
-
 
     public virtual string GetDatabaseType(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => dataTypeProperty.DatabaseType;

--- a/uSync.Migrations/Models/MigrationResults.cs
+++ b/uSync.Migrations/Models/MigrationResults.cs
@@ -9,4 +9,5 @@ public class MigrationResults
     public bool Success { get; set; }
     public Guid MigrationId { get; set; }
     public IEnumerable<MigrationMessage> Messages { get; set; }
+        = new List<MigrationMessage>();
 }

--- a/uSync.Migrations/Models/PreValue.cs
+++ b/uSync.Migrations/Models/PreValue.cs
@@ -3,6 +3,6 @@
 public class PreValue
 {
     public int SortOrder { get; set; }
-    public string Alias { get; set; }
-    public string Value { get; set; }
+    public string Alias { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
 }

--- a/uSync.Migrations/Models/SyncMigrationContext.cs
+++ b/uSync.Migrations/Models/SyncMigrationContext.cs
@@ -30,6 +30,10 @@ public class SyncMigrationContext : IDisposable
     /// </summary>
     public int SourceVersion { get; }
 
+    /// <summary>
+    ///  the current default language of the install. 
+    /// </summary>
+    public string DefaultLanguage { get; set; } = string.Empty;
 
     private Dictionary<string, ISyncPropertyMigrator> _migrators { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
@@ -65,7 +69,6 @@ public class SyncMigrationContext : IDisposable
 
     private Dictionary<int, Guid> _idKeyMap { get; set; } = new();
 
-    public string DefaultLanguage { get; set; }
 
   
     /// <summary>

--- a/uSync.Migrations/Services/SyncMigrationService.cs
+++ b/uSync.Migrations/Services/SyncMigrationService.cs
@@ -8,6 +8,7 @@ using uSync.BackOffice.Configuration;
 using uSync.Migrations.Composing;
 using uSync.Migrations.Configuration.Models;
 using uSync.Migrations.Handlers;
+using uSync.Migrations.Migrators;
 using uSync.Migrations.Models;
 
 namespace uSync.Migrations.Services;
@@ -186,7 +187,7 @@ internal class SyncMigrationService : ISyncMigrationService
         var preferredList = _migrators.GetPreferredMigratorList(preferredMigrators);
         if (preferredList != null)
         {
-            foreach (var item in preferredList)
+            foreach (var item in preferredList.Where(x => x.Migrator.Versions.Contains(context.SourceVersion)))
             {
                 context.AddPropertyMigration(item.EditorAlias, item.Migrator);
             }

--- a/uSync.Migrations/uSync.Migrations.csproj
+++ b/uSync.Migrations/uSync.Migrations.csproj
@@ -24,8 +24,4 @@
 			<_Parameter1>uSync.Migrations.Tests</_Parameter1>
 		</AssemblyAttribute>
 	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="Handlers\Shared\" />
-	</ItemGroup>
 </Project>


### PR DESCRIPTION
Still a little bit of work in progress on the share but : 

- Shared code for the migration handlers between v7 and v8. with only minimal differences 
- clean up the handlers so they don't have lots of repeated code. 

to do (in this PR)

- [x]  work out the best way to reuse migrators for v8 ( or do we have v8 only ones - seems a shame when nested to block is already done). 
