### PR TITLE
Update the UI - So we group profiles by migrations and conversions

### DIFF
--- a/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Composing;
+﻿using System.Text.RegularExpressions;
+
+using Umbraco.Cms.Core.Composing;
 
 using uSync.Migrations.Composing;
 using uSync.Migrations.Configuration.Models;
@@ -17,14 +19,15 @@ internal class BlockMigrationProfile : ISyncMigrationProfile
 
     public int Order => 200;
 
-    public string Name => "To Blocks";
+	public string Name => "Nested Content To BlockLists";
 
     public string Icon => "icon-brick color-green";
 
-    public string Description => "Convert to block list (Experimental!)";
+    public string Description => "Convert Nested content to BlockList (Experimental!)";
 
     public MigrationOptions Options => new MigrationOptions
     {
+        Group = "Convert",
         Source = "uSync/v9",
         Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
         Handlers = _migrationHandlers.SelectGroup(8, string.Empty),
@@ -34,5 +37,4 @@ internal class BlockMigrationProfile : ISyncMigrationProfile
             { Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.NestedContent, nameof(NestedToBlockListMigrator) }
         }
     };
-
 }

--- a/uSync.Migrations/Configuration/ISyncMigrationConfigurationService.cs
+++ b/uSync.Migrations/Configuration/ISyncMigrationConfigurationService.cs
@@ -4,5 +4,6 @@ namespace uSync.Migrations.Configuration;
 
 public interface ISyncMigrationConfigurationService
 {
-    MigrationProfileInfo GetProfiles();
+	MigrationProfileInfo GetProfiles();
+	IEnumerable<ISyncMigrationProfile> GetProfiles(string groupAlias);
 }

--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -6,6 +6,7 @@ namespace uSync.Migrations.Configuration.Models;
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class MigrationOptions
 {
+    public string Group { get; set; } = "legacy";
     public string Source { get; set; } = "uSync/data";
     public string Target { get; set; } = "uSync/migrated";
 

--- a/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
+++ b/uSync.Migrations/Configuration/SyncMigrationConfigurationService.cs
@@ -66,7 +66,10 @@ internal class SyncMigrationConfigurationService : ISyncMigrationConfigurationSe
         return info;
     }
 
-    private MigrationProfileInfo GetCoreInfo() => new MigrationProfileInfo
+	public IEnumerable<ISyncMigrationProfile> GetProfiles(string groupAlias)
+        => GetProfiles().Profiles.Where(x => x.Options.Group.Equals(groupAlias, StringComparison.OrdinalIgnoreCase));
+
+	private MigrationProfileInfo GetCoreInfo() => new MigrationProfileInfo
     {
         Profiles = _syncMigrationProfiles.ToList()
     };

--- a/uSync.Migrations/Controllers/uSyncMigrationsController.cs
+++ b/uSync.Migrations/Controllers/uSyncMigrationsController.cs
@@ -48,8 +48,8 @@ public class uSyncMigrationsController : UmbracoAuthorizedApiController
         => _migrationService.MigrateFiles(options);
 
     [HttpGet]
-    public MigrationProfileInfo GetProfiles()
-        => _profileConfigService.GetProfiles();
+    public IEnumerable<ISyncMigrationProfile> GetProfiles(string groupAlias)
+        => _profileConfigService.GetProfiles(groupAlias);
 
     [HttpGet]
     public string ValidateSource(int version, string source)

--- a/uSync.Migrations/wwwroot/uSyncMigrations/Lang/en-us.xml
+++ b/uSync.Migrations/wwwroot/uSyncMigrations/Lang/en-us.xml
@@ -10,7 +10,7 @@
 		
 		<key alias="title">uSync Migrations</key>
 		<key alias="intro">
-			<![CDATA[<p>uSync.Migrations is a tool to help you migrate your site settings and content from Umbraco 7.x to the latest and greatest versions of Umbraco.</p>]]>
+			<![CDATA[<p>you can migrate your own way</p>]]>
 		</key>
 
 		<key alias="customize">

--- a/uSync.Migrations/wwwroot/uSyncMigrations/dashboard.controller.js
+++ b/uSync.Migrations/wwwroot/uSyncMigrations/dashboard.controller.js
@@ -6,6 +6,8 @@
         editorService, notificationsService) {
 
         var vm = this;
+        vm.view = "groups";
+
         vm.include = [];
 
         vm.working = false;
@@ -13,22 +15,51 @@
 
         vm.state = 'init';
 
+        vm.loadProfiles = loadProfiles;
         vm.start = start;
+
+        vm.groups = [
+            {
+                alias: 'legacy',
+                name: "Migrate Legacy",
+                description: "Migrate settings and content from your old (Umbraco 7) sites",
+                icon: "icon-shift color-purple"
+            },
+            {
+                alias: 'convert',
+                name: "Convert existing",
+                description: "Convert some of your existing data to newer properties",
+                icon: "icon-conversation color-blue"
+            }
+        ];
 
         // start 
         vm.$onInit = function () {
 
-            var p = [];
+        //    var p = [];
 
-            p.push(uSyncMigrationService.getProfiles()
+        //    p.push(uSyncMigrationService.getProfiles()
+        //        .then(function (result) {
+        //            vm.profiles = result.data.profiles;
+        //            vm.hasCustom = result.data.hasCustom;
+        //        }))
+
+        //    $q.all(p)
+        //        .then(function () {
+        //            vm.loading = false;
+        //        });
+
+            vm.loading = false;
+        }
+
+
+        function loadProfiles(group) {
+            vm.view = 'profiles';
+            vm.group = group;
+
+            uSyncMigrationService.getProfiles(group.alias)
                 .then(function (result) {
-                    vm.profiles = result.data.profiles;
-                    vm.hasCustom = result.data.hasCustom;
-                }))
-
-            $q.all(p)
-                .then(function () {
-                    vm.loading = false;
+                    vm.profiles = result.data;
                 });
         }
 

--- a/uSync.Migrations/wwwroot/uSyncMigrations/dashboard.html
+++ b/uSync.Migrations/wwwroot/uSyncMigrations/dashboard.html
@@ -7,7 +7,7 @@
         <div><localize key="usyncmigrate_beta"></localize></div>
     </div>
 
-    <umb-box>
+    <umb-box ng-if="vm.view == 'groups'">
         <umb-box-header title-key="usyncmigrate_title"></umb-box-header>
         <umb-box-content>
             <localize key="usyncmigrate_intro"></localize>
@@ -18,40 +18,71 @@
 
     <div ng-if="!vm.loading">
 
-        <div class="usync-group-actions">
-            <umb-box ng-repeat="profile in vm.profiles" class="usync-group-box">
+        <div class="usync-group-actions" ng-if="vm.view == 'groups'">
+            <umb-box ng-repeat="group in vm.groups" class="usync-group-box">
                 <umb-box-content>
                     <div class="usync-group-box-header">
                         <div class="usync-group-box-title">
-                            <i class="icon {{profile.icon}}"></i>
-                            <h2>{{profile.name}}</h2>
+                            <i class="icon {{group.icon}}"></i>
+                            <h2>{{group.name}}</h2>
                         </div>
-                        <small>Umbraco v{{profile.options.sourceVersion}} -> v8+</small>
                     </div>
-                    <div>{{profile.description}}</div>
-                    <div class="mt2 muted" style="min-height: 45px;">
-                        <ul class="inline">
-                            <li ng-repeat="handler in profile.options.handlers"
-                                ng-if="handler.include == true">
-                                <small>{{handler.name}}</small>
-                            </li>
-                        </ul>
-                    </div>
-
+                    <div>{{group.description}}</div>
                     <div class="usync-group-buttons">
                         <umb-button button-style="success btn-large"
-                                    action="vm.start(profile)"
-                                    label="Migrate"
-                                    disabled="vm.working == true"
-                                    state="vm.state">
+                                    action="vm.loadProfiles(group)"
+                                    label="View options">
                         </umb-button>
                     </div>
-
                 </umb-box-content>
             </umb-box>
         </div>
-        <div ng-if="!vm.hasCustom" class="color-blue-grey flex justify-center mt2 mb3">
-            <localize key="usyncmigrate_customize"></localize>
+
+        <div ng-if="vm.view == 'profiles'">
+            <umb-box>
+                <umb-box-header title="{{vm.group.name}}">
+                    <button type="button" ng-click="vm.view = 'groups'"
+                            class="btn btn-link">
+                        <i class="icon icon-arrow-left"></i> back
+                    </button>
+                </umb-box-header>
+                <umb-box-content>
+                    {{vm.group.description}}
+                </umb-box-content>
+            </umb-box>
+
+            <div class="usync-group-actions">
+                <umb-box ng-repeat="profile in vm.profiles" class="usync-group-box">
+                    <umb-box-content>
+                        <div class="usync-group-box-header">
+                            <div class="usync-group-box-title">
+                                <i class="icon {{profile.icon}}"></i>
+                                <h2>{{profile.name}}</h2>
+                            </div>
+                            <small>Umbraco v{{profile.options.sourceVersion}} -> v8+</small>
+                        </div>
+                        <div>{{profile.description}}</div>
+                        <div class="mt2 muted" style="min-height: 45px;">
+                            <ul class="inline">
+                                <li ng-repeat="handler in profile.options.handlers"
+                                    ng-if="handler.include == true">
+                                    <small>{{handler.name}}</small>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div class="usync-group-buttons">
+                            <umb-button button-style="success btn-large"
+                                        action="vm.start(profile)"
+                                        label="Migrate"
+                                        disabled="vm.working == true"
+                                        state="vm.state">
+                            </umb-button>
+                        </div>
+
+                    </umb-box-content>
+                </umb-box>
+            </div>
         </div>
     </div>
 </div>

--- a/uSync.Migrations/wwwroot/uSyncMigrations/migration.service.js
+++ b/uSync.Migrations/wwwroot/uSyncMigrations/migration.service.js
@@ -26,8 +26,8 @@
             return $http.post(serviceRoot + "Migrate", options);
         }
 
-        function getProfiles() {
-            return $http.get(serviceRoot + "GetProfiles");
+        function getProfiles(groupAlias) {
+            return $http.get(serviceRoot + "GetProfiles/?groupAlias=" + groupAlias);
         }
 
         function validateSource(version, source) {


### PR DESCRIPTION
Little change to the UI, so we are going to have migrations (Umbraco 7 -> 8/9/10/11) and Converters (inplace updates of things like block grid/blocklists...)

Converting block grid for example is going to be way easier (in both code and UI) if we do it on an existing site base - because we can access things like grid configs and automate most of it (i hope).

this change just makes that easier to present to the users. 


