### PR TITLE
Add logging to the handlers.

### DIFF
--- a/uSync.Migrations/Handlers/Eight/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentBaseMigrationHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Strings;
@@ -17,7 +19,9 @@ internal class ContentBaseMigrationHandler<TEntity> : SharedContentBaseHandler<T
     public ContentBaseMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IShortStringHelper shortStringHelper) : base(eventAggregator, migrationFileService, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        ILogger<ContentBaseMigrationHandler<TEntity>> logger) 
+        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
     { }
 
     protected override string GetContentType(XElement source)

--- a/uSync.Migrations/Handlers/Eight/ContentMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Strings;
 
@@ -15,7 +17,8 @@ internal class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, I
     public ContentMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IShortStringHelper shortStringHelper)
-        : base(eventAggregator, migrationFileService, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        ILogger<ContentMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
     { }
 }

--- a/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
@@ -13,7 +15,9 @@ internal class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseH
 {
     public ContentTypeBaseMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<ContentTypeBaseMigrationHandler<TEntity>> logger) 
+        : base(eventAggregator, migrationFileService, logger)
     { }
 
     protected override void UpdatePropertyXml(XElement newProperty)

--- a/uSync.Migrations/Handlers/Eight/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
 using uSync.Migrations.Services;
@@ -13,6 +15,8 @@ internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<Con
 {
     public ContentTypeMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
-    {  }
+        ISyncMigrationFileService migrationFileService,
+        ILogger<ContentTypeMigrationHandler> logger) 
+        : base(eventAggregator, migrationFileService, logger)
+    { }
 }

--- a/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Newtonsoft.Json.Linq;
 
 using Umbraco.Cms.Core.Events;
@@ -22,7 +24,9 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
     public DataTypeMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IDataTypeService dataTypeService) : base(eventAggregator, migrationFileService, dataTypeService)
+        IDataTypeService dataTypeService,
+        ILogger<DataTypeMigrationHandler> logger) 
+        : base(eventAggregator, migrationFileService, dataTypeService, logger)
     { }
 
     protected override string GetEditorAlias(XElement source)

--- a/uSync.Migrations/Handlers/Eight/DictionaryMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/DictionaryMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
 using uSync.Migrations.Handlers.Shared;
@@ -14,7 +16,9 @@ internal class DictionaryMigrationHandler : SharedHandlerBase<DictionaryItem>, I
 {
     public DictionaryMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<DictionaryMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, logger)
     {
     }
 }

--- a/uSync.Migrations/Handlers/Eight/LanguageMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/LanguageMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
 using uSync.Migrations.Handlers.Shared;
@@ -14,8 +16,9 @@ internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigr
 {
     public LanguageMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService) 
-        : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<LanguageMigrationHandler> logger) 
+        : base(eventAggregator, migrationFileService, logger)
     { }
 }
 

--- a/uSync.Migrations/Handlers/Eight/MacroMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/MacroMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
 using uSync.Migrations.Handlers.Shared;
@@ -14,6 +16,8 @@ internal class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationH
 {
     public MacroMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<MacroMigrationHandler> logger) 
+        : base(eventAggregator, migrationFileService, logger)
     { }
 }

--- a/uSync.Migrations/Handlers/Eight/MediaMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/MediaMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Strings;
 
@@ -15,7 +17,8 @@ internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISync
     public MediaMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IShortStringHelper shortStringHelper) 
-        : base(eventAggregator, migrationFileService, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        ILogger<MediaMigrationHandler> logger) 
+        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
     { }
 }

--- a/uSync.Migrations/Handlers/Eight/MediaTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/MediaTypeMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
 using uSync.Migrations.Services;
@@ -13,7 +15,9 @@ internal class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<Media
 {
     public MediaTypeMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<MediaTypeMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, logger)
     {
     }
 }

--- a/uSync.Migrations/Handlers/Eight/TemplateMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/TemplateMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
 
 using uSync.Migrations.Handlers.Shared;
@@ -15,7 +17,8 @@ internal class TemplateMigrationHandler : SharedTemplateHandler, ISyncMigrationH
     public TemplateMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IFileService fileService) 
-        : base(eventAggregator, migrationFileService, fileService)
+        IFileService fileService,
+        ILogger<TemplateMigrationHandler> logger) 
+        : base(eventAggregator, migrationFileService, fileService, logger)
     { } 
 }

--- a/uSync.Migrations/Handlers/Seven/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentBaseMigrationHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Strings;
@@ -18,8 +20,9 @@ internal abstract class ContentBaseMigrationHandler<TEntity> : SharedContentBase
     public ContentBaseMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IShortStringHelper shortStringHelper)
-        : base(eventAggregator, migrationFileService, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        ILogger<ContentBaseMigrationHandler<TEntity>> logger)
+        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
     { }
 
     protected override int GetId(XElement source)

--- a/uSync.Migrations/Handlers/Seven/ContentMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Strings;
 
@@ -15,7 +17,8 @@ internal class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, I
     public ContentMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IShortStringHelper shortStringHelper)
-        : base(eventAggregator, migrationFileService, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        ILogger<ContentMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
     { }
 }

--- a/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
@@ -15,8 +17,9 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
 {
     public ContentTypeBaseMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService)
-        : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<ContentTypeBaseMigrationHandler<TEntity>> logger)
+        : base(eventAggregator, migrationFileService, logger)
     { }
 
     protected override (string alias, Guid key) GetAliasAndKey(XElement source)

--- a/uSync.Migrations/Handlers/Seven/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
 using uSync.Migrations.Handlers.Seven;
@@ -14,7 +16,8 @@ internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<Con
 {
     public ContentTypeMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService)
-        : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<ContentTypeMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, logger)
     { }
 }

--- a/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
@@ -30,8 +32,9 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
         IEventAggregator eventAggregator,
         ISyncMigrationFileService fileService,
         IDataTypeService dataTypeService,
-        SyncPropertyMigratorCollection migrators)
-        : base(eventAggregator, fileService, dataTypeService)
+        SyncPropertyMigratorCollection migrators,
+        ILogger<DataTypeMigrationHandler> logger)
+        : base(eventAggregator, fileService, dataTypeService, logger)
     {
         _migrators = migrators;
     }

--- a/uSync.Migrations/Handlers/Seven/DictionaryMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/DictionaryMigrationHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
@@ -21,8 +23,9 @@ internal class DictionaryMigrationHandler : SharedHandlerBase<DictionaryItem>, I
 {
     public DictionaryMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService)
-        : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<DictionaryMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, logger)
     { }
 
     /// <summary>

--- a/uSync.Migrations/Handlers/Seven/LanguageMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/LanguageMigrationHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System.Globalization;
 using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -23,8 +25,9 @@ internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigr
     public LanguageMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        ILocalizationService localizationService)
-        : base(eventAggregator, migrationFileService)
+        ILocalizationService localizationService,
+        ILogger<LanguageMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, logger)
     {
         _localizationService = localizationService;
     }

--- a/uSync.Migrations/Handlers/Seven/MacroMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/MacroMigrationHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
@@ -18,8 +20,9 @@ internal class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationH
 {
     public MacroMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService)
-        : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<MacroMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, logger)
     { }
 
     protected override (string alias, Guid key) GetAliasAndKey(XElement source)

--- a/uSync.Migrations/Handlers/Seven/MediaMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/MediaMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Strings;
 
@@ -15,8 +17,9 @@ internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISync
     public MediaMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IShortStringHelper shortStringHelper)
-        : base(eventAggregator, migrationFileService, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        ILogger<MediaMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
     {
         _ignoredProperties.UnionWith(new[]
         {

--- a/uSync.Migrations/Handlers/Seven/MediaTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/MediaTypeMigrationHandler.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Events;
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
 using uSync.Migrations.Services;
@@ -13,7 +15,8 @@ internal class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<Media
 {
     public MediaTypeMigrationHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService)
-        : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<MediaTypeMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, logger)
     { }
 }

--- a/uSync.Migrations/Handlers/Seven/TemplateMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/TemplateMigrationHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
 
@@ -19,8 +21,9 @@ internal class TemplateMigrationHandler : SharedTemplateHandler,  ISyncMigration
     public TemplateMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IFileService fileService)
-        : base(eventAggregator, migrationFileService, fileService)
+        IFileService fileService,
+        ILogger<TemplateMigrationHandler> logger)
+        : base(eventAggregator, migrationFileService, fileService, logger)
     { }
 
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)

--- a/uSync.Migrations/Handlers/Shared/SharedContentBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentBaseHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Strings;
@@ -22,7 +24,9 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
     public SharedContentBaseHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IShortStringHelper shortStringHelper) : base(eventAggregator, migrationFileService)
+        IShortStringHelper shortStringHelper,
+        ILogger<SharedContentBaseHandler<TEntity>> logger) 
+        : base(eventAggregator, migrationFileService, logger)
     {
         _shortStringHelper = shortStringHelper;
     }

--- a/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 
@@ -13,7 +15,9 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
 {
     protected SharedContentTypeBaseHandler(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService) : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<SharedContentTypeBaseHandler<TEntity>> logger) 
+        : base(eventAggregator, migrationFileService, logger)
     { }
 
     protected override void PrepareFile(XElement source, SyncMigrationContext context)

--- a/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Newtonsoft.Json;
 
 using Umbraco.Cms.Core.Events;
@@ -23,8 +25,9 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
     public SharedDataTypeHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IDataTypeService dataTypeService)
-        : base(eventAggregator, migrationFileService)
+        IDataTypeService dataTypeService,
+        ILogger<SharedDataTypeHandler> logger)
+        : base(eventAggregator, migrationFileService, logger)
     {
         _dataTypeService = dataTypeService;
         _jsonSerializerSettings = new JsonSerializerSettings()

--- a/uSync.Migrations/Handlers/Shared/SharedHandlerBase.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedHandlerBase.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models.Entities;
 
@@ -28,8 +30,9 @@ internal abstract class SharedHandlerBase<TObject> :MigrationHandlerBase<TObject
 {
     protected SharedHandlerBase(
         IEventAggregator eventAggregator,
-        ISyncMigrationFileService migrationFileService) 
-        : base(eventAggregator, migrationFileService)
+        ISyncMigrationFileService migrationFileService,
+        ILogger<SharedHandlerBase<TObject>> _logger) 
+        : base(eventAggregator, migrationFileService, _logger)
     { }
 
     /// <summary>

--- a/uSync.Migrations/Handlers/Shared/SharedTemplateHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedTemplateHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+using Microsoft.Extensions.Logging;
+
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -19,7 +21,9 @@ internal abstract class SharedTemplateHandler : SharedHandlerBase<Template>
     protected SharedTemplateHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        IFileService fileService) : base(eventAggregator, migrationFileService)
+        IFileService fileService,
+        ILogger<SharedTemplateHandler> logger) 
+        : base(eventAggregator, migrationFileService, logger)
     {
         _fileService = fileService;
     }


### PR DESCRIPTION
Adds logging to the handlers (so changes all the constructors!). 

At least allows us to log which file might fail on a migration #61 