### PR TITLE
Feature : v8 grid to block grid

### DIFF
--- a/MyMigrations/MyMigrations.csproj
+++ b/MyMigrations/MyMigrations.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.0.0" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/uSync.Migrations.Tests/appsettings-schema.json
+++ b/uSync.Migrations.Tests/appsettings-schema.json
@@ -1,0 +1,4120 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "webOptimizer": {
+      "title": "web optimizer",
+      "type": "object",
+      "description": "Settings for WebOptimizer.Core",
+      "properties": {
+        "enableCaching": {
+          "description": "Determines if the \"cache-control\" HTTP headers should be set and if conditional GET (304) requests should be supported. This could be helpful to disable while in development mode.",
+          "type": "boolean"
+        },
+        "enableTagHelperBundling": {
+          "description": "Determines if `<script>` and `<link>` elements should point to the bundled path or a reference per source file should be created. This is helpful to disable when in development mode.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "cdn": {
+      "title": "CDN",
+      "type": "object",
+      "description": "Definitions for WebEssentials.AspNetCore.CdnTagHelpers",
+      "properties": {
+        "url": {
+          "description": "An absolute URL used as a prefix for static resources",
+          "type": "string",
+          "pattern": "^((//|https?://).+|)$"
+        },
+        "prefetch": {
+          "description": "If true, injects a <link rel='dns-prefetch'> tag that speeds up DNS resolution to the CDN.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "pwa": {
+      "properties": {
+        "cacheId": {
+          "description": "The cache identifier of the service worker (can be any string). Change this property to force the service worker to reload in browsers.",
+          "type": "string",
+          "default": "v1.0"
+        },
+        "offlineRoute": {
+          "description": "The route to the page to show when offline.",
+          "type": "string",
+          "default": "/offline.html"
+        },
+        "registerServiceWorker": {
+          "description": "Determines if a script that registers the service worker should be injected into the bottom of the HTML page.",
+          "type": "boolean",
+          "default": true
+        },
+        "registerWebmanifest": {
+          "description": "Determines if a meta tag that points to the web manifest should be inserted at the end of the head element.",
+          "type": "boolean",
+          "default": true
+        },
+        "routesToPreCache": {
+          "description": "A comma separated list of routes to pre-cache when service worker installs in the browser.",
+          "type": "string",
+          "default": ""
+        },
+        "strategy": {
+          "description": "Selects one of the predefined service worker types.",
+          "enum": [
+            "cacheFirst",
+            "cacheFirstSafe",
+            "minimal",
+            "networkFirst"
+          ],
+          "default": "cacheFirstSafe"
+        }
+      }
+    },
+    "ElmahIo": {
+      "properties": {
+        "ApiKey": {
+          "description": "An elmah.io API key with the Messages | Write permission.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{32}$"
+        },
+        "LogId": {
+          "description": "The Id of the elmah.io log to store messages in.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        },
+        "Application": {
+          "description": "An application name to put on all error messages.",
+          "type": "string"
+        },
+        "HandledStatusCodesToLog": {
+          "description": "A list of HTTP status codes (besides 404) to log even though no exception is thrown.",
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "TreatLoggingAsBreadcrumbs": {
+          "description": "Include log messages from Microsoft.Extensions.Logging as breadcrumbs.",
+          "type": "boolean"
+        },
+        "HeartbeatId": {
+          "description": "The Id of the elmah.io heartbeat to notify.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{32}$"
+        }
+      },
+      "required": [
+        "ApiKey",
+        "LogId"
+      ]
+    },
+    "protocols": {
+      "description": "The protocols enabled on the endpoint.",
+      "type": "string",
+      "enum": [
+        "None",
+        "Http1",
+        "Http2",
+        "Http1AndHttp2",
+        "Http3",
+        "Http1AndHttp2AndHttp3"
+      ]
+    },
+    "certificate": {
+      "title": "certificate",
+      "description": "Certificate configuration.",
+      "type": "object",
+      "properties": {
+        "Path": {
+          "description": "The certificate file path. If a file path is specified then the certificate will be loaded from the file system.",
+          "type": "string"
+        },
+        "KeyPath": {
+          "description": "The certificate key file path. Available in .NET 5 and later.",
+          "type": "string"
+        },
+        "Password": {
+          "description": "The certificate password used to access the private key.",
+          "type": "string"
+        },
+        "Subject": {
+          "description": "The certificate subject. If a subject is specified then the certificate will be loaded from the certificate store.",
+          "type": "string"
+        },
+        "Store": {
+          "description": "The certificate store name. Defaults to 'My'.",
+          "type": "string",
+          "default": "My"
+        },
+        "Location": {
+          "description": "The certificate store location. Defaults to 'CurrentUser'.",
+          "type": "string",
+          "enum": [
+            "LocalMachine",
+            "CurrentUser"
+          ],
+          "default": "CurrentUser"
+        },
+        "AllowInvalid": {
+          "description": "A value indicating whether or not to load certificates that are considered invalid. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "sslProtocols": {
+      "description": "Specifies allowable SSL protocols. Defaults to 'None' which allows the operating system to choose the best protocol to use, and to block protocols that are not secure. Unless your app has a specific reason not to, you should use this default. Available in .NET 5 and later.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "None",
+          "Tls",
+          "Tls11",
+          "Tls12",
+          "Tls13"
+        ],
+        "default": "None"
+      }
+    },
+    "clientCertificateMode": {
+      "description": "Specifies the client certificate requirements for a HTTPS connection. Defaults to 'NoCertificate'. Available in .NET 5 and later.",
+      "type": "string",
+      "enum": [
+        "NoCertificate",
+        "AllowCertificate",
+        "RequireCertificate"
+      ],
+      "default": "NoCertificate"
+    },
+    "kestrel": {
+      "title": "kestrel",
+      "type": "object",
+      "description": "ASP.NET Core Kestrel server configuration.",
+      "properties": {
+        "Endpoints": {
+          "title": "endpoints",
+          "description": "Endpoints that Kestrel listens to for network requests. Each endpoint has a name specified by its JSON property name.",
+          "type": "object",
+          "additionalProperties": {
+            "title": "endpoint options",
+            "description": "Kestrel endpoint configuration.",
+            "type": "object",
+            "properties": {
+              "Url": {
+                "description": "The scheme, host name, and port the endpoint will listen on. A Url is required.",
+                "type": "string",
+                "format": "uri"
+              },
+              "Protocols": {
+                "$ref": "#/definitions/protocols"
+              },
+              "SslProtocols": {
+                "$ref": "#/definitions/sslProtocols"
+              },
+              "Certificate": {
+                "$ref": "#/definitions/certificate"
+              },
+              "ClientCertificateMode": {
+                "$ref": "#/definitions/clientCertificateMode"
+              },
+              "Sni": {
+                "title": "SNI",
+                "description": "Server Name Indication (SNI) configuration. This enables the mapping of client requested host names to certificates and other TLS settings. Wildcard names prefixed with '*.', as well as a top level '*' are supported. Available in .NET 5 and later.",
+                "type": "object",
+                "additionalProperties": {
+                  "title": "SNI options",
+                  "description": "Endpoint SNI configuration.",
+                  "type": "object",
+                  "properties": {
+                    "Protocols": {
+                      "$ref": "#/definitions/protocols"
+                    },
+                    "SslProtocols": {
+                      "$ref": "#/definitions/sslProtocols"
+                    },
+                    "Certificate": {
+                      "$ref": "#/definitions/certificate"
+                    },
+                    "ClientCertificateMode": {
+                      "$ref": "#/definitions/clientCertificateMode"
+                    }
+                  }
+                }
+              }
+            },
+            "required": [
+              "Url"
+            ]
+          }
+        },
+        "EndpointDefaults": {
+          "title": "endpoint defaults",
+          "description": "Default configuration applied to all endpoints. Named endpoint specific configuration overrides defaults.",
+          "type": "object",
+          "properties": {
+            "Protocols": {
+              "$ref": "#/definitions/protocols"
+            },
+            "SslProtocols": {
+              "$ref": "#/definitions/sslProtocols"
+            },
+            "ClientCertificateMode": {
+              "$ref": "#/definitions/clientCertificateMode"
+            }
+          }
+        },
+        "Certificates": {
+          "title": "certificates",
+          "description": "Certificates that Kestrel uses with HTTPS endpoints. Each certificate has a name specified by its JSON property name. The 'Default' certificate is used by HTTPS endpoints that haven't specified a certificate.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/certificate"
+          }
+        }
+      }
+    },
+    "logLevelThreshold": {
+      "description": "Log level threshold.",
+      "type": "string",
+      "enum": [
+        "Trace",
+        "Debug",
+        "Information",
+        "Warning",
+        "Error",
+        "Critical",
+        "None"
+      ]
+    },
+    "logLevel": {
+      "title": "logging level options",
+      "description": "Log level configurations used when creating logs. Only logs that exceeds its matching log level will be enabled. Each log level configuration has a category specified by its JSON property name. For more information about configuring log levels, see https://docs.microsoft.com/aspnet/core/fundamentals/logging/#configure-logging.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/logLevelThreshold"
+      }
+    },
+    "logging": {
+      "title": "logging options",
+      "type": "object",
+      "description": "Configuration for Microsoft.Extensions.Logging.",
+      "properties": {
+        "LogLevel": {
+          "$ref": "#/definitions/logLevel"
+        },
+        "Console": {
+          "properties": {
+            "LogLevel": {
+              "$ref": "#/definitions/logLevel"
+            },
+            "FormatterName": {
+              "description": "Name of the log message formatter to use. Defaults to 'simple'.",
+              "type": "string",
+              "default": "simple"
+            },
+            "FormatterOptions": {
+              "title": "formatter options",
+              "description": "Log message formatter options. Additional properties are available on the options depending on the configured formatter. The formatter is specified by FormatterName.",
+              "type": "object",
+              "properties": {
+                "IncludeScopes": {
+                  "description": "Include scopes when true. Defaults to false.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "TimestampFormat": {
+                  "description": "Format string used to format timestamp in logging messages. Defaults to null.",
+                  "type": "string"
+                },
+                "UseUtcTimestamp": {
+                  "description": "Indication whether or not UTC timezone should be used to for timestamps in logging messages. Defaults to false.",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "LogToStandardErrorThreshold": {
+              "description": "The minimum level of messages are written to Console.Error.",
+              "$ref": "#/definitions/logLevelThreshold"
+            }
+          }
+        },
+        "EventSource": {
+          "properties": {
+            "LogLevel": {
+              "$ref": "#/definitions/logLevel"
+            }
+          }
+        },
+        "Debug": {
+          "properties": {
+            "LogLevel": {
+              "$ref": "#/definitions/logLevel"
+            }
+          }
+        },
+        "EventLog": {
+          "properties": {
+            "LogLevel": {
+              "$ref": "#/definitions/logLevel"
+            }
+          }
+        },
+        "ElmahIo": {
+          "properties": {
+            "LogLevel": {
+              "$ref": "#/definitions/logLevel"
+            }
+          }
+        },
+        "ElmahIoBreadcrumbs": {
+          "properties": {
+            "LogLevel": {
+              "$ref": "#/definitions/logLevel"
+            }
+          }
+        }
+      },
+      "additionalProperties": {
+        "title": "provider logging settings",
+        "type": "object",
+        "description": "Logging configuration for a provider. The provider name must match the configuration's JSON property property name.",
+        "properties": {
+          "LogLevel": {
+            "$ref": "#/definitions/logLevel"
+          }
+        }
+      }
+    },
+    "allowedHosts": {
+      "description": "ASP.NET Core host filtering middleware configuration. Allowed hosts is a semicolon-delimited list of host names without port numbers. Requests without a matching host name will be refused. Host names may be prefixed with a '*.' wildcard, or use '*' to allow all hosts.",
+      "type": "string"
+    },
+    "connectionStrings": {
+      "title": "connection string options",
+      "description": "Connection string configuration. Get connection strings with the IConfiguration.GetConnectionString(string) extension method.",
+      "type": "object",
+      "additionalProperties": {
+        "description": "Connection string configuration. Each connection string has a name specified by its JSON property name.",
+        "type": "string"
+      }
+    },
+    "NLog": {
+      "title": "NLog options",
+      "type": "object",
+      "description": "NLog configuration",
+      "default": {},
+      "properties": {
+        "autoReload": {
+          "type": "boolean",
+          "description": "Automatically reload the NLog configuration when notified that appsettings.json file has changed.",
+          "default": false
+        },
+        "throwConfigExceptions": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Throws an exception when there is a config error? If not set, then throwExceptions will be used for this setting.",
+          "default": false
+        },
+        "throwExceptions": {
+          "type": "boolean",
+          "description": "Throws an exception when there is an error. For unit testing only and advanced troubleshooting.",
+          "default": false
+        },
+        "internalLogLevel": {
+          "type": "string",
+          "description": "The minimal log level for the internal logger.",
+          "enum": [
+            "Trace",
+            "Debug",
+            "Info",
+            "Warn",
+            "Error",
+            "Fatal",
+            "Off"
+          ],
+          "default": "Off"
+        },
+        "internalLogFile": {
+          "type": "string",
+          "description": "Write internal log to the specified filepath"
+        },
+        "internalLogToConsole": {
+          "type": "boolean",
+          "description": "Write internal log to a console",
+          "default": "false"
+        },
+        "internalLogToConsoleError": {
+          "type": "boolean",
+          "description": "Write internal log to a console with error stream",
+          "default": "false"
+        },
+        "globalThreshold": {
+          "type": "string",
+          "description": "Log events below this threshold are not logged.",
+          "enum": [
+            "Trace",
+            "Debug",
+            "Info",
+            "Warn",
+            "Error",
+            "Fatal",
+            "Off"
+          ],
+          "default": "Off"
+        },
+        "autoShutdown": {
+          "type": "boolean",
+          "description": "Automatically call `LogFactory.Shutdown` on AppDomain.Unload or AppDomain.ProcessExit",
+          "default": "true"
+        },
+        "extensions": {
+          "type": "array",
+          "description": "Load NLog extension packages for additional targets and layouts",
+          "default": [],
+          "items": {
+            "title": "extension",
+            "type": "object",
+            "description": "",
+            "default": {},
+            "properties": {
+              "assembly": {
+                "type": "string",
+                "description": "Assembly Name of the NLog extension package."
+              },
+              "prefix": {
+                "type": "string",
+                "description": "Appends prefix to all type-names loaded from the assembly",
+                "default": ""
+              },
+              "assemblyFile": {
+                "type": "string",
+                "description": "Absolute filepath to the Assembly-file of the NLog extension package.",
+                "default": ""
+              }
+            }
+          }
+        },
+        "variables": {
+          "title": "variables",
+          "type": "object",
+          "description": "Key-value pair of variables",
+          "propertyNames": {
+            "pattern": "^[A-Za-z0-9_.-]+$"
+          },
+          "patternProperties": {
+            ".*": {
+              "type": [
+                "number",
+                "string",
+                "boolean"
+              ]
+            }
+          }
+        },
+        "targetDefaultWrapper": {
+          "title": "default wrapper",
+          "type": "object",
+          "description": "Wrap all defined targets with this custom target wrapper.",
+          "default": {},
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": ""
+            }
+          }
+        },
+        "targets": {
+          "title": "targets",
+          "type": "object",
+          "description": "",
+          "default": {},
+          "properties": {
+            "async": {
+              "type": "boolean",
+              "description": "Wrap all defined targets using AsyncWrapper with OverflowAction=Discard for better performance."
+            }
+          }
+        },
+        "rules": {
+          "oneOf": [
+            {
+              "type": "array",
+              "description": "",
+              "default": [],
+              "items": {
+                "$ref": "#/definitions/NLogRulesItem"
+              }
+            },
+            {
+              "title": "rules",
+              "type": "object",
+              "propertyNames": {
+                "pattern": "^[0-9]+$"
+              },
+              "patternProperties": {
+                ".*": {
+                  "$ref": "#/definitions/NLogRulesItem"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "NLogRulesItem": {
+      "title": "NLog rule item",
+      "type": "object",
+      "description": "Redirect LogEvents from matching Logger objects to specified targets",
+      "default": {},
+      "required": [
+        "logger"
+      ],
+      "properties": {
+        "logger": {
+          "type": "string",
+          "description": "Match Logger objects based on their Logger-name. Can use wildcard characters ('*' or '?')."
+        },
+        "ruleName": {
+          "type": "string",
+          "description": "Rule identifier to allow rule lookup with Configuration.FindRuleByName and Configuration.RemoveRuleByName."
+        },
+        "level": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "",
+              "enum": [
+                "Trace",
+                "Debug",
+                "Info",
+                "Warn",
+                "Error",
+                "Fatal"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "levels": {
+          "type": "string",
+          "description": "Comma separated list of levels that this rule matches."
+        },
+        "minLevel": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "",
+              "enum": [
+                "Trace",
+                "Debug",
+                "Info",
+                "Warn",
+                "Error",
+                "Fatal"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "maxLevel": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "",
+              "enum": [
+                "Trace",
+                "Debug",
+                "Info",
+                "Warn",
+                "Error",
+                "Fatal"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "finalMinLevel": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "",
+              "enum": [
+                "Trace",
+                "Debug",
+                "Info",
+                "Warn",
+                "Error",
+                "Fatal"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "writeTo": {
+          "type": "string",
+          "description": "Name or names of a target - separated by comma. Remove this property for sending events to the blackhole."
+        },
+        "final": {
+          "type": "boolean",
+          "description": "Ignore further rules if this one matches.",
+          "default": false
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "",
+          "default": true
+        },
+        "filters": {
+          "oneOf": [
+            {
+              "type": "array",
+              "description": "",
+              "default": [],
+              "items": {
+                "title": "filter",
+                "type": "object",
+                "description": "",
+                "default": {},
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": ""
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "Result action when filter matches logevent.",
+                    "enum": [
+                      "Neutral",
+                      "Log",
+                      "Ignore",
+                      "LogFinal",
+                      "IgnoreFinal"
+                    ],
+                    "default": "Neutral"
+                  }
+                }
+              }
+            },
+            {
+              "title": "filter",
+              "type": "object",
+              "description": "",
+              "default": {}
+            }
+          ]
+        },
+        "filterDefaultAction": {
+          "type": "string",
+          "description": "Default action if none of the filters match.",
+          "enum": [
+            "Neutral",
+            "Log",
+            "Ignore",
+            "LogFinal",
+            "IgnoreFinal"
+          ],
+          "default": "Ignore"
+        }
+      }
+    },
+    "umbraco": {
+      "description": "Configuration of Open Source .NET CMS - Umbraco",
+      "properties": {
+        "CMS": {
+          "title": "CMD options",
+          "type": "object",
+          "properties": {
+            "ActiveDirectory": {
+              "$ref": "#/definitions/umbracoActiveDirectory"
+            },
+            "Content": {
+              "$ref": "#/definitions/umbracoContent"
+            },
+            "Debug": {
+              "$ref": "#/definitions/umbracoDebug"
+            },
+            "Examine": {
+              "properties": {
+                "LuceneDirectoryFactory": {
+                  "description": "Lucene directory factory type",
+                  "type": "string"
+                }
+              }
+            },
+            "ExceptionFilter": {
+              "properties": {
+                "Disabled": {
+                  "description": "Indicating whether the exception filter is disabled",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "Global": {
+              "$ref": "#/definitions/umbracoGlobal"
+            },
+            "HealthChecks": {
+              "$ref": "#/definitions/umbracoHealthChecks"
+            },
+            "Hosting": {
+              "$ref": "#/definitions/umbracoHosting"
+            },
+            "Imaging": {
+              "$ref": "#/definitions/umbracoImaging"
+            },
+            "KeepAlive": {
+              "$ref": "#/definitions/umbracoKeepAlive"
+            },
+            "Logging": {
+              "properties": {
+                "MaxLogAge": {
+                  "description": "Maximum age of a log file - https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings",
+                  "type": "string",
+                  "default": "1.00:00:00"
+                }
+              }
+            },
+            "ModelsBuilder": {
+              "$ref": "#/definitions/umbracoModelsBuilder"
+            },
+            "NuCache": {
+              "properties": {
+                "BTreeBlockSize": {
+                  "type": "integer"
+                }
+              }
+            },
+            "Plugins": {
+              "properties": {
+                "BrowsableFileExtensions": {
+                  "description": "Allowed file extensions (including the period .) that should be accessible from the browser",
+                  "type": [
+                    "string"
+                  ]
+                }
+              }
+            },
+            "RequestHandler": {
+              "$ref": "#/definitions/umbracoRequestHandler"
+            },
+            "RichTextEditor": {
+              "$ref": "#/definitions/umbracoRichTextEditor"
+            },
+            "Runtime": {
+              "properties": {
+                "MaxQueryStringLength": {
+                  "description": "Value for the maximum query string length",
+                  "type": "integer"
+                },
+                "MaxRequestLength": {
+                  "description": "Value for the maximum request length",
+                  "type": "integer"
+                }
+              }
+            },
+            "RuntimeMinification": {
+              "$ref": "#/definitions/umbracoRuntimeMinification"
+            },
+            "Security": {
+              "$ref": "#/definitions/umbracoSecurity"
+            },
+            "Tours": {
+              "properties": {
+                "EnableTours": {
+                  "description": "Indicating whether back-office tours are enabled",
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            },
+            "TypeFinder": {
+              "properties": {
+                "AssembliesAcceptingLoadExceptions": {
+                  "description": "A CSV string of assemblies that accept load exceptions during type finder operations",
+                  "type": "string"
+                }
+              }
+            },
+            "WebRouting": {
+              "$ref": "#/definitions/umbracoWebRouting"
+            },
+            "Unattended": {
+              "$ref": "#/definitions/umbracoUnattended"
+            }
+          }
+        }
+      },
+      "required": [
+        "CMS"
+      ]
+    },
+    "umbracoActiveDirectory": {
+      "description": "Configuration of Active Directory for Umbraco CMS",
+      "properties": {
+        "Domain": {
+          "type": "string",
+          "description": "Active Directory Domain"
+        }
+      }
+    },
+    "umbracoContent": {
+      "properties": {
+        "AllowedUploadFiles": {
+          "description": "Collection of file extensions without . that are allowed for upload",
+          "type": [
+            "string"
+          ]
+        },
+        "DisallowedUploadFiles": {
+          "description": "Collection of file extensions without . that are disallowed for upload",
+          "type": [
+            "string"
+          ]
+        },
+        "Error404Collection": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/umbracoContentErrorPage"
+          }
+        },
+        "Imaging": {
+          "properties": {
+            "AutoFillImageProperties": {
+              "description": "Imaging autofill following media file upload fields",
+              "properties": {
+                "Alias": {
+                  "default": "umbracoFile"
+                },
+                "ExtensionFieldAlias": {
+                  "default": "umbracoExtension"
+                },
+                "HeightFieldAlias": {
+                  "default": "umbracoHeight"
+                },
+                "LengthFieldAlias": {
+                  "default": "umbracoBytes"
+                },
+                "WidthFieldAlias": {
+                  "default": "umbracoWidth"
+                }
+              }
+            },
+            "ImageFileTypes": {
+              "description": "Collection of accepted image file extensions",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "LoginBackgroundImage": {
+          "description": "Path to the login screen background image",
+          "default": "assets/img/login.jpg",
+          "type": "string"
+        },
+        "LoginLogoImage": {
+          "description": "Path to the login screen logo image",
+          "default": "assets/img/application/umbraco_logo_white.svg",
+          "type": "string"
+        },
+        "MacroErrors": {
+          "description": "Macro error behaviour",
+          "enum": [
+            "Inline",
+            "Silent",
+            "Throw",
+            "Content"
+          ]
+        },
+        "Notifications": {
+          "properties": {
+            "Email": {
+              "description": "Email address used for notifications",
+              "type": "string"
+            },
+            "DisableHtmlEmail": {
+              "description": "Whether HTML email notifications should be disabled",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "PreviewBadge": {
+          "description": "Preview badge mark-up",
+          "type": "string"
+        },
+        "ResolveUrlsFromTextString": {
+          "description": "URLs should be resolved from text strings",
+          "type": "boolean",
+          "default": false
+        },
+        "ShowDeprecatedPropertyEditors": {
+          "description": "Deprecated property editors should be shown",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "umbracoContentErrorPage": {
+      "properties": {
+        "ContentId": {
+          "description": "An int of the content",
+          "type": "integer"
+        },
+        "ContentKey": {
+          "description": "A guid of the content",
+          "type": "string"
+        },
+        "ContentXPath": {
+          "description": "An XPath query for the content",
+          "type": "string"
+        },
+        "Culture": {
+          "description": "Content culture",
+          "type": "string"
+        }
+      }
+    },
+    "umbracoDebug": {
+      "properties": {
+        "LogIncompletedScopes": {
+          "description": "Indicating whether incompleted scopes should be logged",
+          "type": "boolean",
+          "default": false
+        },
+        "DumpOnTimeoutThreadAbort": {
+          "description": "Indicating whether memory dumps on thread abort should be taken",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "umbracoGlobal": {
+      "properties": {
+        "ReservedUrls": {
+          "description": "CSV string of reserved URLs (must end with a comma)",
+          "type": "string",
+          "default": "~/config/splashes/noNodes.aspx,~/.well-known,"
+        },
+        "ReservedPaths": {
+          "description": "CSV string of reserved paths (must end with a comma)",
+          "type": "string",
+          "default": "~/app_plugins/,~/install/,~/mini-profiler-resources/,~/umbraco/,"
+        },
+        "TimeOut": {
+          "description": "Duration of timeout https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings",
+          "type": "string",
+          "default": "00:20:00"
+        },
+        "DefaultUILanguage": {
+          "description": "Default UI language of Umbraco backoffice",
+          "type": "string",
+          "default": "en-US"
+        },
+        "HideTopLevelNodeFromPath": {
+          "description": "Indicating whether to hide the top level node from the path",
+          "type": "boolean",
+          "default": false
+        },
+        "UseHttps": {
+          "description": "Indicating whether HTTPS should be used",
+          "type": "boolean",
+          "default": false
+        },
+        "VersionCheckPeriod": {
+          "description": "Check for new version. Period in days",
+          "type": "integer",
+          "default": 7
+        },
+        "IconsPath": {
+          "description": "Path to Umbraco Icons for backoffice",
+          "type": "string",
+          "default": "~/umbraco/assets/icons"
+        },
+        "UmbracoCssPath": {
+          "description": "Path to store CSS files used for website built with Umbraco",
+          "type": "string",
+          "default": "~/css"
+        },
+        "UmbracoMediaPath": {
+          "description": "Path to store media files",
+          "type": "string",
+          "default": "~/media"
+        },
+        "InstallMissingDatabase": {
+          "description": "Indicating whether to install the database when it is missing",
+          "type": "boolean",
+          "default": false
+        },
+        "DisableElectionForSingleServer": {
+          "description": "Indicating whether to disable the election for a single server",
+          "type": "boolean",
+          "default": false
+        },
+        "NoNodesViewPath": {
+          "description": "Path to view when the website built with Umbraco has no content nodes",
+          "type": "string",
+          "default": "~/umbraco/UmbracoWebsite/NoNodes.cshtml"
+        },
+        "DatabaseServerRegistrar": {
+          "properties": {
+            "WaitTimeBetweenCalls": {
+              "description": "The amount of time to wait between calls to the database on the background thread https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings",
+              "type": "string",
+              "default": "00:01:00"
+            },
+            "StaleServerTimeout": {
+              "description": "The time span to wait before considering a server stale, after it has last been accessed https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings",
+              "type": "string",
+              "default": "00:02:00"
+            }
+          }
+        },
+        "DatabaseServerMessenger": {
+          "properties": {
+            "MaxProcessingInstructionCount": {
+              "description": "The maximum number of instructions that can be processed at startup; otherwise the server cold-boots (rebuilds its caches)",
+              "type": "integer",
+              "default": 1000
+            },
+            "TimeToRetainInstructions": {
+              "description": "The time to keep instructions in the database. Records older than this number will be pruned https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings",
+              "type": "string",
+              "default": "2.00:00:00"
+            },
+            "TimeBetweenSyncOperations": {
+              "description": "The time to wait between each sync operations https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings",
+              "type": "string",
+              "default": "00:00:05"
+            },
+            "TimeBetweenPruneOperations": {
+              "description": "The time to wait between each prune operations https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings",
+              "type": "string",
+              "default": "00:01:00"
+            }
+          }
+        },
+        "Smtp": {
+          "properties": {
+            "From": {
+              "description": "Email address to use for messages",
+              "type": "string"
+            },
+            "Host": {
+              "description": "SMTP Server hostname",
+              "type": "string"
+            },
+            "Port": {
+              "description": "SMTP Server Port Number",
+              "type": "integer"
+            },
+            "SecureSocketOptions": {
+              "description": "Secure socket options for SMTP server",
+              "enum": [
+                "None",
+                "Auto",
+                "SslOnConnect",
+                "StartTls",
+                "StartTlsWhenAvailable"
+              ],
+              "default": "Auto"
+            },
+            "PickupDirectoryLocation": {
+              "description": "SMTP pick-up directory path",
+              "type": "string"
+            },
+            "DeliveryMethod": {
+              "description": "SMTP delivery method",
+              "enum": [
+                "Network",
+                "SpecifiedPickupDirectory",
+                "PickupDirectoryFromIis"
+              ],
+              "default": "Network"
+            },
+            "Username": {
+              "description": "SMTP server username",
+              "type": "string"
+            },
+            "Password": {
+              "description": "SMTP server password",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "umbracoHealthChecks": {
+      "properties": {
+        "DisabledChecks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/umbracoDisabledHealthChecks"
+          }
+        },
+        "Notification": {
+          "properties": {
+            "Enabled": {
+              "description": "Indicating whether health check notifications are enabled",
+              "type": "boolean",
+              "default": false
+            },
+            "FirstRunTime": {
+              "description": "The first run time of a healthcheck notification in crontab format",
+              "type": "string"
+            },
+            "Period": {
+              "description": "The period of the healthcheck notifications are run https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings",
+              "type": "string",
+              "default": "1.00:00:00"
+            },
+            "NotificationMethods": {
+              "title": "notification methods",
+              "description": "A collection of health check notification methods that are set by their alias such as 'email'",
+              "type": "object",
+              "additionalProperties": {
+                "title": "notification method options",
+                "type": "object",
+                "properties": {
+                  "Enabled": {
+                    "description": "Indicating whether the health check notification method is enabled",
+                    "type": "boolean"
+                  },
+                  "Verbosity": {
+                    "description": "The health check notifications reporting verbosity",
+                    "enum": [
+                      "Summary",
+                      "Detailed"
+                    ],
+                    "default": "Summary"
+                  },
+                  "FailureOnly": {
+                    "description": "Indicating whether the health check notifications should occur on failures only",
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "Settings": {
+                    "title": "options",
+                    "description": "An object of Health Check Notification provider specific settings. For the email notification it uses a setting 'RecipientEmail'",
+                    "type": "object"
+                  }
+                }
+              }
+            },
+            "DisabledChecks": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/umbracoDisabledHealthChecks"
+              }
+            }
+          }
+        }
+      }
+    },
+    "umbracoDisabledHealthChecks": {
+      "properties": {
+        "Id": {
+          "description": "Guid of healthcheck to disable",
+          "type": "string"
+        }
+      }
+    },
+    "umbracoHosting": {
+      "properties": {
+        "ApplicationVirtualPath": {
+          "type": "string"
+        },
+        "Debug": {
+          "description": "Indicating whether umbraco is running in [debug mode]",
+          "type": "boolean",
+          "default": false
+        },
+        "LocalTempStorageLocation": {
+          "description": "The location of temporary files",
+          "default": "Default",
+          "enum": [
+            "Default",
+            "EnvironmentTemp"
+          ]
+        }
+      }
+    },
+    "umbracoImaging": {
+      "properties": {
+        "Cache": {
+          "properties": {
+            "BrowserMaxAge": {
+              "description": "Browser image cache maximum age https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings",
+              "type": "string",
+              "default": "7.00:00:00"
+            },
+            "CacheMaxAge": {
+              "description": "Image cache maximum age https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings",
+              "type": "string",
+              "default": "365.00:00:00"
+            },
+            "CachedNameLength": {
+              "description": "Length of the cached name",
+              "type": "integer",
+              "default": 8
+            },
+            "CacheFolder": {
+              "description": "Location of media cache folder",
+              "type": "string",
+              "default": "..\\umbraco\\mediacache"
+            }
+          }
+        },
+        "Resize": {
+          "properties": {
+            "MaxWidth": {
+              "description": "Value for the maximum resize width",
+              "type": "integer",
+              "default": 5000
+            },
+            "MaxHeight": {
+              "description": "Value for the maximum resize height",
+              "type": "integer",
+              "default": 5000
+            }
+          }
+        }
+      }
+    },
+    "umbracoKeepAlive": {
+      "properties": {
+        "DisableKeepAliveTask": {
+          "description": "Indicating whether the keep alive task is disabled",
+          "type": "boolean",
+          "default": false
+        },
+        "KeepAlivePingUrl": {
+          "description": "Keep alive ping URL. {umbracoApplicationUrl} is replaced",
+          "type": "string",
+          "default": "{umbracoApplicationUrl}/api/keepalive/ping"
+        }
+      }
+    },
+    "umbracoRichTextEditor": {
+      "properties": {
+        "Commands": {
+          "description": "Commands to add to the TinyMCE Richtext editor",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/umbracoRichTextEditorCommands"
+          }
+        },
+        "Plugins": {
+          "description": "An array of TinyMCE Plugins to load such as 'paste', 'table'",
+          "type": [
+            "string"
+          ]
+        },
+        "CustomConfig": {
+          "title": "TinyMCE options",
+          "description": "Custom configuration for TinyMCE and its plugins",
+          "type": "object"
+        },
+        "ValidElements": {
+          "description": "A CSV string of valid HTML elements in the richtext editor. Ex: iframe[*],button[class|title]",
+          "type": "string"
+        },
+        "InvalidElements": {
+          "description": "A CSV string of invalid HTML elements in the richtext editor. Ex: font",
+          "type": "string"
+        }
+      }
+    },
+    "umbracoRichTextEditorCommands": {
+      "properties": {
+        "Name": {
+          "description": "Friendly name of Richtext Editor Command",
+          "type": "string"
+        },
+        "Alias": {
+          "description": "Alias of the Richtext Editor Command",
+          "type": "string"
+        },
+        "Mode": {
+          "description": "Set how the Richtext Editor Command can be used. Such as when a selection is made",
+          "enum": [
+            "Insert",
+            "Selection",
+            "All"
+          ]
+        }
+      }
+    },
+    "umbracoRequestHandler": {
+      "properties": {
+        "AddTrailingSlash": {
+          "description": "Indicating whether to add a trailing slash to URLs",
+          "type": "boolean",
+          "default": true
+        },
+        "CharCollection": {
+          "description": "Character collection for replacements",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/umbracoCharCollection"
+          }
+        },
+        "ConvertUrlsToAscii": {
+          "description": "Indicating whether to convert URLs to ASCII (valid values: true, try or false)",
+          "enum": [
+            "try",
+            "true",
+            "false"
+          ],
+          "default": "try"
+        }
+      }
+    },
+    "umbracoCharCollection": {
+      "required": [
+        "Char",
+        "Replacement"
+      ],
+      "properties": {
+        "Char": {
+          "type": "string",
+          "default": "ä"
+        },
+        "Replacement": {
+          "type": "string",
+          "default": "ae"
+        }
+      }
+    },
+    "umbracoRuntimeMinification": {
+      "properties": {
+        "UseInMemoryCache": {
+          "type": "boolean",
+          "default": false
+        },
+        "CacheBuster": {
+          "description": "Cache buster type to use",
+          "enum": [
+            "Version",
+            "AppDomain",
+            "Timestamp"
+          ],
+          "default": "Version"
+        }
+      }
+    },
+    "umbracoSecurity": {
+      "properties": {
+        "AllowPasswordReset": {
+          "description": "Indicating whether to allow user password reset",
+          "type": "boolean",
+          "default": true
+        },
+        "AuthCookieDomain": {
+          "description": "Authorization cookie domain",
+          "type": "string"
+        },
+        "AuthCookieName": {
+          "description": "The authorization cookie name",
+          "type": "string",
+          "default": "UMB_UCONTEXT"
+        },
+        "HideDisabledUsersInBackOffice": {
+          "description": "Indicating whether to hide disabled users in the back-office",
+          "type": "boolean",
+          "default": false
+        },
+        "KeepUserLoggedIn": {
+          "description": "Indicating whether to keep the user logged in",
+          "type": "boolean",
+          "default": false
+        },
+        "MemberPassword": {
+          "$ref": "#/definitions/umbracoMemberPassword"
+        },
+        "UsernameIsEmail": {
+          "description": "Indicating whether the user's email address is to be considered as their username",
+          "type": "boolean",
+          "default": true
+        },
+        "UserPassword": {
+          "$ref": "#/definitions/umbracoUserPassword"
+        }
+      }
+    },
+    "umbracoMemberPassword": {
+      "properties": {
+        "RequiredLength": {
+          "type": "integer",
+          "default": 10
+        },
+        "RequireNonLetterOrDigit": {
+          "type": "boolean",
+          "default": false
+        },
+        "RequireDigit": {
+          "type": "boolean",
+          "default": false
+        },
+        "RequireLowercase": {
+          "type": "boolean",
+          "default": false
+        },
+        "RequireUppercase": {
+          "type": "boolean",
+          "default": false
+        },
+        "MaxFailedAccessAttemptsBeforeLockout": {
+          "type": "integer",
+          "default": 5
+        },
+        "HashAlgorithmType": {
+          "type": "string",
+          "default": "HMACSHA256"
+        }
+      }
+    },
+    "umbracoUserPassword": {
+      "properties": {
+        "RequiredLength": {
+          "type": "integer",
+          "default": 10
+        },
+        "RequireNonLetterOrDigit": {
+          "type": "boolean",
+          "default": false
+        },
+        "RequireDigit": {
+          "type": "boolean",
+          "default": false
+        },
+        "RequireLowercase": {
+          "type": "boolean",
+          "default": false
+        },
+        "RequireUppercase": {
+          "type": "boolean",
+          "default": false
+        },
+        "MaxFailedAccessAttemptsBeforeLockout": {
+          "type": "integer",
+          "default": 5
+        },
+        "HashAlgorithmType": {
+          "type": "string",
+          "default": "PBKDF2.ASPNETCORE.V3"
+        }
+      }
+    },
+    "umbracoWebRouting": {
+      "properties": {
+        "TryMatchingEndpointsForAllPages": {
+          "description": "Indicating whether to check if any routed endpoints match a front-end request before the Umbraco dynamic router tries to map the request to an Umbraco content item",
+          "type": "boolean",
+          "default": false
+        },
+        "TrySkipIisCustomErrors": {
+          "description": "Indicating whether IIS custom errors should be skipped",
+          "type": "boolean",
+          "default": false
+        },
+        "InternalRedirectPreservesTemplate": {
+          "description": "Indicating whether an internal redirect should preserve the template",
+          "type": "boolean",
+          "default": false
+        },
+        "DisableAlternativeTemplates": {
+          "description": "Indicating whether the use of alternative templates are disabled",
+          "type": "boolean",
+          "default": false
+        },
+        "ValidateAlternativeTemplates": {
+          "description": "Indicating whether the use of alternative templates should be validated",
+          "type": "boolean",
+          "default": false
+        },
+        "DisableFindContentByIdPath": {
+          "description": "Indicating whether find content ID by path is disabled",
+          "type": "boolean",
+          "default": false
+        },
+        "DisableRedirectUrlTracking": {
+          "description": "Indicating whether redirect URL tracking is disabled",
+          "type": "boolean",
+          "default": false
+        },
+        "UrlProviderMode": {
+          "enum": [
+            "Default",
+            "Relative",
+            "Absolute",
+            "Auto"
+          ],
+          "default": "Auto"
+        },
+        "UmbracoApplicationUrl": {
+          "type": "string"
+        }
+      }
+    },
+    "umbracoUnattended": {
+      "properties": {
+        "InstallUnattended": {
+          "description": "Indicating whether unattended installs are enabled",
+          "type": "boolean",
+          "default": false
+        },
+        "UpgradeUnattended": {
+          "description": "Indicating whether unattended upgrades are enabled",
+          "type": "boolean",
+          "default": false
+        },
+        "UnattendedUserName": {
+          "description": "Use for creating a user with a name for Unattended Installs",
+          "type": "string"
+        },
+        "UnattendedUserEmail": {
+          "description": "Use for creating a user with an email for Unattended Installs",
+          "type": "string"
+        },
+        "UnattendedUserPassword": {
+          "description": "Use for creating a user with a password for Unattended Installs",
+          "type": "string"
+        }
+      }
+    },
+    "umbracoModelsBuilder": {
+      "properties": {
+        "ModelsMode": {
+          "description": "ModelsBuilder generation mode",
+          "enum": [
+            "Nothing",
+            "InMemoryAuto",
+            "SourceCodeManual",
+            "SourceCodeAuto"
+          ],
+          "default": "InMemoryAuto"
+        },
+        "ModelsNamespace": {
+          "type": "string",
+          "description": "Namespace to use when generating strongly typed models",
+          "default": "Umbraco.Cms.Web.Common.PublishedModels"
+        },
+        "ModelsDirectory": {
+          "type": "string",
+          "description": "Location to generate ModelsBuilder models",
+          "default": "~/umbraco/models"
+        },
+        "DebugLevel": {
+          "type": "integer",
+          "description": "Indicates the debug level. For internal / development use. Set to greater than zero to enable detailed logging.",
+          "default": 0
+        },
+        "AcceptUnsafeModelsDirectory": {
+          "type": "boolean",
+          "description": "Indicates that the directory indicated in ModelsDirectory is allowed to be outside the website root (e.g. ~/../../some/place). Because that can be a potential security risk, it is not allowed by default.",
+          "default": false
+        },
+        "FlagOutOfDateModels": {
+          "type": "boolean",
+          "description": "Indicates whether out-of-date models (i.e. after a content type or data type has been modified) should be flagged.",
+          "default": true
+        }
+      }
+    },
+    "JsonSchemaUmbracoDefinition": {
+      "type": "object",
+      "description": "Configuration of Umbraco CMS and packages\n            ",
+      "properties": {
+        "CMS": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/JsonSchemaCmsDefinition"
+            }
+          ]
+        },
+        "Forms": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/JsonSchemaFormsDefinition"
+            }
+          ]
+        },
+        "Deploy": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/JsonSchemaDeployDefinition"
+            }
+          ]
+        }
+      }
+    },
+    "JsonSchemaCmsDefinition": {
+      "type": "object",
+      "description": "Configurations for the Umbraco CMS\n            ",
+      "properties": {
+        "Content": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsContentSettings"
+        },
+        "Debug": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsCoreDebugSettings"
+        },
+        "ExceptionFilter": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsExceptionFilterSettings"
+        },
+        "ModelsBuilder": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsModelsBuilderSettings"
+        },
+        "Global": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsGlobalSettings"
+        },
+        "HealthChecks": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsHealthChecksSettings"
+        },
+        "Hosting": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsHostingSettings"
+        },
+        "Imaging": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsImagingSettings"
+        },
+        "Examine": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsIndexCreatorSettings"
+        },
+        "KeepAlive": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsKeepAliveSettings"
+        },
+        "Logging": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsLoggingSettings"
+        },
+        "NuCache": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsNuCacheSettings"
+        },
+        "RequestHandler": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsRequestHandlerSettings"
+        },
+        "Runtime": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsRuntimeSettings"
+        },
+        "Security": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsSecuritySettings"
+        },
+        "Tours": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsTourSettings"
+        },
+        "TypeFinder": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsTypeFinderSettings"
+        },
+        "WebRouting": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsWebRoutingSettings"
+        },
+        "Plugins": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsUmbracoPluginSettings"
+        },
+        "Unattended": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsUnattendedSettings"
+        },
+        "RichTextEditor": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsRichTextEditorSettings"
+        },
+        "RuntimeMinification": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsRuntimeMinificationSettings"
+        },
+        "BasicAuth": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsBasicAuthSettings"
+        },
+        "PackageMigration": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsPackageMigrationSettings"
+        },
+        "LegacyPasswordMigration": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsLegacyPasswordMigrationSettings"
+        },
+        "ContentDashboard": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationContentDashboardSettings"
+        },
+        "HelpPage": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsHelpPageSettings"
+        },
+        "DefaultDataCreation": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsInstallDefaultDataSettings"
+        },
+        "DataTypes": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsDataTypesSettings"
+        },
+        "Marketplace": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsMarketplaceSettings"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsContentSettings": {
+      "type": "object",
+      "description": "Typed configuration options for content settings.\n            ",
+      "properties": {
+        "Notifications": {
+          "description": "Gets or sets a value for the content notification settings.\n            ",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsContentNotificationSettings"
+            }
+          ]
+        },
+        "Imaging": {
+          "description": "Gets or sets a value for the content imaging settings.\n            ",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsContentImagingSettings"
+            }
+          ]
+        },
+        "ResolveUrlsFromTextString": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether URLs should be resolved from text strings.\n            ",
+          "default": false
+        },
+        "Error404Collection": {
+          "type": "array",
+          "description": "Gets or sets a value for the collection of error pages.\n            ",
+          "items": {
+            "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsContentErrorPage"
+          }
+        },
+        "PreviewBadge": {
+          "type": "string",
+          "description": "Gets or sets a value for the preview badge mark-up.\n            ",
+          "default": "\n            <div id=\"umbracoPreviewBadge\" class=\"umbraco-preview-badge\">\n                <span class=\"umbraco-preview-badge__header\">Preview mode</span>\n                <a href=\"{0}/preview/?id={2}\" class=\"umbraco-preview-badge__a open\" title=\"Open preview in BackOffice\">\n                    …\n                </a>\n                <a href=\"{0}/preview/end?redir={1}\" class=\"umbraco-preview-badge__a end\" title=\"End preview mode\">\n                    <svg viewBox=\"0 0 100 100\" xmlns=\"http://www.w3.org/2000/svg\"><title>Click to end preview mode</title><path fill=\"#fff\" d=\"M5273.1 2400.1v-2c0-2.8-5-4-9.7-4s-9.7 1.3-9.7 4v2a7 7 0 002 4.9l5 4.9c.3.3.4.6.4 1v6.4c0 .4.2.7.6.8l2.9.9c.5.1 1-.2 1-.8v-7.2c0-.4.2-.7.4-1l5.1-5a7 7 0 002-4.9zm-9.7-.1c-4.8 0-7.4-1.3-7.5-1.8.1-.5 2.7-1.8 7.5-1.8s7.3 1.3 7.5 1.8c-.2.5-2.7 1.8-7.5 1.8z\"/><path fill=\"#fff\" d=\"M5268.4 2410.3c-.6 0-1 .4-1 1s.4 1 1 1h4.3c.6 0 1-.4 1-1s-.4-1-1-1h-4.3zM5272.7 2413.7h-4.3c-.6 0-1 .4-1 1s.4 1 1 1h4.3c.6 0 1-.4 1-1s-.4-1-1-1zM5272.7 2417h-4.3c-.6 0-1 .4-1 1s.4 1 1 1h4.3c.6 0 1-.4 1-1 0-.5-.4-1-1-1z\"/><path fill=\"#fff\" d=\"M78.2 13l-8.7 11.7a32.5 32.5 0 11-51.9 25.8c0-10.3 4.7-19.7 12.9-25.8L21.8 13a47 47 0 1056.4 0z\"/><path fill=\"#fff\" d=\"M42.7 2.5h14.6v49.4H42.7z\"/></svg>\n                </a>\n            </div>\n            <style type=\"text/css\">\n                .umbraco-preview-badge {{\n                    position: fixed;\n                    bottom: 0;\n                    display: inline-flex;\n                    background: rgba(27, 38, 79, 0.9);\n                    color: #fff;\n                    font-size: 12px;\n                    z-index: 99999999;\n                    justify-content: center;\n                    align-items: center;\n                    box-shadow: 0 5px 10px rgba(0, 0, 0, .2), 0 1px 2px rgba(0, 0, 0, .2);\n                    line-height: 1;\n                    pointer-events:none;\n                    left: 50%;\n                    transform: translate(-50%, 40px);\n                    animation: umbraco-preview-badge--effect 10s 1.2s ease both;\n                    border-radius: 3px 3px 0 0;\n                }}\n                @keyframes umbraco-preview-badge--effect {{\n                    0% {{\n                        transform: translate(-50%, 40px);\n                        animation-timing-function: ease-out;\n                    }}\n                    1.5% {{\n                        transform: translate(-50%, -20px);\n                        animation-timing-function: ease-in;\n                    }}\n                    5.0% {{\n                        transform: translate(-50%, -8px);\n                        animation-timing-function: ease-in;\n                    }}\n                    7.5% {{\n                        transform: translate(-50%, -4px);\n                        animation-timing-function: ease-in;\n                    }}\n                    9.2% {{\n                        transform: translate(-50%, -2px);\n                        animation-timing-function: ease-in;\n                    }}\n                    3.5%,\n                    6.5%,\n                    8.5% {{\n                        transform: translate(-50%, 0);\n                        animation-timing-function: ease-out;\n                    }}\n                    9.7% {{\n                        transform: translate(-50%, 0);\n                        animation-timing-function: ease-out;\n                    }}\n                    10.0% {{\n                        transform: translate(-50%, 0);\n                    }}\n\n\n                    60% {{\n                        transform: translate(-50%, 0);\n                        animation-timing-function: ease-out;\n                    }}\n                    61.5% {{\n                        transform: translate(-50%, -20px);\n                        animation-timing-function: ease-in;\n                    }}\n                    65.0% {{\n                        transform: translate(-50%, -8px);\n                        animation-timing-function: ease-in;\n                    }}\n                    67.5% {{\n                        transform: translate(-50%, -4px);\n                        animation-timing-function: ease-in;\n                    }}\n                    69.2% {{\n                        transform: translate(-50%, -2px);\n                        animation-timing-function: ease-in;\n                    }}\n                    63.5%,\n                    66.5%,\n                    68.5% {{\n                        transform: translate(-50%, 0);\n                        animation-timing-function: ease-out;\n                    }}\n                    69.7% {{\n                        transform: translate(-50%, 0);\n                        animation-timing-function: ease-out;\n                    }}\n                    70.0% {{\n                        transform: translate(-50%, 0);\n                    }}\n                    100.0% {{\n                        transform: translate(-50%, 0);\n                    }}\n                }}\n                .umbraco-preview-badge__header {{\n                    padding: 1em;\n                    font-weight: bold;\n                    pointer-events:none;\n                }}\n                .umbraco-preview-badge__a {{\n                    width: 3em;\n                    padding: 1em;\n                    display: flex;\n                    flex-shrink: 0;\n                    align-items: center;\n                    align-self: stretch;\n                    color:white;\n                    text-decoration:none;\n                    font-weight: bold;\n                    border-left: 1px solid hsla(0,0%,100%,.25);\n                    pointer-events:all;\n                }}\n                .umbraco-preview-badge__a svg {{\n                    width: 1em;\n                    height:1em;\n                }}\n                .umbraco-preview-badge__a:hover {{\n                    background: #202d5e;\n                }}\n                .umbraco-preview-badge__end svg {{\n                    fill: #fff;\n                    width:1em;\n                }}\n            </style>\n            <script type=\"text/javascript\" data-umbraco-path=\"{0}\" src=\"{0}/js/umbraco.websitepreview.min.js\"></script>"
+        },
+        "MacroErrors": {
+          "description": "Gets or sets a value for the macro error behaviour.\n            ",
+          "default": "Inline",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreMacrosMacroErrorBehaviour"
+            }
+          ]
+        },
+        "ShowDeprecatedPropertyEditors": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether deprecated property editors should be shown.\n            ",
+          "default": false
+        },
+        "LoginBackgroundImage": {
+          "type": "string",
+          "description": "Gets or sets a value for the path to the login screen background image.\n            ",
+          "default": "assets/img/login.jpg"
+        },
+        "LoginLogoImage": {
+          "type": "string",
+          "description": "Gets or sets a value for the path to the login screen logo image.\n            ",
+          "default": "assets/img/application/umbraco_logo_white.svg"
+        },
+        "HideBackOfficeLogo": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to hide the backoffice umbraco logo or not.\n            ",
+          "default": false
+        },
+        "DisableDeleteWhenReferenced": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to disable the deletion of items referenced by other items.\n            ",
+          "default": false
+        },
+        "DisableUnpublishWhenReferenced": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to disable the unpublishing of items referenced by other items.\n            ",
+          "default": false
+        },
+        "ContentVersionCleanupPolicy": {
+          "description": "Get or sets the model representing the global content version cleanup policy\n            ",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsContentVersionCleanupPolicySettings"
+            }
+          ]
+        },
+        "AllowEditInvariantFromNonDefault": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to allow editing invariant properties from a non-default language variation.",
+          "default": false
+        },
+        "AllowedUploadedFileExtensions": {
+          "type": "array",
+          "description": "Gets or sets a value for the collection of file extensions that are allowed for upload.\n            ",
+          "items": {
+            "type": "string"
+          }
+        },
+        "DisallowedUploadedFileExtensions": {
+          "type": "array",
+          "description": "Gets or sets a value for the collection of file extensions that are disallowed for upload.\n            ",
+          "default": "ashx,aspx,ascx,config,cshtml,vbhtml,asmx,air,axd,xamlx",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsContentNotificationSettings": {
+      "type": "object",
+      "description": "Typed configuration options for content notification settings.\n            ",
+      "properties": {
+        "Email": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Gets or sets a value for the email address for notifications.\n            "
+        },
+        "DisableHtmlEmail": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether HTML email notifications should be disabled.\n            ",
+          "default": false
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsContentImagingSettings": {
+      "type": "object",
+      "description": "Typed configuration options for content imaging settings.\n            ",
+      "properties": {
+        "ImageFileTypes": {
+          "type": "array",
+          "description": "Gets or sets a value for the collection of accepted image file extensions.\n            ",
+          "default": "jpeg,jpg,gif,bmp,png,tiff,tif,webp",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AutoFillImageProperties": {
+          "type": "array",
+          "description": "Gets or sets a value for the imaging autofill following media file upload fields.\n            ",
+          "items": {
+            "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsImagingAutoFillUploadField"
+          }
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsImagingAutoFillUploadField": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsValidationValidatableEntryBase"
+        },
+        {
+          "type": "object",
+          "description": "Typed configuration options for image autofill upload settings.\n            ",
+          "required": [
+            "Alias",
+            "WidthFieldAlias",
+            "HeightFieldAlias",
+            "LengthFieldAlias",
+            "ExtensionFieldAlias"
+          ],
+          "properties": {
+            "Alias": {
+              "type": "string",
+              "description": "Gets or sets a value for the alias of the image upload property.\n            ",
+              "minLength": 1
+            },
+            "WidthFieldAlias": {
+              "type": "string",
+              "description": "Gets or sets a value for the width field alias of the image upload property.\n            ",
+              "minLength": 1
+            },
+            "HeightFieldAlias": {
+              "type": "string",
+              "description": "Gets or sets a value for the height field alias of the image upload property.\n            ",
+              "minLength": 1
+            },
+            "LengthFieldAlias": {
+              "type": "string",
+              "description": "Gets or sets a value for the length field alias of the image upload property.\n            ",
+              "minLength": 1
+            },
+            "ExtensionFieldAlias": {
+              "type": "string",
+              "description": "Gets or sets a value for the extension field alias of the image upload property.\n            ",
+              "minLength": 1
+            }
+          }
+        }
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsValidationValidatableEntryBase": {
+      "type": "object",
+      "description": "Provides a base class for configuration models that can be validated based on data annotations.\n            ",
+      "x-abstract": true
+    },
+    "UmbracoCmsCoreConfigurationModelsContentErrorPage": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsValidationValidatableEntryBase"
+        },
+        {
+          "type": "object",
+          "description": "Typed configuration for a content error page.\n            ",
+          "required": [
+            "Culture"
+          ],
+          "properties": {
+            "ContentId": {
+              "type": "integer",
+              "description": "Gets or sets a value for the content Id.\n            ",
+              "format": "int32"
+            },
+            "ContentKey": {
+              "type": "string",
+              "description": "Gets or sets a value for the content key.\n            ",
+              "format": "guid"
+            },
+            "ContentXPath": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "description": "Gets or sets a value for the content XPath.\n            "
+            },
+            "Culture": {
+              "type": "string",
+              "description": "Gets or sets a value for the content culture.\n            ",
+              "minLength": 1
+            }
+          }
+        }
+      ]
+    },
+    "UmbracoCmsCoreMacrosMacroErrorBehaviour": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Inline",
+        "Silent",
+        "Throw",
+        "Content"
+      ],
+      "enum": [
+        "Inline",
+        "Silent",
+        "Throw",
+        "Content"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsContentVersionCleanupPolicySettings": {
+      "type": "object",
+      "description": "Model representing the global content version cleanup policy\n            ",
+      "properties": {
+        "EnableCleanup": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether or not the cleanup job should be executed.\n            ",
+          "default": false
+        },
+        "KeepAllVersionsNewerThanDays": {
+          "type": "integer",
+          "description": "Gets or sets the number of days where all historical content versions are kept.\n            ",
+          "format": "int32",
+          "default": 7
+        },
+        "KeepLatestVersionPerDayForDays": {
+          "type": "integer",
+          "description": "Gets or sets the number of days where the latest historical content version for that day are kept.\n            ",
+          "format": "int32",
+          "default": 90
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsCoreDebugSettings": {
+      "type": "object",
+      "description": "Typed configuration options for core debug settings.\n            ",
+      "properties": {
+        "LogIncompletedScopes": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether incompleted scopes should be logged.\n            ",
+          "default": false
+        },
+        "DumpOnTimeoutThreadAbort": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether memory dumps on thread abort should be taken.\n            ",
+          "default": false
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsExceptionFilterSettings": {
+      "type": "object",
+      "description": "Typed configuration options for exception filter settings.\n            ",
+      "properties": {
+        "Disabled": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether the exception filter is disabled.\n            ",
+          "default": false
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsModelsBuilderSettings": {
+      "type": "object",
+      "description": "Typed configuration options for models builder settings.\n            ",
+      "properties": {
+        "ModelsMode": {
+          "description": "Gets or sets a value for the models mode.\n            ",
+          "default": "InMemoryAuto",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsMode"
+            }
+          ]
+        },
+        "ModelsNamespace": {
+          "type": "string",
+          "description": "Gets or sets a value for models namespace.\n            ",
+          "default": "Umbraco.Cms.Web.Common.PublishedModels"
+        },
+        "FlagOutOfDateModels": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether we should flag out-of-date models.\n            "
+        },
+        "ModelsDirectory": {
+          "type": "string",
+          "description": "Gets or sets a value for the models directory.\n            ",
+          "default": "~/umbraco/models"
+        },
+        "AcceptUnsafeModelsDirectory": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to accept an unsafe value for ModelsDirectory.\n            ",
+          "default": false
+        },
+        "DebugLevel": {
+          "type": "integer",
+          "description": "Gets or sets a value indicating the debug log level.\n            ",
+          "format": "int32",
+          "default": 0
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsMode": {
+      "type": "string",
+      "description": "Defines the models generation modes.\n            ",
+      "x-enumNames": [
+        "Nothing",
+        "InMemoryAuto",
+        "SourceCodeManual",
+        "SourceCodeAuto"
+      ],
+      "enum": [
+        "Nothing",
+        "InMemoryAuto",
+        "SourceCodeManual",
+        "SourceCodeAuto"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsGlobalSettings": {
+      "type": "object",
+      "description": "Typed configuration options for global settings.\n            ",
+      "properties": {
+        "ReservedUrls": {
+          "type": "string",
+          "description": "Gets or sets a value for the reserved URLs (must end with a comma).\n            ",
+          "default": "~/.well-known,"
+        },
+        "ReservedPaths": {
+          "type": "string",
+          "description": "Gets or sets a value for the reserved paths (must end with a comma).\n            ",
+          "default": "~/app_plugins/,~/install/,~/mini-profiler-resources/,~/umbraco/,"
+        },
+        "TimeOut": {
+          "type": "string",
+          "description": "Gets or sets a value for the back-office login timeout.\n            ",
+          "format": "duration",
+          "default": "00:20:00"
+        },
+        "DefaultUILanguage": {
+          "type": "string",
+          "description": "Gets or sets a value for the default UI language.\n            ",
+          "default": "en-US"
+        },
+        "HideTopLevelNodeFromPath": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to hide the top level node from the path.\n            ",
+          "default": true
+        },
+        "UseHttps": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether HTTPS should be used.\n            ",
+          "default": false
+        },
+        "VersionCheckPeriod": {
+          "type": "integer",
+          "description": "Gets or sets a value for the version check period in days.\n            ",
+          "format": "int32",
+          "default": 7
+        },
+        "IconsPath": {
+          "type": "string",
+          "description": "Gets or sets a value for the Umbraco icons path.\n            ",
+          "default": "umbraco/assets/icons"
+        },
+        "UmbracoCssPath": {
+          "type": "string",
+          "description": "Gets or sets a value for the Umbraco CSS path.\n            ",
+          "default": "~/css"
+        },
+        "UmbracoScriptsPath": {
+          "type": "string",
+          "description": "Gets or sets a value for the Umbraco scripts path.\n            ",
+          "default": "~/scripts"
+        },
+        "UmbracoMediaPath": {
+          "type": "string",
+          "description": "Gets or sets a value for the Umbraco media request path.\n            ",
+          "default": "~/media"
+        },
+        "UmbracoMediaPhysicalRootPath": {
+          "type": "string",
+          "description": "Gets or sets a value for the physical Umbraco media root path (falls back to UmbracoMediaPath when\nempty).\n            "
+        },
+        "InstallMissingDatabase": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to install the database when it is missing.\n            ",
+          "default": false
+        },
+        "DisableElectionForSingleServer": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to disable the election for a single server.\n            ",
+          "default": false
+        },
+        "DatabaseFactoryServerVersion": {
+          "type": "string",
+          "description": "Gets or sets a value for the database factory server version.\n            "
+        },
+        "MainDomLock": {
+          "type": "string",
+          "description": "Gets or sets a value for the main dom lock.\n            "
+        },
+        "MainDomKeyDiscriminator": {
+          "type": "string",
+          "description": "Gets or sets a value to discriminate MainDom boundaries.\n\n    Generally the default should suffice but useful for advanced scenarios e.g. azure deployment slot based zero\n    downtime deployments.\n\n            "
+        },
+        "MainDomReleaseSignalPollingInterval": {
+          "type": "integer",
+          "description": "Gets or sets the duration (in milliseconds) for which the MainDomLock release signal polling task should sleep.\n            ",
+          "format": "int32",
+          "default": 2000
+        },
+        "Id": {
+          "type": "string",
+          "description": "Gets or sets the telemetry ID.\n            "
+        },
+        "NoNodesViewPath": {
+          "type": "string",
+          "description": "Gets or sets a value for the path to the no content view.\n            ",
+          "default": "~/umbraco/UmbracoWebsite/NoNodes.cshtml"
+        },
+        "DatabaseServerRegistrar": {
+          "description": "Gets or sets a value for the database server registrar settings.\n            ",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsDatabaseServerRegistrarSettings"
+            }
+          ]
+        },
+        "DatabaseServerMessenger": {
+          "description": "Gets or sets a value for the database server messenger settings.\n            ",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsDatabaseServerMessengerSettings"
+            }
+          ]
+        },
+        "Smtp": {
+          "description": "Gets or sets a value for the SMTP settings.\n            ",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsSmtpSettings"
+            }
+          ]
+        },
+        "SanitizeTinyMce": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether TinyMCE scripting sanitization should be applied.\n            ",
+          "default": false
+        },
+        "DistributedLockingReadLockDefaultTimeout": {
+          "type": "string",
+          "description": "Gets or sets a value representing the maximum time to wait whilst attempting to obtain a distributed read lock.\n            ",
+          "format": "duration",
+          "default": "00:01:00"
+        },
+        "DistributedLockingWriteLockDefaultTimeout": {
+          "type": "string",
+          "description": "Gets or sets a value representing the maximum time to wait whilst attempting to obtain a distributed write lock.\n            ",
+          "format": "duration",
+          "default": "00:00:05"
+        },
+        "DistributedLockingMechanism": {
+          "type": "string",
+          "description": "Gets or sets a value representing the DistributedLockingMechanism to use."
+        },
+        "ForceCombineUrlPathLeftToRight": {
+          "type": "boolean",
+          "description": "Force url paths to be left to right, even when the culture has right to left text",
+          "default": true,
+          "x-example": "For the following hierarchy\n- Root (/ar)\n  - 1 (/ar/1)\n    - 2 (/ar/1/2)\n      - 3 (/ar/1/2/3)\n        - 3 (/ar/1/2/3/4)\nWhen forced\n- https://www.umbraco.com/ar/1/2/3/4\nwhen not\n- https://www.umbraco.com/ar/4/3/2/1"
+        },
+        "ShowMaintenancePageWhenInUpgradeState": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsDatabaseServerRegistrarSettings": {
+      "type": "object",
+      "description": "Typed configuration options for database server registrar settings.\n            ",
+      "properties": {
+        "WaitTimeBetweenCalls": {
+          "type": "string",
+          "description": "Gets or sets a value for the amount of time to wait between calls to the database on the background thread.\n            ",
+          "format": "duration",
+          "default": "00:01:00"
+        },
+        "StaleServerTimeout": {
+          "type": "string",
+          "description": "Gets or sets a value for the time span to wait before considering a server stale, after it has last been accessed.\n            ",
+          "format": "duration",
+          "default": "00:02:00"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsDatabaseServerMessengerSettings": {
+      "type": "object",
+      "description": "Typed configuration options for database server messaging settings.\n            ",
+      "properties": {
+        "MaxProcessingInstructionCount": {
+          "type": "integer",
+          "description": "Gets or sets a value for the maximum number of instructions that can be processed at startup; otherwise the server\ncold-boots (rebuilds its caches).\n            ",
+          "format": "int32",
+          "default": 1000
+        },
+        "TimeToRetainInstructions": {
+          "type": "string",
+          "description": "Gets or sets a value for the time to keep instructions in the database; records older than this number will be\npruned.\n            ",
+          "format": "duration",
+          "default": "2.00:00:00"
+        },
+        "TimeBetweenSyncOperations": {
+          "type": "string",
+          "description": "Gets or sets a value for the time to wait between each sync operations.\n            ",
+          "format": "duration",
+          "default": "00:00:05"
+        },
+        "TimeBetweenPruneOperations": {
+          "type": "string",
+          "description": "Gets or sets a value for the time to wait between each prune operations.\n            ",
+          "format": "duration",
+          "default": "00:01:00"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsSmtpSettings": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsValidationValidatableEntryBase"
+        },
+        {
+          "type": "object",
+          "description": "Typed configuration options for SMTP settings.\n            ",
+          "required": [
+            "From"
+          ],
+          "properties": {
+            "From": {
+              "type": "string",
+              "description": "Gets or sets a value for the SMTP from address to use for messages.\n            ",
+              "format": "email",
+              "minLength": 1
+            },
+            "Host": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "description": "Gets or sets a value for the SMTP host.\n            "
+            },
+            "Port": {
+              "type": "integer",
+              "description": "Gets or sets a value for the SMTP port.\n            ",
+              "format": "int32"
+            },
+            "SecureSocketOptions": {
+              "description": "Gets or sets a value for the secure socket options.\n            ",
+              "default": "Auto",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsSecureSocketOptions"
+                }
+              ]
+            },
+            "PickupDirectoryLocation": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "description": "Gets or sets a value for the SMTP pick-up directory.\n            "
+            },
+            "DeliveryMethod": {
+              "description": "Gets or sets a value for the SMTP delivery method.\n            ",
+              "default": "Network",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/SystemNetMailSmtpDeliveryMethod"
+                }
+              ]
+            },
+            "Username": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "description": "Gets or sets a value for the SMTP user name.\n            "
+            },
+            "Password": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "description": "Gets or sets a value for the SMTP password.\n            "
+            }
+          }
+        }
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsSecureSocketOptions": {
+      "type": "string",
+      "description": "Matches MailKit.Security.SecureSocketOptions and defined locally to avoid having to take\na dependency on this external library into Umbraco.Core.\n            ",
+      "x-enumNames": [
+        "None",
+        "Auto",
+        "SslOnConnect",
+        "StartTls",
+        "StartTlsWhenAvailable"
+      ],
+      "enum": [
+        "None",
+        "Auto",
+        "SslOnConnect",
+        "StartTls",
+        "StartTlsWhenAvailable"
+      ]
+    },
+    "SystemNetMailSmtpDeliveryMethod": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Network",
+        "SpecifiedPickupDirectory",
+        "PickupDirectoryFromIis"
+      ],
+      "enum": [
+        "Network",
+        "SpecifiedPickupDirectory",
+        "PickupDirectoryFromIis"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsHealthChecksSettings": {
+      "type": "object",
+      "description": "Typed configuration options for healthchecks settings.\n            ",
+      "properties": {
+        "DisabledChecks": {
+          "type": "array",
+          "description": "Gets or sets a value for the collection of healthchecks that are disabled.\n            ",
+          "items": {
+            "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsDisabledHealthCheckSettings"
+          }
+        },
+        "Notification": {
+          "description": "Gets or sets a value for the healthcheck notification settings.\n            ",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsHealthChecksNotificationSettings"
+            }
+          ]
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsDisabledHealthCheckSettings": {
+      "type": "object",
+      "description": "Typed configuration options for disabled healthcheck settings.\n            ",
+      "properties": {
+        "Id": {
+          "type": "string",
+          "description": "Gets or sets a value for the healthcheck Id to disable.\n            ",
+          "format": "guid"
+        },
+        "DisabledOn": {
+          "type": "string",
+          "description": "Gets or sets a value for the date the healthcheck was disabled.\n            ",
+          "format": "date-time"
+        },
+        "DisabledBy": {
+          "type": "integer",
+          "description": "Gets or sets a value for Id of the user that disabled the healthcheck.\n            ",
+          "format": "int32"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsHealthChecksNotificationSettings": {
+      "type": "object",
+      "description": "Typed configuration options for healthcheck notification settings.\n            ",
+      "properties": {
+        "Enabled": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether health check notifications are enabled.\n            ",
+          "default": false
+        },
+        "FirstRunTime": {
+          "type": "string",
+          "description": "Gets or sets a value for the first run time of a healthcheck notification in crontab format.\n            "
+        },
+        "Period": {
+          "type": "string",
+          "description": "Gets or sets a value for the period of the healthcheck notification.\n            ",
+          "format": "duration",
+          "default": "1.00:00:00"
+        },
+        "NotificationMethods": {
+          "type": "object",
+          "description": "Gets or sets a value for the collection of health check notification methods.\n            ",
+          "additionalProperties": {
+            "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsHealthChecksNotificationMethodSettings"
+          }
+        },
+        "DisabledChecks": {
+          "type": "array",
+          "description": "Gets or sets a value for the collection of health checks that are disabled for notifications.\n            ",
+          "items": {
+            "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsDisabledHealthCheckSettings"
+          }
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsHealthChecksNotificationMethodSettings": {
+      "type": "object",
+      "description": "Typed configuration options for healthcheck notification method settings.\n            ",
+      "properties": {
+        "Enabled": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether the health check notification method is enabled.\n            ",
+          "default": false
+        },
+        "Verbosity": {
+          "description": "Gets or sets a value for the health check notifications reporting verbosity.\n            ",
+          "default": "Summary",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreHealthChecksHealthCheckNotificationVerbosity"
+            }
+          ]
+        },
+        "FailureOnly": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether the health check notifications should occur on failures only.\n            ",
+          "default": false
+        },
+        "Settings": {
+          "type": "object",
+          "description": "Gets or sets a value providing provider specific settings for the health check notification method.\n            ",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "UmbracoCmsCoreHealthChecksHealthCheckNotificationVerbosity": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Summary",
+        "Detailed"
+      ],
+      "enum": [
+        "Summary",
+        "Detailed"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsHostingSettings": {
+      "type": "object",
+      "description": "Typed configuration options for hosting settings.\n            ",
+      "properties": {
+        "ApplicationVirtualPath": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Gets or sets a value for the application virtual path.\n            "
+        },
+        "LocalTempStorageLocation": {
+          "description": "Gets or sets a value for the location of temporary files.\n            ",
+          "default": "Default",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationLocalTempStorage"
+            }
+          ]
+        },
+        "Debug": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether umbraco is running in [debug mode].\n            ",
+          "default": false
+        },
+        "SiteName": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Gets or sets a value specifying the name of the site.\n            "
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationLocalTempStorage": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Unknown",
+        "Default",
+        "EnvironmentTemp"
+      ],
+      "enum": [
+        "Unknown",
+        "Default",
+        "EnvironmentTemp"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsImagingSettings": {
+      "type": "object",
+      "description": "Typed configuration options for imaging settings.\n            ",
+      "properties": {
+        "Cache": {
+          "description": "Gets or sets a value for imaging cache settings.\n            ",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsImagingCacheSettings"
+            }
+          ]
+        },
+        "Resize": {
+          "description": "Gets or sets a value for imaging resize settings.\n            ",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsImagingResizeSettings"
+            }
+          ]
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsImagingCacheSettings": {
+      "type": "object",
+      "description": "Typed configuration options for image cache settings.\n            ",
+      "properties": {
+        "BrowserMaxAge": {
+          "type": "string",
+          "description": "Gets or sets a value for the browser image cache maximum age.\n            ",
+          "format": "duration",
+          "default": "7.00:00:00"
+        },
+        "CacheMaxAge": {
+          "type": "string",
+          "description": "Gets or sets a value for the image cache maximum age.\n            ",
+          "format": "duration",
+          "default": "365.00:00:00"
+        },
+        "CacheHashLength": {
+          "type": "integer",
+          "description": "Gets or sets a value for the image cache hash length.\n            ",
+          "default": 12
+        },
+        "CacheFolderDepth": {
+          "type": "integer",
+          "description": "Gets or sets a value for the image cache folder depth.\n            ",
+          "default": 8
+        },
+        "CacheFolder": {
+          "type": "string",
+          "description": "Gets or sets a value for the image cache folder.\n            ",
+          "default": "~/umbraco/Data/TEMP/MediaCache"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsImagingResizeSettings": {
+      "type": "object",
+      "description": "Typed configuration options for image resize settings.\n            ",
+      "properties": {
+        "MaxWidth": {
+          "type": "integer",
+          "description": "Gets or sets a value for the maximim resize width.\n            ",
+          "format": "int32",
+          "default": 5000
+        },
+        "MaxHeight": {
+          "type": "integer",
+          "description": "Gets or sets a value for the maximim resize height.\n            ",
+          "format": "int32",
+          "default": 5000
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsIndexCreatorSettings": {
+      "type": "object",
+      "description": "Typed configuration options for index creator settings.\n            ",
+      "properties": {
+        "LuceneDirectoryFactory": {
+          "description": "Gets or sets a value for lucene directory factory type.\n            ",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsLuceneDirectoryFactory"
+            }
+          ]
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsLuceneDirectoryFactory": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Default",
+        "SyncedTempFileSystemDirectoryFactory",
+        "TempFileSystemDirectoryFactory"
+      ],
+      "enum": [
+        "Default",
+        "SyncedTempFileSystemDirectoryFactory",
+        "TempFileSystemDirectoryFactory"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsKeepAliveSettings": {
+      "type": "object",
+      "description": "Typed configuration options for keep alive settings.\n            ",
+      "properties": {
+        "DisableKeepAliveTask": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether the keep alive task is disabled.\n            ",
+          "default": false
+        },
+        "KeepAlivePingUrl": {
+          "type": "string",
+          "description": "Gets or sets a value for the keep alive ping URL.\n            ",
+          "default": "~/api/keepalive/ping"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsLoggingSettings": {
+      "type": "object",
+      "description": "Typed configuration options for logging settings.\n            ",
+      "properties": {
+        "MaxLogAge": {
+          "type": "string",
+          "description": "Gets or sets a value for the maximum age of a log file.\n            ",
+          "format": "duration",
+          "default": "1.00:00:00"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsNuCacheSettings": {
+      "type": "object",
+      "description": "Typed configuration options for NuCache settings.\n            ",
+      "properties": {
+        "BTreeBlockSize": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Gets or sets a value defining the BTree block size.\n            ",
+          "format": "int32"
+        },
+        "NuCacheSerializerType": {
+          "description": "The serializer type that nucache uses to persist documents in the database.\n            ",
+          "default": "MessagePack",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsNuCacheSerializerType"
+            }
+          ]
+        },
+        "SqlPageSize": {
+          "type": "integer",
+          "description": "The paging size to use for nucache SQL queries.\n            ",
+          "format": "int32",
+          "default": 1000
+        },
+        "KitBatchSize": {
+          "type": "integer",
+          "description": "The size to use for nucache Kit batches.  Higher value means more content loaded into memory at a time.\n            ",
+          "format": "int32",
+          "default": 1
+        },
+        "UnPublishedContentCompression": {
+          "type": "boolean"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsNuCacheSerializerType": {
+      "type": "string",
+      "description": "The serializer type that nucache uses to persist documents in the database.\n            ",
+      "x-enumNames": [
+        "MessagePack",
+        "JSON"
+      ],
+      "enum": [
+        "MessagePack",
+        "JSON"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsRequestHandlerSettings": {
+      "type": "object",
+      "description": "Typed configuration options for request handler settings.\n            ",
+      "properties": {
+        "AddTrailingSlash": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to add a trailing slash to URLs.\n            ",
+          "default": true
+        },
+        "ConvertUrlsToAscii": {
+          "type": "string",
+          "description": "Gets or sets a value indicating whether to convert URLs to ASCII (valid values: \"true\", \"try\" or \"false\").\n            ",
+          "default": "try"
+        },
+        "EnableDefaultCharReplacements": {
+          "type": "boolean",
+          "description": "Disable all default character replacements\n            ",
+          "default": true
+        },
+        "UserDefinedCharCollection": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Add additional character replacements, or override defaults\n            ",
+          "items": {
+            "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsCharItem"
+          }
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsCharItem": {
+      "type": "object",
+      "properties": {
+        "Char": {
+          "type": "string",
+          "description": "The character to replace\n            "
+        },
+        "Replacement": {
+          "type": "string",
+          "description": "The replacement character\n            "
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsRuntimeSettings": {
+      "type": "object",
+      "description": "Typed configuration options for runtime settings.",
+      "properties": {
+        "Mode": {
+          "description": "Gets or sets the runtime mode.",
+          "default": "BackofficeDevelopment",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsRuntimeMode"
+            }
+          ]
+        },
+        "MaxQueryStringLength": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Gets or sets a value for the maximum query string length.",
+          "format": "int32"
+        },
+        "MaxRequestLength": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Gets or sets a value for the maximum request length in kb.\n            ",
+          "format": "int32"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsRuntimeMode": {
+      "type": "string",
+      "description": "Represents the configured Umbraco runtime mode.",
+      "x-enumNames": [
+        "BackofficeDevelopment",
+        "Development",
+        "Production"
+      ],
+      "enum": [
+        "BackofficeDevelopment",
+        "Development",
+        "Production"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsSecuritySettings": {
+      "type": "object",
+      "description": "Typed configuration options for security settings.\n            ",
+      "properties": {
+        "KeepUserLoggedIn": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to keep the user logged in.\n            ",
+          "default": false
+        },
+        "HideDisabledUsersInBackOffice": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to hide disabled users in the back-office.\n            ",
+          "default": false
+        },
+        "AllowPasswordReset": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to allow user password reset.\n            ",
+          "default": true
+        },
+        "AuthCookieName": {
+          "type": "string",
+          "description": "Gets or sets a value for the authorization cookie name.\n            ",
+          "default": "UMB_UCONTEXT"
+        },
+        "AuthCookieDomain": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Gets or sets a value for the authorization cookie domain.\n            "
+        },
+        "UsernameIsEmail": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether the user's email address is to be considered as their username.\n            "
+        },
+        "AllowedUserNameCharacters": {
+          "type": "string",
+          "description": "Gets or sets the set of allowed characters for a username\n            ",
+          "default": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+\\"
+        },
+        "UserPassword": {
+          "description": "Gets or sets a value for the user password settings.\n            ",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsUserPasswordConfigurationSettings"
+            }
+          ]
+        },
+        "MemberPassword": {
+          "description": "Gets or sets a value for the member password settings.\n            ",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsMemberPasswordConfigurationSettings"
+            }
+          ]
+        },
+        "MemberBypassTwoFactorForExternalLogins": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to bypass the two factor requirement in Umbraco when using external login\nfor members. Thereby rely on the External login and potential 2FA at that provider.\n            ",
+          "default": true
+        },
+        "UserBypassTwoFactorForExternalLogins": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to bypass the two factor requirement in Umbraco when using external login\nfor users. Thereby rely on the External login and potential 2FA at that provider.\n            ",
+          "default": true
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsUserPasswordConfigurationSettings": {
+      "type": "object",
+      "description": "Typed configuration options for user password settings.\n            ",
+      "properties": {
+        "RequiredLength": {
+          "type": "integer",
+          "description": "Gets a value for the minimum required length for the password.\n            ",
+          "format": "int32",
+          "default": 10
+        },
+        "RequireNonLetterOrDigit": {
+          "type": "boolean",
+          "description": "Gets a value indicating whether at least one non-letter or digit is required for the password.\n            ",
+          "default": false
+        },
+        "RequireDigit": {
+          "type": "boolean",
+          "description": "Gets a value indicating whether at least one digit is required for the password.\n            ",
+          "default": false
+        },
+        "RequireLowercase": {
+          "type": "boolean",
+          "description": "Gets a value indicating whether at least one lower-case character is required for the password.\n            ",
+          "default": false
+        },
+        "RequireUppercase": {
+          "type": "boolean",
+          "description": "Gets a value indicating whether at least one upper-case character is required for the password.\n            ",
+          "default": false
+        },
+        "HashAlgorithmType": {
+          "type": "string",
+          "description": "Gets a value for the password hash algorithm type.\n            ",
+          "default": "PBKDF2.ASPNETCORE.V3"
+        },
+        "MaxFailedAccessAttemptsBeforeLockout": {
+          "type": "integer",
+          "description": "Gets a value for the maximum failed access attempts before lockout.\n            ",
+          "format": "int32",
+          "default": 5
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsMemberPasswordConfigurationSettings": {
+      "type": "object",
+      "description": "Typed configuration options for member password settings.\n            ",
+      "properties": {
+        "RequiredLength": {
+          "type": "integer",
+          "description": "Gets a value for the minimum required length for the password.\n            ",
+          "format": "int32",
+          "default": 10
+        },
+        "RequireNonLetterOrDigit": {
+          "type": "boolean",
+          "description": "Gets a value indicating whether at least one non-letter or digit is required for the password.\n            ",
+          "default": false
+        },
+        "RequireDigit": {
+          "type": "boolean",
+          "description": "Gets a value indicating whether at least one digit is required for the password.\n            ",
+          "default": false
+        },
+        "RequireLowercase": {
+          "type": "boolean",
+          "description": "Gets a value indicating whether at least one lower-case character is required for the password.\n            ",
+          "default": false
+        },
+        "RequireUppercase": {
+          "type": "boolean",
+          "description": "Gets a value indicating whether at least one upper-case character is required for the password.\n            ",
+          "default": false
+        },
+        "HashAlgorithmType": {
+          "type": "string",
+          "description": "Gets a value for the password hash algorithm type.\n            ",
+          "default": "PBKDF2.ASPNETCORE.V3"
+        },
+        "MaxFailedAccessAttemptsBeforeLockout": {
+          "type": "integer",
+          "description": "Gets a value for the maximum failed access attempts before lockout.\n            ",
+          "format": "int32",
+          "default": 5
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsTourSettings": {
+      "type": "object",
+      "description": "Typed configuration options for tour settings.\n            ",
+      "properties": {
+        "EnableTours": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether back-office tours are enabled.\n            ",
+          "default": true
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsTypeFinderSettings": {
+      "type": "object",
+      "description": "Typed configuration options for type finder settings.\n            ",
+      "required": [
+        "AssembliesAcceptingLoadExceptions"
+      ],
+      "properties": {
+        "AssembliesAcceptingLoadExceptions": {
+          "type": "string",
+          "description": "Gets or sets a value for the assemblies that accept load exceptions during type finder operations.\n            ",
+          "minLength": 1
+        },
+        "AdditionalEntryAssemblies": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "By default the entry assemblies for scanning plugin types is the Umbraco DLLs. If you require\nscanning for plugins based on different root referenced assemblies you can add the assembly name to this list.\n            ",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsWebRoutingSettings": {
+      "type": "object",
+      "description": "Typed configuration options for web routing settings.\n            ",
+      "properties": {
+        "TryMatchingEndpointsForAllPages": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to check if any routed endpoints match a front-end request before\nthe Umbraco dynamic router tries to map the request to an Umbraco content item.\n            ",
+          "default": false
+        },
+        "TrySkipIisCustomErrors": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether IIS custom errors should be skipped.\n            ",
+          "default": false
+        },
+        "InternalRedirectPreservesTemplate": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether an internal redirect should preserve the template.\n            ",
+          "default": false
+        },
+        "DisableAlternativeTemplates": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether the use of alternative templates are disabled.\n            ",
+          "default": false
+        },
+        "ValidateAlternativeTemplates": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether the use of alternative templates should be validated.\n            ",
+          "default": false
+        },
+        "DisableFindContentByIdPath": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether find content ID by path is disabled.\n            ",
+          "default": false
+        },
+        "DisableRedirectUrlTracking": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether redirect URL tracking is disabled.\n            ",
+          "default": false
+        },
+        "UrlProviderMode": {
+          "description": "Gets or sets a value for the URL provider mode (UrlMode).\n            ",
+          "default": "Auto",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreModelsPublishedContentUrlMode"
+            }
+          ]
+        },
+        "UmbracoApplicationUrl": {
+          "type": "string",
+          "description": "Gets or sets a value for the Umbraco application URL.\n            "
+        }
+      }
+    },
+    "UmbracoCmsCoreModelsPublishedContentUrlMode": {
+      "type": "string",
+      "description": "Specifies the type of URLs that the URL provider should produce, Auto is the default.\n            ",
+      "x-enumNames": [
+        "Default",
+        "Relative",
+        "Absolute",
+        "Auto"
+      ],
+      "enum": [
+        "Default",
+        "Relative",
+        "Absolute",
+        "Auto"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsUmbracoPluginSettings": {
+      "type": "object",
+      "description": "Typed configuration options for the plugins.\n            ",
+      "properties": {
+        "BrowsableFileExtensions": {
+          "type": "array",
+          "description": "Gets or sets the allowed file extensions (including the period \".\") that should be accessible from the browser.\n            ",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsUnattendedSettings": {
+      "type": "object",
+      "description": "Typed configuration options for unattended settings.\n            ",
+      "properties": {
+        "InstallUnattended": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether unattended installs are enabled.\n            ",
+          "default": false
+        },
+        "UpgradeUnattended": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether unattended upgrades are enabled.\n            ",
+          "default": false
+        },
+        "PackageMigrationsUnattended": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether unattended package migrations are enabled.\n            "
+        },
+        "UnattendedUserName": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Gets or sets a value to use for creating a user with a name for Unattended Installs\n            "
+        },
+        "UnattendedUserEmail": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Gets or sets a value to use for creating a user with an email for Unattended Installs\n            ",
+          "format": "email"
+        },
+        "UnattendedUserPassword": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Gets or sets a value to use for creating a user with a password for Unattended Installs\n            "
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsRichTextEditorSettings": {
+      "type": "object",
+      "properties": {
+        "Commands": {
+          "type": "array",
+          "description": "HTML RichText Editor TinyMCE Commands\n            ",
+          "items": {
+            "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsRichTextEditorCommand"
+          }
+        },
+        "Plugins": {
+          "type": "array",
+          "description": "HTML RichText Editor TinyMCE Plugins\n            ",
+          "items": {
+            "type": "string"
+          }
+        },
+        "CustomConfig": {
+          "type": "object",
+          "description": "HTML RichText Editor TinyMCE Custom Config\n            ",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "ValidElements": {
+          "type": "string",
+          "default": "+a[id|style|rel|data-id|data-udi|rev|charset|hreflang|dir|lang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|onclick|ondblclick|onmousedown|onmouseup|onmouseover|onmousemove|onmouseout|onkeypress|onkeydown|onkeyup],-strong/-b[class|style],-em/-i[class|style],-strike[class|style],-u[class|style],#p[id|style|dir|class|align],-ol[class|reversed|start|style|type],-ul[class|style],-li[class|style],br[class],img[id|dir|lang|longdesc|usemap|style|class|src|onmouseover|onmouseout|border|alt=|title|hspace|vspace|width|height|align|umbracoorgwidth|umbracoorgheight|onresize|onresizestart|onresizeend|rel|data-id],-sub[style|class],-sup[style|class],-blockquote[dir|style|class],-table[border=0|cellspacing|cellpadding|width|height|class|align|summary|style|dir|id|lang|bgcolor|background|bordercolor],-tr[id|lang|dir|class|rowspan|width|height|align|valign|style|bgcolor|background|bordercolor],tbody[id|class],thead[id|class],tfoot[id|class],#td[id|lang|dir|class|colspan|rowspan|width|height|align|valign|style|bgcolor|background|bordercolor|scope],-th[id|lang|dir|class|colspan|rowspan|width|height|align|valign|style|scope],caption[id|lang|dir|class|style],-div[id|dir|class|align|style],-span[class|align|style],-pre[class|align|style],address[class|align|style],-h1[id|dir|class|align|style],-h2[id|dir|class|align|style],-h3[id|dir|class|align|style],-h4[id|dir|class|align|style],-h5[id|dir|class|align|style],-h6[id|style|dir|class|align|style],hr[class|style],small[class|style],dd[id|class|title|style|dir|lang],dl[id|class|title|style|dir|lang],dt[id|class|title|style|dir|lang],object[class|id|width|height|codebase|*],param[name|value|_value|class],embed[type|width|height|src|class|*],map[name|class],area[shape|coords|href|alt|target|class],bdo[class],button[class],iframe[*],figure,figcaption"
+        },
+        "InvalidElements": {
+          "type": "string",
+          "description": "Invalid HTML elements for RichText Editor\n            ",
+          "default": "font"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsRichTextEditorCommand": {
+      "type": "object",
+      "required": [
+        "Alias",
+        "Name",
+        "Mode"
+      ],
+      "properties": {
+        "Alias": {
+          "type": "string",
+          "minLength": 1
+        },
+        "Name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "Mode": {
+          "$ref": "#/definitions/UmbracoCmsCoreModelsContentEditingRichTextEditorCommandMode"
+        }
+      }
+    },
+    "UmbracoCmsCoreModelsContentEditingRichTextEditorCommandMode": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Insert",
+        "Selection",
+        "All"
+      ],
+      "enum": [
+        "Insert",
+        "Selection",
+        "All"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsRuntimeMinificationSettings": {
+      "type": "object",
+      "properties": {
+        "UseInMemoryCache": {
+          "type": "boolean",
+          "description": "Use in memory cache\n            ",
+          "default": false
+        },
+        "CacheBuster": {
+          "description": "The cache buster type to use\n            ",
+          "default": "Version",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsRuntimeMinificationCacheBuster"
+            }
+          ]
+        },
+        "Version": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "The unique version string used if CacheBuster is 'Version'.\n            "
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsRuntimeMinificationCacheBuster": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Version",
+        "AppDomain",
+        "Timestamp"
+      ],
+      "enum": [
+        "Version",
+        "AppDomain",
+        "Timestamp"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsBasicAuthSettings": {
+      "type": "object",
+      "description": "Typed configuration options for basic authentication settings.",
+      "properties": {
+        "Enabled": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether to keep the user logged in.",
+          "default": false
+        },
+        "AllowedIPs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "SharedSecret": {
+          "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsSharedSecret"
+        },
+        "RedirectToLoginPage": {
+          "type": "boolean"
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsSharedSecret": {
+      "type": "object",
+      "properties": {
+        "HeaderName": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "default": "X-Authentication-Shared-Secret"
+        },
+        "Value": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsPackageMigrationSettings": {
+      "type": "object",
+      "description": "Typed configuration options for package migration settings.\n            ",
+      "properties": {
+        "RunSchemaAndContentMigrations": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether package migration steps that install schema and content should run.\n            ",
+          "default": true
+        },
+        "AllowComponentOverrideOfRunSchemaAndContentMigrations": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether components can override the configured value for\nRunSchemaAndContentMigrations.\n            ",
+          "default": true
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsLegacyPasswordMigrationSettings": {
+      "type": "object",
+      "description": "Typed configuration options for legacy machine key settings used for migration of members from a v8 solution.\n            ",
+      "properties": {
+        "MachineKeyDecryptionKey": {
+          "type": "string",
+          "description": "Gets or sets the decryption hex-formatted string key found in legacy web.config machineKey configuration-element.\n            ",
+          "default": ""
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationContentDashboardSettings": {
+      "type": "object",
+      "description": "Typed configuration options for content dashboard settings.\n            ",
+      "properties": {
+        "AllowContentDashboardAccessToAllUsers": {
+          "type": "boolean",
+          "description": "Gets a value indicating whether the content dashboard should be available to all users.\n            "
+        },
+        "ContentDashboardPath": {
+          "type": "string",
+          "description": "Gets the path to use when constructing the URL for retrieving data for the content dashboard.\n            ",
+          "default": "cms"
+        },
+        "ContentDashboardUrlAllowlist": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Gets the allowed addresses to retrieve data for the content dashboard.\n            ",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsHelpPageSettings": {
+      "type": "object",
+      "properties": {
+        "HelpPageUrlAllowList": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Gets or sets the allowed addresses to retrieve data for the content dashboard.\n            ",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsInstallDefaultDataSettings": {
+      "type": "object",
+      "description": "Typed configuration options for installation of default data.\n            ",
+      "properties": {
+        "InstallData": {
+          "description": "Gets or sets a value indicating whether to create default data on installation.\n            ",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsInstallDefaultDataOption"
+            }
+          ]
+        },
+        "Values": {
+          "type": "array",
+          "description": "Gets or sets a value indicating which default data (languages, data types, etc.) should be created when\nInstallData is\nset to Values or ExceptValues.\n            ",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsInstallDefaultDataOption": {
+      "type": "string",
+      "description": "An enumeration of options available for control over installation of default Umbraco data.\n            ",
+      "x-enumNames": [
+        "None",
+        "Values",
+        "ExceptValues",
+        "All"
+      ],
+      "enum": [
+        "None",
+        "Values",
+        "ExceptValues",
+        "All"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsDataTypesSettings": {
+      "type": "object",
+      "properties": {
+        "CanBeChanged": {
+          "description": "Gets or sets a value indicating if data types can be changed after they've been used.",
+          "default": "True",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/UmbracoCmsCoreConfigurationModelsDataTypeChangeMode"
+            }
+          ]
+        }
+      }
+    },
+    "UmbracoCmsCoreConfigurationModelsDataTypeChangeMode": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "True",
+        "False",
+        "FalseWithHelpText"
+      ],
+      "enum": [
+        "True",
+        "False",
+        "FalseWithHelpText"
+      ]
+    },
+    "UmbracoCmsCoreConfigurationModelsMarketplaceSettings": {
+      "type": "object",
+      "description": "Configuration options for the Marketplace.",
+      "properties": {
+        "AdditionalParameters": {
+          "type": "object",
+          "description": "Gets or sets the additional parameters that are sent to the Marketplace.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "JsonSchemaFormsDefinition": {
+      "type": "object",
+      "description": "Configurations for the Umbraco Forms package to Umbraco CMS\n            ",
+      "properties": {
+        "FormDesign": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationFormDesignSettings"
+        },
+        "Options": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationPackageOptionSettings"
+        },
+        "Security": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationSecuritySettings"
+        },
+        "FieldTypes": {
+          "$ref": "#/definitions/JsonSchemaFieldTypesDefinition"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationFormDesignSettings": {
+      "type": "object",
+      "properties": {
+        "Defaults": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationDefaultFormSettings"
+        },
+        "DisableAutomaticAdditionOfDataConsentField": {
+          "type": "boolean"
+        },
+        "DisableDefaultWorkflow": {
+          "type": "boolean"
+        },
+        "MaxNumberOfColumnsInFormGroup": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "DefaultTheme": {
+          "type": "string"
+        },
+        "DefaultEmailTemplate": {
+          "type": "string"
+        },
+        "RemoveProvidedEmailTemplate": {
+          "type": "boolean"
+        },
+        "RemoveProvidedFormTemplates": {
+          "type": "boolean"
+        },
+        "FormElementHtmlIdPrefix": {
+          "type": "string"
+        },
+        "SettingsCustomization": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationValidationSettingsCustomization"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationDefaultFormSettings": {
+      "type": "object",
+      "properties": {
+        "ManualApproval": {
+          "type": "boolean"
+        },
+        "DisableStylesheet": {
+          "type": "boolean"
+        },
+        "MarkFieldsIndicator": {
+          "$ref": "#/definitions/UmbracoFormsCoreEnumsFormFieldIndication"
+        },
+        "Indicator": {
+          "type": "string"
+        },
+        "RequiredErrorMessage": {
+          "type": "string"
+        },
+        "InvalidErrorMessage": {
+          "type": "string"
+        },
+        "ShowValidationSummary": {
+          "type": "boolean"
+        },
+        "HideFieldValidationLabels": {
+          "type": "boolean"
+        },
+        "MessageOnSubmit": {
+          "type": "string"
+        },
+        "StoreRecordsLocally": {
+          "type": "boolean"
+        },
+        "AutocompleteAttribute": {
+          "type": "string"
+        },
+        "DaysToRetainSubmittedRecordsFor": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "DaysToRetainApprovedRecordsFor": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "UmbracoFormsCoreEnumsFormFieldIndication": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "NoIndicator",
+        "MarkMandatoryFields",
+        "MarkOptionalFields"
+      ],
+      "enum": [
+        "NoIndicator",
+        "MarkMandatoryFields",
+        "MarkOptionalFields"
+      ]
+    },
+    "UmbracoFormsCoreConfigurationValidationSettingsCustomization": {
+      "type": "object",
+      "properties": {
+        "DataSourceTypes": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationProviderSettingsCustomization"
+        },
+        "FieldTypes": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationProviderSettingsCustomization"
+        },
+        "PrevalueSourceTypes": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationProviderSettingsCustomization"
+        },
+        "WorkflowTypes": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationProviderSettingsCustomization"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationProviderSettingsCustomization": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationProviderSettingsCustomizationDetail"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationProviderSettingsCustomizationDetail": {
+      "type": "object",
+      "properties": {
+        "IsHidden": {
+          "type": "boolean"
+        },
+        "DefaultValue": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "IsReadOnly": {
+          "type": "boolean"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationPackageOptionSettings": {
+      "type": "object",
+      "properties": {
+        "IgnoreWorkFlowsOnEdit": {
+          "type": "string"
+        },
+        "ExecuteWorkflowAsync": {
+          "type": "string"
+        },
+        "AllowEditableFormSubmissions": {
+          "type": "boolean"
+        },
+        "AppendQueryStringOnRedirectAfterFormSubmission": {
+          "type": "boolean"
+        },
+        "CultureToUseWhenParsingDatesForBackOffice": {
+          "type": "string"
+        },
+        "TriggerConditionsCheckOn": {
+          "type": "string"
+        },
+        "ScheduledRecordDeletion": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationScheduledRecordDeletionSettings"
+        },
+        "DisableRecordIndexing": {
+          "type": "boolean"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationScheduledRecordDeletionSettings": {
+      "type": "object",
+      "properties": {
+        "Enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "FirstRunTime": {
+          "type": "string"
+        },
+        "Period": {
+          "type": "string",
+          "format": "duration",
+          "default": "1.00:00:00"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationSecuritySettings": {
+      "type": "object",
+      "properties": {
+        "DisallowedFileUploadExtensions": {
+          "type": "string"
+        },
+        "EnableAntiForgeryToken": {
+          "type": "boolean"
+        },
+        "SavePlainTextPasswords": {
+          "type": "boolean"
+        },
+        "DisableFileUploadAccessProtection": {
+          "type": "boolean"
+        },
+        "ManageSecurityWithUserGroups": {
+          "type": "boolean"
+        },
+        "GrantAccessToNewFormsForUserGroups": {
+          "type": "string"
+        },
+        "DefaultUserAccessToNewForms": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationFormAccess"
+        },
+        "FormsApiKey": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "EnableAntiForgeryTokenForFormsApi": {
+          "type": "boolean"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationFormAccess": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Grant",
+        "Deny"
+      ],
+      "enum": [
+        "Grant",
+        "Deny"
+      ]
+    },
+    "JsonSchemaFieldTypesDefinition": {
+      "type": "object",
+      "description": "Configurations for the Umbraco Forms Field Types\n            ",
+      "properties": {
+        "DatePicker": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationDatePickerSettings"
+        },
+        "Recaptcha2": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationRecaptcha2Settings"
+        },
+        "Recaptcha3": {
+          "$ref": "#/definitions/UmbracoFormsCoreConfigurationRecaptcha3Settings"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationDatePickerSettings": {
+      "type": "object",
+      "properties": {
+        "DatePickerYearRange": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationRecaptcha2Settings": {
+      "type": "object",
+      "properties": {
+        "PublicKey": {
+          "type": "string"
+        },
+        "PrivateKey": {
+          "type": "string"
+        }
+      }
+    },
+    "UmbracoFormsCoreConfigurationRecaptcha3Settings": {
+      "type": "object",
+      "properties": {
+        "SiteKey": {
+          "type": "string"
+        },
+        "PrivateKey": {
+          "type": "string"
+        }
+      }
+    },
+    "JsonSchemaDeployDefinition": {
+      "type": "object",
+      "description": "Configurations for the Umbraco Deploy package to Umbraco CMS\n            ",
+      "properties": {
+        "Settings": {
+          "$ref": "#/definitions/UmbracoDeployCoreConfigurationDeployConfigurationDeploySettings"
+        },
+        "Project": {
+          "$ref": "#/definitions/UmbracoDeployCoreConfigurationDeployProjectConfigurationDeployProjectConfig"
+        },
+        "Debug": {
+          "$ref": "#/definitions/UmbracoDeployCoreConfigurationDebugConfigurationDebugSettings"
+        }
+      }
+    },
+    "UmbracoDeployCoreConfigurationDeployConfigurationDeploySettings": {
+      "type": "object",
+      "properties": {
+        "ApiKey": {
+          "type": "string"
+        },
+        "ExcludedEntityTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RelationTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UmbracoDeployCoreConfigurationDeployConfigurationRelationTypeSetting"
+          }
+        },
+        "ValueConnectors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UmbracoDeployCoreConfigurationDeployConfigurationValueConnectorSetting"
+          }
+        },
+        "Edition": {
+          "$ref": "#/definitions/UmbracoDeployCoreConfigurationEdition"
+        },
+        "Kabum": {
+          "type": "string"
+        },
+        "SessionTimeout": {
+          "type": "string",
+          "format": "duration"
+        },
+        "SourceDeployTimeout": {
+          "type": "string",
+          "format": "duration"
+        },
+        "DatabaseCommandTimeout": {
+          "type": "string",
+          "format": "duration"
+        },
+        "EnableSignatureCacheReads": {
+          "type": "boolean"
+        },
+        "HttpClientTimeout": {
+          "type": "string",
+          "format": "duration"
+        },
+        "DiskOperationsTimeout": {
+          "type": "string",
+          "format": "duration"
+        },
+        "IgnoreBrokenDependenciesBehavior": {
+          "$ref": "#/definitions/UmbracoDeployCoreConfigurationDeployConfigurationIgnoreBrokenDependenciesBehavior"
+        },
+        "TransferFormsAsContent": {
+          "type": "boolean"
+        },
+        "TransferDictionaryAsContent": {
+          "type": "boolean"
+        },
+        "AllowMembersDeploymentOperations": {
+          "$ref": "#/definitions/UmbracoDeployCoreConfigurationDeployConfigurationMembersDeploymentOperations"
+        },
+        "TransferMemberGroupsAsContent": {
+          "type": "boolean"
+        },
+        "AcceptInvalidCertificates": {
+          "type": "boolean"
+        },
+        "ExportMemberGroups": {
+          "type": "boolean"
+        },
+        "AllowDomainsDeploymentOperations": {
+          "$ref": "#/definitions/UmbracoDeployCoreConfigurationDeployConfigurationDomainsDeploymentOperations"
+        },
+        "ReloadMemoryCacheFollowingDiskReadOperation": {
+          "type": "boolean"
+        },
+        "PreferLocalDbConnectionString": {
+          "type": "boolean"
+        },
+        "UseDatabaseTransferQueue": {
+          "type": "boolean"
+        },
+        "SourceDeployBatchSize": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        }
+      }
+    },
+    "UmbracoDeployCoreConfigurationDeployConfigurationRelationTypeSetting": {
+      "type": "object",
+      "properties": {
+        "Alias": {
+          "type": "string"
+        },
+        "Mode": {
+          "$ref": "#/definitions/UmbracoDeployCoreCoreRelationMode"
+        }
+      }
+    },
+    "UmbracoDeployCoreCoreRelationMode": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Exclude",
+        "Weak",
+        "Strong"
+      ],
+      "enum": [
+        "Exclude",
+        "Weak",
+        "Strong"
+      ]
+    },
+    "UmbracoDeployCoreConfigurationDeployConfigurationValueConnectorSetting": {
+      "type": "object",
+      "properties": {
+        "Alias": {
+          "type": "string"
+        },
+        "TypeName": {
+          "type": "string"
+        }
+      }
+    },
+    "UmbracoDeployCoreConfigurationEdition": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Default",
+        "BackOfficeOnly"
+      ],
+      "enum": [
+        "Default",
+        "BackOfficeOnly"
+      ]
+    },
+    "UmbracoDeployCoreConfigurationDeployConfigurationIgnoreBrokenDependenciesBehavior": {
+      "type": "string",
+      "description": "",
+      "x-enumFlags": true,
+      "x-enumNames": [
+        "None",
+        "Restore",
+        "Transfer",
+        "All"
+      ],
+      "enum": [
+        "None",
+        "Restore",
+        "Transfer",
+        "All"
+      ]
+    },
+    "UmbracoDeployCoreConfigurationDeployConfigurationMembersDeploymentOperations": {
+      "type": "string",
+      "description": "",
+      "x-enumFlags": true,
+      "x-enumNames": [
+        "None",
+        "Restore",
+        "Transfer",
+        "All"
+      ],
+      "enum": [
+        "None",
+        "Restore",
+        "Transfer",
+        "All"
+      ]
+    },
+    "UmbracoDeployCoreConfigurationDeployConfigurationDomainsDeploymentOperations": {
+      "type": "string",
+      "description": "",
+      "x-enumFlags": true,
+      "x-enumNames": [
+        "None",
+        "Culture",
+        "AbsolutePath",
+        "Hostname",
+        "All"
+      ],
+      "enum": [
+        "None",
+        "Culture",
+        "AbsolutePath",
+        "Hostname",
+        "All"
+      ]
+    },
+    "UmbracoDeployCoreConfigurationDeployProjectConfigurationDeployProjectConfig": {
+      "type": "object",
+      "properties": {
+        "CurrentWorkspaceName": {
+          "type": "string"
+        },
+        "Workspaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UmbracoDeployCoreConfigurationDeployProjectConfigurationWorkspace"
+          }
+        }
+      }
+    },
+    "UmbracoDeployCoreConfigurationDeployProjectConfigurationWorkspace": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "type": "string",
+          "format": "guid"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string"
+        },
+        "Url": {
+          "type": "string"
+        }
+      }
+    },
+    "UmbracoDeployCoreConfigurationDebugConfigurationDebugSettings": {
+      "type": "object",
+      "properties": {
+        "IsDebug": {
+          "type": "boolean"
+        },
+        "IsSqlAzure": {
+          "type": "boolean"
+        },
+        "EnvironmentId": {
+          "type": "string"
+        },
+        "EnvironmentName": {
+          "type": "string"
+        },
+        "IsRunningCloud": {
+          "type": "boolean"
+        },
+        "IsRunningHosted": {
+          "type": "boolean"
+        },
+        "PortalUrl": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "patternProperties": {
+    "^WebOptimizer$": {
+      "$ref": "#/definitions/webOptimizer"
+    },
+    "^webOptimizer$": {
+      "$ref": "#/definitions/webOptimizer"
+    },
+    "^weboptimizer$": {
+      "$ref": "#/definitions/webOptimizer"
+    },
+    "^(cdn|Cdn)$": {
+      "$ref": "#/definitions/cdn"
+    },
+    "^(pwa|PWA|Pwa)$": {
+      "$ref": "#/definitions/pwa"
+    },
+    "^(ElmahIo|Elmahio|elmahIo|elmahio)$": {
+      "$ref": "#/definitions/ElmahIo"
+    },
+    "^(nlog|Nlog|NLog)$": {
+      "$ref": "#/definitions/NLog"
+    },
+    "^(Umbraco|umbraco)$": {
+      "$ref": "#/definitions/umbraco"
+    }
+  },
+  "properties": {
+    "Kestrel": {
+      "$ref": "#/definitions/kestrel"
+    },
+    "Logging": {
+      "$ref": "#/definitions/logging"
+    },
+    "AllowedHosts": {
+      "$ref": "#/definitions/allowedHosts"
+    },
+    "ConnectionStrings": {
+      "$ref": "#/definitions/connectionStrings"
+    },
+    "Umbraco": {
+      "description": "Gets or sets the Umbraco\n            ",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/JsonSchemaUmbracoDefinition"
+        }
+      ]
+    }
+  },
+  "title": "JsonSchemaAppSettings",
+  "type": "object"
+}

--- a/uSync.Migrations.Tests/uSync.Migrations.Tests.csproj
+++ b/uSync.Migrations.Tests/uSync.Migrations.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
@@ -12,9 +12,9 @@
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
 		<PackageReference Include="coverlet.collector" Version="3.0.2" />
-		<PackageReference Include="Umbraco.Cms.Tests" Version="10.0.0" />
-		<PackageReference Include="Umbraco.Cms.Tests.Integration" Version="10.0.0" />
-		<PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.0.0" />
+		<PackageReference Include="Umbraco.Cms.Tests" Version="10.4.0" />
+		<PackageReference Include="Umbraco.Cms.Tests.Integration" Version="10.4.0" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.4.0" />
 
 	</ItemGroup>
 

--- a/uSync.Migrations/Composing/SyncMigrationsComposer.cs
+++ b/uSync.Migrations/Composing/SyncMigrationsComposer.cs
@@ -8,6 +8,8 @@ using uSync.Migrations.Configuration;
 using uSync.Migrations.Configuration.Models;
 using uSync.Migrations.Handlers;
 using uSync.Migrations.Migrators;
+using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+using uSync.Migrations.Migrators.BlockGrid.Extensions;
 using uSync.Migrations.Notifications;
 using uSync.Migrations.Services;
 using uSync.Migrations.Validation;
@@ -38,9 +40,16 @@ public static class SyncMigrationsBuilderExtensions
             return builder;
         }
 
+        builder.Services.AddSingleton<GridConventions>();
+
         builder
             .WithCollectionBuilder<SyncPropertyMigratorCollectionBuilder>()
                 .Append(builder.TypeLoader.GetTypes<ISyncPropertyMigrator>());
+
+        builder
+            .WithCollectionBuilder<SyncBlockMigratorCollectionBuilder>()
+                .Add(() => builder.TypeLoader.GetTypes<ISyncBlockMigrator>());
+        
 
         builder.Services.AddTransient<ISyncMigrationFileService, SyncMigrationFileService>();
 

--- a/uSync.Migrations/Composing/UmbracoBuilderExtensions.cs
+++ b/uSync.Migrations/Composing/UmbracoBuilderExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Umbraco.Cms.Core.DependencyInjection;
 
+using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+
 namespace uSync.Migrations.Composing;
 
 public static class UmbracoBuilderExtensions
@@ -9,4 +11,7 @@ public static class UmbracoBuilderExtensions
 
     public static SyncMigrationHandlerCollectionBuilder SyncMigrationHandlers(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<SyncMigrationHandlerCollectionBuilder>();
+
+    public static SyncBlockMigratorCollectionBuilder SyncBlockMigrators(this IUmbracoBuilder builder)
+        => builder.WithCollectionBuilder<SyncBlockMigratorCollectionBuilder>();
 }

--- a/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core.Composing;
 
 using uSync.Migrations.Composing;
 using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Migrators.BlockGrid;
 using uSync.Migrations.Migrators.Optional;
 
 namespace uSync.Migrations.Configuration.CoreProfiles;
@@ -19,22 +20,23 @@ internal class BlockMigrationProfile : ISyncMigrationProfile
 
     public int Order => 200;
 
-	public string Name => "Nested Content To BlockLists";
+	public string Name => "Convert to BlockLists and BlockGrid";
 
     public string Icon => "icon-brick color-green";
 
-    public string Description => "Convert Nested content to BlockList (Experimental!)";
+    public string Description => "Convert Nested content and Grid to BlockList and BlockGrid  (Experimental!)";
 
     public MigrationOptions Options => new MigrationOptions
     {
         Group = "Convert",
-        Source = "uSync/grid-v9",
-        Target = $"{uSyncMigrations.MigrationFolder}/blocks",
-        Handlers = _migrationHandlers.SelectGroup(8, string.Empty),
+        Source = "uSync/v9",
+		Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
+		Handlers = _migrationHandlers.SelectGroup(8, string.Empty),
         SourceVersion = 8,
         PreferredMigrators = new Dictionary<string, string>
         {
-            { Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.NestedContent, nameof(NestedToBlockListMigrator) }
+			{ UmbConstants.PropertyEditors.Aliases.NestedContent, nameof(NestedToBlockListMigrator) },
+			{ UmbConstants.PropertyEditors.Aliases.Grid, nameof(GridToBlockGridMigrator) }
         }
     };
 }

--- a/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
@@ -28,8 +28,8 @@ internal class BlockMigrationProfile : ISyncMigrationProfile
     public MigrationOptions Options => new MigrationOptions
     {
         Group = "Convert",
-        Source = "uSync/v9",
-        Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
+        Source = "uSync/grid-v9",
+        Target = $"{uSyncMigrations.MigrationFolder}/blocks",
         Handlers = _migrationHandlers.SelectGroup(8, string.Empty),
         SourceVersion = 8,
         PreferredMigrators = new Dictionary<string, string>

--- a/uSync.Migrations/Extensions/ContentTypeExtensions.cs
+++ b/uSync.Migrations/Extensions/ContentTypeExtensions.cs
@@ -1,0 +1,74 @@
+﻿using System.Xml.Linq;
+
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+
+using uSync.Core;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Extensions;
+internal static class ContentTypeExtensions
+{
+	public static XElement MakeXMLFromNewDocType(this NewContentTypeInfo newDocType,
+		IDataTypeService dataTypeService)
+	{
+		var source = new XElement("ContentType",
+					 new XAttribute(uSyncConstants.Xml.Key, newDocType.Alias.ToGuid()),
+					 new XAttribute(uSyncConstants.Xml.Alias, newDocType.Alias),
+					 new XAttribute(uSyncConstants.Xml.Level, 1),
+					 new XElement(uSyncConstants.Xml.Info,
+						 new XElement(uSyncConstants.Xml.Name, newDocType.Name),
+						 new XElement("Icon", newDocType.Icon),
+						 new XElement("Thumbnail", "folder.png"),
+						 new XElement("Description", newDocType.Description),
+						 new XElement("AllowAtRoot", false),
+						 new XElement("IsListView", false),
+						 new XElement("Variations", "Nothing"),
+						 new XElement("IsElement", newDocType.IsElement),
+						 new XElement("Folder", newDocType.Folder ?? "")),
+					 new XElement("GenericProperties"),
+					 new XElement("Tabs",
+						 new XElement("Tab",
+							 new XElement("Key", Guid.NewGuid().ToString()),
+							 new XElement("Caption", "Block"),
+							 new XElement("Alias", "block"),
+							 new XElement("Type", "Group"),
+							 new XElement("SortOrder", 0))
+						 )
+					 );
+
+		var properties = source.Element("GenericProperties");
+		var index = 0;
+		foreach (var property in newDocType.Properties)
+		{
+			index++;
+
+			var dataType = dataTypeService.GetDataType(property.DataTypeAlias);
+			if (dataType == null) continue;
+
+			var propNode = new XElement("GenericProperty",
+			new XElement("Key", property.Name.ToGuid()),
+				new XElement("Name", property.Name),
+				new XElement("Alias", property.Alias),
+				new XElement("Definition", dataType.Key),
+				new XElement("Type", dataType.EditorAlias),
+				new XElement("Mandatory", false),
+				new XElement("Validation", ""),
+				new XElement("Description", new XCData("")),
+				new XElement("SortOrder", index),
+				new XElement("Tab", "Block", new XAttribute("Alias", "block")),
+				new XElement("Variations", "Nothing"),
+				new XElement("MandatoryMessage", ""),
+				new XElement("ValidationRegExpMessage", ""),
+				new XElement("LabelOnTop", ""));
+
+			properties.Add(propNode);
+		}
+
+		return source;
+
+
+	}
+}

--- a/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 
 using uSync.Migrations.Handlers.Shared;
 using uSync.Migrations.Models;
@@ -16,8 +17,9 @@ internal class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseH
     public ContentTypeBaseMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        ILogger<ContentTypeBaseMigrationHandler<TEntity>> logger) 
-        : base(eventAggregator, migrationFileService, logger)
+        ILogger<ContentTypeBaseMigrationHandler<TEntity>> logger,
+        IDataTypeService dataTypeService) 
+        : base(eventAggregator, migrationFileService, logger, dataTypeService)
     { }
 
     protected override void UpdatePropertyXml(XElement newProperty)

--- a/uSync.Migrations/Handlers/Eight/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeMigrationHandler.cs
@@ -2,6 +2,7 @@
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 
 using uSync.Migrations.Services;
 
@@ -16,7 +17,8 @@ internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<Con
     public ContentTypeMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        ILogger<ContentTypeMigrationHandler> logger) 
-        : base(eventAggregator, migrationFileService, logger)
+        ILogger<ContentTypeMigrationHandler> logger,
+        IDataTypeService dataTypeService) 
+        : base(eventAggregator, migrationFileService, logger, dataTypeService)
     { }
 }

--- a/uSync.Migrations/Handlers/Eight/MediaTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/MediaTypeMigrationHandler.cs
@@ -2,6 +2,7 @@
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 
 using uSync.Migrations.Services;
 
@@ -16,8 +17,9 @@ internal class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<Media
     public MediaTypeMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        ILogger<MediaTypeMigrationHandler> logger)
-        : base(eventAggregator, migrationFileService, logger)
-    {
+        ILogger<MediaTypeMigrationHandler> logger,
+		IDataTypeService dataTypeService)
+		: base(eventAggregator, migrationFileService, logger, dataTypeService)
+	{
     }
 }

--- a/uSync.Migrations/Handlers/MigrationHandlerBase.cs
+++ b/uSync.Migrations/Handlers/MigrationHandlerBase.cs
@@ -98,16 +98,37 @@ internal abstract class MigrationHandlerBase<TObject>
 
     public virtual IEnumerable<MigrationMessage> DoMigration(SyncMigrationContext context)
     {
-        return MigrateFolder(GetSourceFolder(context.SourceFolder), 0, context);
+        var messages = new List<MigrationMessage>();
+        messages.AddRange(PreDoMigration(context));
+        messages.AddRange(MigrateFolder(GetSourceFolder(context.SourceFolder), 0, context));
+        messages.AddRange(PostDoMigration(context));
+        return messages;
     }
 
+
     /// <summary>
-    ///  migrate a folder 
+    ///  so handlers can run things before main DoMigrationLoop
     /// </summary>
-    /// <remarks>
-    ///  We have to do it like this for v7 because it did level by folder structure.
-    /// </remarks>
-    private IEnumerable<MigrationMessage> MigrateFolder(string folder, int level, SyncMigrationContext context)
+    /// <param name="context"></param>
+    /// <returns></returns>
+	protected virtual IEnumerable<MigrationMessage> PreDoMigration(SyncMigrationContext context)
+		=> Enumerable.Empty<MigrationMessage>();
+
+    /// <summary>
+    ///  So Handlers can run things post main DoMigrationLoop
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns></returns>
+	protected virtual IEnumerable<MigrationMessage> PostDoMigration(SyncMigrationContext context)
+		=> Enumerable.Empty<MigrationMessage>();
+
+	/// <summary>
+	///  migrate a folder 
+	/// </summary>
+	/// <remarks>
+	///  We have to do it like this for v7 because it did level by folder structure.
+	/// </remarks>
+	private IEnumerable<MigrationMessage> MigrateFolder(string folder, int level, SyncMigrationContext context)
     {
         if (Directory.Exists(folder) == false)
         {

--- a/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 
 using uSync.Core;
 using uSync.Migrations.Handlers.Shared;
@@ -18,8 +19,9 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
     public ContentTypeBaseMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        ILogger<ContentTypeBaseMigrationHandler<TEntity>> logger)
-        : base(eventAggregator, migrationFileService, logger)
+        ILogger<ContentTypeBaseMigrationHandler<TEntity>> logger,
+        IDataTypeService dataTypeService)
+        : base(eventAggregator, migrationFileService, logger, dataTypeService)
     { }
 
     protected override (string alias, Guid key) GetAliasAndKey(XElement source)

--- a/uSync.Migrations/Handlers/Seven/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeMigrationHandler.cs
@@ -2,6 +2,7 @@
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 
 using uSync.Migrations.Handlers.Seven;
 using uSync.Migrations.Services;
@@ -17,7 +18,8 @@ internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<Con
     public ContentTypeMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        ILogger<ContentTypeMigrationHandler> logger)
-        : base(eventAggregator, migrationFileService, logger)
-    { }
+        ILogger<ContentTypeMigrationHandler> logger,
+		IDataTypeService dataTypeService)
+		: base(eventAggregator, migrationFileService, logger, dataTypeService)
+	{ }
 }

--- a/uSync.Migrations/Handlers/Seven/MediaTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/MediaTypeMigrationHandler.cs
@@ -2,6 +2,7 @@
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 
 using uSync.Migrations.Services;
 
@@ -16,7 +17,8 @@ internal class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<Media
     public MediaTypeMigrationHandler(
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
-        ILogger<MediaTypeMigrationHandler> logger)
-        : base(eventAggregator, migrationFileService, logger)
-    { }
+        ILogger<MediaTypeMigrationHandler> logger,
+		IDataTypeService dataTypeService)
+		: base(eventAggregator, migrationFileService, logger, dataTypeService)
+	{ }
 }

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/DocTypeGridEditorBlockMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/DocTypeGridEditorBlockMigrator.cs
@@ -1,0 +1,106 @@
+﻿using System.Text.RegularExpressions;
+
+using Newtonsoft.Json.Linq;
+
+using Polly;
+
+using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Extensions;
+
+using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+internal class DocTypeGridEditorBlockMigrator : ISyncBlockMigrator
+{
+	public string[] Aliases => new[] { "docType" };
+
+	/// <summary>
+	///  the DTGE doesn't generate any new content types, 
+	///  because all the content types it uses are already
+	///  in the migration.
+	/// </summary>
+	public IEnumerable<NewContentTypeInfo> AdditionalContentTypes(IGridEditorConfig editorConfig)
+		=> Enumerable.Empty<NewContentTypeInfo>();
+
+	public IEnumerable<string> GetAllowedContentTypes(IGridEditorConfig config, SyncMigrationContext context)
+	{
+		if (config?.Config.TryGetValue("allowedDocTypes", out var allowedDocTypesValue) == true
+				  && allowedDocTypesValue is JArray allowedDocTypes)
+		{
+			// dtge. 
+			var allowedDocTypeExpressions = allowedDocTypes.Values<string>().ToArray();
+			if (allowedDocTypeExpressions.Length == 0) return Enumerable.Empty<string>();
+
+			var allContentTypeAliases = context.GetContentTypeAliases();
+
+			return allContentTypeAliases
+					.Where(contentTypeAlias =>
+						allowedDocTypeExpressions.WhereNotNull()
+						.Any(allowedExpression => Regex.IsMatch(contentTypeAlias, allowedExpression, RegexOptions.IgnoreCase) == true));
+		}
+
+		return Enumerable.Empty<string>();
+	}
+
+
+
+	/// <summary>
+	///  returns the actual doctype this content value is using
+	/// </summary>
+	/// <param name="control"></param>
+	/// <returns></returns>
+	/// <exception cref="NotImplementedException"></exception>
+	public string GetContentTypeAlias(GridValue.GridControl control)
+		=> control.Value?.Value<string>("dtgeContentTypeAlias") ?? string.Empty;
+
+	/// <remarks>
+	///  for dtge - this isn't one answer to what is the content type, 
+	///  when we are looking at the config. 
+	///  
+	///  we assume that the migration already contains the content types
+	///  that are using in the DTGE so we don't actually have to pass 
+	///  things back to the migration process at this point
+	/// </remarks>
+	public string GetContentTypeAlias(IGridEditorConfig editorConfig)
+		=> string.Empty;
+
+	public string GetEditorAlias(IGridEditorConfig editor)
+		=> string.Empty;
+
+	public Dictionary<string, object> GetPropertyValues(GridValue.GridControl control, SyncMigrationContext context)
+	{
+		var propertyValues = new Dictionary<string, object>();
+
+		var contentTypeAlias = GetContentTypeAlias(control);
+		if (string.IsNullOrWhiteSpace(contentTypeAlias)) return propertyValues;
+
+		var elementValue = control.Value?.Value<JObject>("value")?
+			.ToObject<IDictionary<string, object>>();
+
+		if (elementValue == null) return propertyValues;
+
+		foreach (var (propertyAlias, value) in elementValue)
+		{
+			var editorAlias = context.GetEditorAlias(contentTypeAlias, propertyAlias);
+
+			if (editorAlias == null) continue;
+
+			var migrator = context.TryGetMigrator(editorAlias.OriginalEditorAlias);
+			var propertyValue = value;
+
+			if (migrator != null) { 
+				var property = new SyncMigrationContentProperty(
+					editorAlias.OriginalEditorAlias,
+					value?.ToString() ?? string.Empty);
+
+				propertyValue = migrator.GetContentValue(property, context);
+			}
+
+			propertyValues[propertyAlias] = propertyValue;
+		}
+
+		return propertyValues;
+	}
+}

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/DocTypeGridEditorBlockMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/DocTypeGridEditorBlockMigrator.cs
@@ -6,6 +6,7 @@ using Polly;
 
 using Umbraco.Cms.Core.Configuration.Grid;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 using uSync.Migrations.Migrators.Models;
@@ -14,6 +15,13 @@ using uSync.Migrations.Models;
 namespace uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
 internal class DocTypeGridEditorBlockMigrator : ISyncBlockMigrator
 {
+	private readonly IContentTypeService _contentTypeService;
+
+	public DocTypeGridEditorBlockMigrator(IContentTypeService contentTypeService)
+	{
+		_contentTypeService = contentTypeService;
+	}
+
 	public string[] Aliases => new[] { "docType" };
 
 	/// <summary>
@@ -39,6 +47,11 @@ internal class DocTypeGridEditorBlockMigrator : ISyncBlockMigrator
 					.Where(contentTypeAlias =>
 						allowedDocTypeExpressions.WhereNotNull()
 						.Any(allowedExpression => Regex.IsMatch(contentTypeAlias, allowedExpression, RegexOptions.IgnoreCase) == true));
+		}
+		else
+		{
+			// if its blank we have to add all element types. ?
+			return _contentTypeService.GetAll().Where((x => x.IsElement == true)).Select(x => x.Alias);
 		}
 
 		return Enumerable.Empty<string>();

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/GridBlockMigratorSimpleBase.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/GridBlockMigratorSimpleBase.cs
@@ -1,0 +1,73 @@
+﻿using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+
+using uSync.Migrations.Migrators.BlockGrid.Extensions;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+
+/// <summary>
+///  base for 'simple' grid things (like text, quote, etc) they all follow a pattern.
+/// </summary>
+public abstract class GridBlockMigratorSimpleBase
+{
+	protected readonly IShortStringHelper _shortStringHelper;
+
+	public GridBlockMigratorSimpleBase(IShortStringHelper shortStringHelper)
+	{
+		_shortStringHelper = shortStringHelper;
+	}
+
+	public abstract string GetEditorAlias(IGridEditorConfig editor);
+
+	/// <summary>
+	///  for the simple migrators we create a new doctype to try and migrate the data into.
+	/// </summary>
+	/// <param name="editorConfig"></param>
+	/// <returns></returns>
+	public IEnumerable<NewContentTypeInfo> AdditionalContentTypes(IGridEditorConfig editor)
+	{
+		var alias = this.GetContentTypeAlias(editor);
+
+		return new NewContentTypeInfo
+		{
+			Key = alias.ToGuid(),
+			Alias = alias,
+			Name = editor.Name ?? editor.Alias,
+			Description = $"Converted from Grid {editor.Name} element",
+			Icon = $"{editor.Icon ?? "icon-book"} color-purple",
+			IsElement = true,
+			Folder = "BlockGrid/Elements",
+			Properties = new List<NewContentTypeProperty>
+			{
+				new NewContentTypeProperty
+				{
+					Alias = editor.Alias,
+					Name = editor.Name ?? editor.Alias,
+					DataTypeAlias = this.GetEditorAlias(editor)
+				}
+			}
+		}.AsEnumerableOfOne();
+	}
+
+	public virtual IEnumerable<string> GetAllowedContentTypes(IGridEditorConfig config, SyncMigrationContext context)
+		=> GetContentTypeAlias(config).AsEnumerableOfOne();
+
+	public virtual string GetContentTypeAlias(GridValue.GridControl control)
+		=> control.Editor.Alias.GetBlockElementContentTypeAlias(_shortStringHelper);
+
+	public virtual string GetContentTypeAlias(IGridEditorConfig editorConfig)
+		=> editorConfig.Alias.GetBlockElementContentTypeAlias(_shortStringHelper);
+
+	public virtual Dictionary<string, object> GetPropertyValues(GridValue.GridControl control, SyncMigrationContext context)
+	{
+		return new Dictionary<string, object>
+		{
+			{ control.Editor.Alias, control.Value ?? string.Empty }
+		};
+	}
+}
+
+

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/GridDefaultBlockMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/GridDefaultBlockMigrator.cs
@@ -1,0 +1,18 @@
+﻿using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.Strings;
+
+namespace uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+
+/// <summary>
+///  default migrator, what happens if we can't find anything. 
+/// </summary>
+public class GridDefaultBlockMigrator : GridBlockMigratorSimpleBase, ISyncBlockMigrator
+{
+	public GridDefaultBlockMigrator(IShortStringHelper shortStringHelper) : base(shortStringHelper)
+	{}
+
+	public string[] Aliases => new[] { "___default___" };
+	public override string GetEditorAlias(IGridEditorConfig editor) => "Label (string)";
+}
+
+

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/GridMediaBlockMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/GridMediaBlockMigrator.cs
@@ -1,0 +1,67 @@
+﻿using Newtonsoft.Json;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+
+using uSync.Migrations.Composing;
+using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+
+public class GridMediaBlockMigrator : GridBlockMigratorSimpleBase, ISyncBlockMigrator
+{
+	private readonly SyncPropertyMigratorCollection _propertyMigrators;
+	public GridMediaBlockMigrator(IShortStringHelper shortStringHelper, SyncPropertyMigratorCollection propertyMigrators)
+		 : base(shortStringHelper)
+	{
+		_propertyMigrators = propertyMigrators;
+	}
+
+	public string[] Aliases => new[] { "media" };
+
+	public override string GetEditorAlias(IGridEditorConfig editor) => "Media Picker";
+
+	public override Dictionary<string, object> GetPropertyValues(GridValue.GridControl control, SyncMigrationContext context)
+	{
+		var properties = new Dictionary<string, object>();
+		if (control.Value == null) return properties;
+
+		// 
+		if (UdiParser.TryParse(control.Value?.Value<string>("udi"), out Udi udi) && udi is GuidUdi guidUdi) {
+
+			var values = new
+			{
+				key = Guid.NewGuid(),
+				mediaKey = guidUdi.Guid
+			}.AsEnumerableOfOne();
+
+			properties.Add("media", JsonConvert.SerializeObject(values));
+		}
+		return properties;
+
+		//var mediaPickerMigrator = _propertyMigrators.FirstOrDefault(x => x.Editors
+		//	.InvariantContains(UmbConstants.PropertyEditors.Aliases.MediaPicker));
+
+		//if (mediaPickerMigrator != null)
+		//{
+		//	var contentValue = mediaPickerMigrator.GetContentValue(new SyncMigrationContentProperty
+		//		(UmbConstants.PropertyEditors.Aliases.MediaPicker3, control.Value.ToString()), context);
+
+		//	properties.Add("media", contentValue);
+		//}
+		//else
+		//{
+		//	var mediaUdi = control.Value?.Value<string>("udi");
+		//	if (mediaUdi != null) properties.Add("media", mediaUdi);
+		//}
+
+		//return properties;
+
+	}
+}
+
+

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/GridRTEBlockMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/GridRTEBlockMigrator.cs
@@ -1,0 +1,17 @@
+﻿using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.Strings;
+
+namespace uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+
+public class GridRTEBlockMigrator : GridBlockMigratorSimpleBase, ISyncBlockMigrator
+{
+
+	public GridRTEBlockMigrator(IShortStringHelper shortStringHelper)
+		: base(shortStringHelper) { }
+
+	public string[] Aliases => new[] { "rte" };
+
+	public override string GetEditorAlias(IGridEditorConfig editor) => "Richtext Editor";
+}
+
+

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/GridTextstringBlockMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/GridTextstringBlockMigrator.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+
+using Org.BouncyCastle.Math.EC.Rfc7748;
+
+using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.Strings;
+
+using uSync.Core.Mapping;
+using uSync.Migrations.Services;
+
+namespace uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+
+/// <summary>
+///  these are the 'simple' grid migrators, they make some assuptions (like a textstring datatype exists)
+///  but they allow us to get the basics of what a grid element will look like when we are in the block grid.
+/// </summary>
+
+public class GridTextstringBlockMigrator : GridBlockMigratorSimpleBase, ISyncBlockMigrator
+{
+	public GridTextstringBlockMigrator(IShortStringHelper shortStringHelper)
+		: base(shortStringHelper)
+	{ }
+
+	public string[] Aliases => new[] { "textstring" };
+
+	public override string GetEditorAlias(IGridEditorConfig editor) => "Textstring";
+}
+
+

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/ISyncBlockMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/ISyncBlockMigrator.cs
@@ -1,0 +1,74 @@
+﻿using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Extensions;
+
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+public interface ISyncBlockMigrator
+{
+	// the grid aliases this block migrator work for., 
+	string[] Aliases { get; }
+
+	IEnumerable<NewContentTypeInfo> AdditionalContentTypes(IGridEditorConfig editorConfig);
+	IEnumerable<string> GetAllowedContentTypes(IGridEditorConfig config, SyncMigrationContext context);
+
+	string GetContentTypeAlias(GridValue.GridControl control);
+	string GetContentTypeAlias(IGridEditorConfig editorConfig);
+	string GetEditorAlias(IGridEditorConfig editor);
+
+
+	Dictionary<string, object> GetPropertyValues(GridValue.GridControl control, SyncMigrationContext context);
+}
+
+
+public class SyncBlockMigratorCollectionBuilder
+	: LazyCollectionBuilderBase<SyncBlockMigratorCollectionBuilder, SyncBlockMigratorCollection, ISyncBlockMigrator>
+{
+	protected override SyncBlockMigratorCollectionBuilder This => this;
+}
+
+
+public class SyncBlockMigratorCollection
+	: BuilderCollectionBase<ISyncBlockMigrator>
+{
+	public SyncBlockMigratorCollection(Func<IEnumerable<ISyncBlockMigrator>> items) : base(items)
+	{}
+
+	public ISyncBlockMigrator? GetMigrator(string? gridAlias)
+	{
+		if (gridAlias == null) return null;
+		return this.FirstOrDefault(x => x.Aliases.InvariantContains(gridAlias));
+	}
+
+	public ISyncBlockMigrator? GetDefaultMigrator()
+		=> GetMigrator("___default___");
+
+	public ISyncBlockMigrator? GetMigrator(GridValue.GridEditor gridEditor)
+	{
+		var migrator = GetMigrator(gridEditor?.View);
+		if (migrator != null) return migrator;
+
+		migrator = GetMigrator(gridEditor?.Alias);
+		if (migrator != null) return migrator;
+
+		return GetDefaultMigrator();
+	}
+
+	public ISyncBlockMigrator? GetMigrator(IGridEditorConfig editorConfig)
+	{
+		// we look in a number of places when in a grid editor
+
+		// 1. view
+		var migrator = GetMigrator(editorConfig?.View);
+		if (migrator != null) return migrator;
+
+		// 2. alias
+		migrator = GetMigrator(editorConfig?.Alias);
+		if (migrator != null) return migrator;
+
+		// if it goes wrong , we return the default, and everything becomes a label.
+		return GetDefaultMigrator();	
+	}
+}

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/ISyncBlockMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/ISyncBlockMigrator.cs
@@ -18,7 +18,6 @@ public interface ISyncBlockMigrator
 	string GetContentTypeAlias(IGridEditorConfig editorConfig);
 	string GetEditorAlias(IGridEditorConfig editor);
 
-
 	Dictionary<string, object> GetPropertyValues(GridValue.GridControl control, SyncMigrationContext context);
 }
 

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigBlockHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigBlockHelper.cs
@@ -1,0 +1,119 @@
+﻿using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
+
+using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+using uSync.Migrations.Migrators.BlockGrid.Extensions;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Config;
+internal class GridToBlockGridConfigBlockHelper
+{
+    private readonly SyncBlockMigratorCollection _syncBlockMigrators;
+
+	public GridToBlockGridConfigBlockHelper(
+		SyncBlockMigratorCollection syncBlockMigrators)
+	{
+		_syncBlockMigrators = syncBlockMigrators;
+	}
+
+	/// <summary>
+	///  adds any datatypes we need to make the grid. 
+	/// </summary>
+	/// <param name="context"></param>
+	public void AddConfigDataTypes(GridToBlockGridConfigContext gridToBlockContext, SyncMigrationContext context)
+    {
+        // add each thing in the config, as a 'new' doctype
+        // the content handler will then either create or ignore these if they are already there. 
+        foreach (var editor in gridToBlockContext.GridConfig.EditorsConfig.Editors)
+        {
+            if (editor.View == null) continue;
+
+            var blockMigrator = _syncBlockMigrators.GetMigrator(editor);
+            if (blockMigrator == null) continue;
+
+            var additionalContentTypes = blockMigrator.AdditionalContentTypes(editor);
+            if (additionalContentTypes == null) continue;
+
+            foreach(var newContentType in additionalContentTypes)
+            {
+                context.AddNewDocType(newContentType);
+                context.AddContentTypeKey(newContentType.Alias, newContentType.Key);
+            }
+        }
+    }
+
+    public void AddContentBlocks(GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context)
+    {
+        // add the grid elements to the block config 
+        var gridContentTypeKeys = AddGridContentBlocksToConfig(gridBlockContext.GridConfig, gridBlockContext, context);
+
+        // now add the editor to the right bit of the blocks.
+        AddEditorsToAllowedAreasInBlocks(gridContentTypeKeys, gridBlockContext, context);
+
+    }
+
+
+    private void AddEditorsToAllowedAreasInBlocks(Dictionary<string, Guid[]> gridContentTypeKeys, GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext migrationContext)
+    {
+        foreach (var (area, gridEditorAliases) in gridBlockContext.AllowedEditors)
+        {
+            var allowedElementTypes = new List<Guid>();
+            foreach (var gridEditorAlias in gridEditorAliases)
+            {
+                if (gridContentTypeKeys.ContainsKey(gridEditorAlias))
+                {
+                    allowedElementTypes.AddRange(gridContentTypeKeys[gridEditorAlias]);
+                }
+            }
+
+            var allowedBlocks = gridBlockContext.ContentBlocks
+                .Where(x => allowedElementTypes.Contains(x.ContentElementTypeKey))
+                .ToArray();
+
+            if (!allowedBlocks.Any()) continue;
+
+            if (area == gridBlockContext.RootArea)
+            {
+                foreach (var block in allowedBlocks)
+                {
+                    block.AllowAtRoot = true;
+                }
+                continue;
+            }
+
+            area.SpecifiedAllowance = allowedBlocks
+                .Select(x => new BlockGridConfiguration.BlockGridAreaConfigurationSpecifiedAllowance
+                {
+                    ElementTypeKey = x.ContentElementTypeKey,
+                }).ToArray();
+        }
+    }
+
+    /// <summary>
+    ///  returns all the allowed/known content types for a section of the grid.
+    /// </summary>
+    private Dictionary<string, Guid[]> AddGridContentBlocksToConfig(IGridConfig gridConfig, GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context)
+    {
+        var referencedEditors = gridBlockContext.AllEditors().ToList();
+
+        var allowedContentTypes = new Dictionary<string, Guid[]>();
+
+        foreach (var editor in gridConfig.EditorsConfig.Editors
+            .Where(x => referencedEditors.Contains("*") ||
+            referencedEditors.InvariantContains(x.Alias)))
+        {
+            var blocks = editor.ConvertToBlockGridBlocks(context, 
+                _syncBlockMigrators,
+                gridBlockContext.GridBlocksGroup.Key);
+
+            gridBlockContext.ContentBlocks.AddRange(blocks);
+
+            allowedContentTypes[editor.Alias] = blocks.Select(x => x.ContentElementTypeKey).ToArray();
+        }
+
+        return allowedContentTypes;
+    }
+
+
+}

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigContext.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigContext.cs
@@ -1,0 +1,99 @@
+﻿using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
+
+using uSync.Migrations.Migrators.BlockGrid.Extensions;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Config;
+
+/// <summary>
+///  lets us pass around the context of our conversion of the block grid. 
+/// </summary>
+/// <remarks>
+///  this makes it much easier to block up the code (espeically around layout/templates)
+///  
+///  i think in a perfect world we will be able to refactor this context out of existantce. 
+/// </remarks>
+internal class GridToBlockGridConfigContext
+{
+    public GridConfiguration GridConfiguration { get; }
+    public IGridConfig GridConfig { get; }
+    public int? GridColumns { get; }
+
+    public List<BlockGridConfiguration.BlockGridGroupConfiguration> BlockGroups { get; } = new();
+    public Dictionary<string, BlockGridConfiguration.BlockGridBlockConfiguration> LayoutBlocks { get; } = new();
+    public List<BlockGridConfiguration.BlockGridBlockConfiguration> ContentBlocks { get; } = new();
+
+    public BlockGridConfiguration.BlockGridAreaConfiguration RootArea { get; } = new();
+    public Dictionary<BlockGridConfiguration.BlockGridAreaConfiguration, IEnumerable<string>> AllowedEditors { get; } = new();
+    public Dictionary<BlockGridConfiguration.BlockGridAreaConfiguration, IEnumerable<string>> AllowedLayouts { get; } = new();
+
+	public BlockGridConfiguration.BlockGridGroupConfiguration LayoutsGroup { get; } = new()
+	{
+		Key = $"group_{nameof(LayoutsGroup)}".ToGuid(),
+		Name = "Layouts"
+	};
+	public BlockGridConfiguration.BlockGridGroupConfiguration GridBlocksGroup { get; } = new()
+	{
+		Key = $"group_{nameof(GridBlocksGroup)}".ToGuid(),
+		Name = "Grid Blocks"
+	};
+
+
+	public GridToBlockGridConfigContext(GridConfiguration gridConfiguration, IGridConfig gridConfig)
+    {
+        GridConfig = gridConfig;
+        GridConfiguration = gridConfiguration;
+        GridColumns = gridConfiguration.GetGridColumns();
+
+        BlockGroups.Add(LayoutsGroup);
+        BlockGroups.Add(GridBlocksGroup);
+    }
+
+    public IEnumerable<string> GetAllowedLayouts(BlockGridConfiguration.BlockGridAreaConfiguration area)
+    {
+        if (AllowedLayouts.TryGetValue(area, out var allowed))
+            return allowed;
+
+        return Enumerable.Empty<string>();
+    }
+
+    public IEnumerable<string> GetRootAllowedLayouts()
+        => GetAllowedLayouts(RootArea);
+
+    public void AppendToRootLayouts(IEnumerable<string> allowed)
+    {
+        var rootAllowed = GetRootAllowedLayouts().ToList();
+        rootAllowed.AddRange(allowed);
+        AllowedLayouts[RootArea] = rootAllowed;
+    }
+
+    public IEnumerable<string> AllEditors()
+        => AllowedEditors.SelectMany(x => x.Value).Distinct();
+
+    public BlockGridConfiguration ConvertToBlockGridConfiguration()
+    {
+        // layoutConfig.ToResult();
+        var result = new BlockGridConfiguration();
+        result.GridColumns = GridColumns;
+
+        result.Blocks = ContentBlocks
+            .Union(LayoutBlocks.Values)
+            .Where(x => x.ContentElementTypeKey != Guid.Empty)
+            .ToArray();
+
+        var referencedGroupKeys = result.Blocks
+            .Select(x => x.GroupKey).Distinct().WhereNotNull()
+            .Select(x => Guid.TryParse(x, out var k) ? k : Guid.Empty)
+            .Distinct()
+            .ToArray();
+
+        result.BlockGroups = BlockGroups
+            .Where(x => referencedGroupKeys.Contains(x.Key))
+            .ToArray();
+
+
+        return result;
+
+    }
+}

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutBlockHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutBlockHelper.cs
@@ -1,0 +1,254 @@
+﻿using System.Data;
+
+using Newtonsoft.Json.Linq;
+
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
+
+using uSync.Migrations.Migrators.BlockGrid.Extensions;
+using uSync.Migrations.Migrators.BlockGrid.Models;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Config;
+
+
+internal class GridToBlockGridConfigLayoutBlockHelper
+{
+    private readonly GridConventions _conventions;
+
+    public GridToBlockGridConfigLayoutBlockHelper(GridConventions conventions)
+    {
+        _conventions = conventions;
+    }
+
+    public void AddLayoutBlocks(GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context)
+    {
+        // gather all the layout blocks we can from the templates 
+        // and layouts sections of the config. 
+        GetTemplateLayouts(gridBlockContext.GridConfiguration.GetItemBlock("templates"), gridBlockContext, context);
+
+        GetLayoutLayouts(gridBlockContext.GridConfiguration.GetItemBlock("layouts"), gridBlockContext, context);
+
+        AddContentTypesForLayoutBlocks(gridBlockContext, context);
+    }
+
+    private void GetTemplateLayouts(JToken? templates, GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context)
+    {
+        if (templates == null) return;
+
+        var gridTemplateConfiguration = templates
+                .ToObject<IEnumerable<GridTemplateConfiguration>>() ?? Enumerable.Empty<GridTemplateConfiguration>();
+
+        foreach (var template in gridTemplateConfiguration)
+        {
+            if (template.Sections == null) continue;
+
+            var areas = new List<BlockGridConfiguration.BlockGridAreaConfiguration>();
+
+            foreach (var (section, index) in template.Sections.Select((x, i) => (x, i)))
+            {
+                var allowed = new List<string>();
+                if (section.Allowed?.Any() == true)
+                {
+                    allowed.AddRange(section.Allowed);
+                }
+                else
+                {
+                    allowed.Add("*");
+                }
+
+                if (section.Grid == gridBlockContext.GridColumns)
+                {
+                    gridBlockContext.AppendToRootLayouts(allowed);
+                    continue;
+                }
+
+                var area = new BlockGridConfiguration.BlockGridAreaConfiguration
+                {
+                    Alias = $"area_{index}",
+                    ColumnSpan = section.Grid
+                };
+
+                var alias = _conventions.GridAreaConfigAlias(area.Alias);
+                area.Key = alias.ToGuid();
+
+                areas.Add(area);
+
+                if (allowed.Any())
+                {
+                    gridBlockContext.AllowedLayouts[area] = allowed;
+                }
+            }
+
+            if (areas.Count == 0) continue;
+
+            if (gridBlockContext.GridColumns == template.Sections.Sum(x => x.Grid))
+            {
+                var allowed = new List<string>();
+                foreach (var area in areas)
+                {
+                    allowed.AddRange(gridBlockContext.GetAllowedLayouts(area));
+                }
+
+                allowed.AddRange(gridBlockContext.GetRootAllowedLayouts());
+
+                continue;
+            }
+
+            var contentTypeAlias = _conventions.TemplateContentTypeAlias(template.Name);
+
+            var layoutBlock = new BlockGridConfiguration.BlockGridBlockConfiguration
+            {
+                Label = template?.Name,
+                Areas = areas.ToArray(),
+                AllowAtRoot = true,
+                ContentElementTypeKey = context.GetContentTypeKeyOrDefault(contentTypeAlias, contentTypeAlias.ToGuid()),
+                GroupKey = gridBlockContext.LayoutsGroup.Key.ToString(),
+                BackgroundColor = Grid.LayoutBlocks.Background,
+                IconColor = Grid.LayoutBlocks.Icon
+			};
+
+            gridBlockContext.LayoutBlocks.TryAdd(contentTypeAlias, layoutBlock);
+
+            context.AddNewDocType(new NewContentTypeInfo
+            {
+                Key = layoutBlock.ContentElementTypeKey,
+                Alias = contentTypeAlias,
+                Name = template?.Name ?? contentTypeAlias,
+                Description = "Grid Layoutblock",
+                Folder = "BlockGrid/Layouts",
+                Icon = "icon-layout color-purple",
+                IsElement = true
+            });
+        }
+    }
+
+    private void GetLayoutLayouts(JToken? layouts, GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context)
+    {
+        if (layouts == null) return;
+
+        var gridLayoutConfigurations = layouts
+            .ToObject<IEnumerable<GridLayoutConfiguration>>() ?? Enumerable.Empty<GridLayoutConfiguration>();
+
+        foreach (var layout in gridLayoutConfigurations)
+        {
+            if (layout.Areas == null) continue;
+
+            var rowAreas = new List<BlockGridConfiguration.BlockGridAreaConfiguration>();
+
+            foreach (var (gridArea, gridAreaIndex) in layout.Areas.Select((x, i) => (x, i)))
+            {
+                var allowed = new List<string>();
+
+                if (gridArea.Allowed?.Any() == true)
+                {
+                    allowed.AddRange(gridArea.Allowed);
+                }
+                else
+                {
+                    allowed.Add("*");
+                }
+
+                if (gridArea.Grid == gridBlockContext.GridColumns)
+                {
+                    gridBlockContext.AppendToRootLayouts(allowed);
+                    continue;
+                }
+
+                var area = new BlockGridConfiguration.BlockGridAreaConfiguration
+                {
+                    Alias = _conventions.AreaAlias(gridAreaIndex),
+                    ColumnSpan = gridArea.Grid,
+                    RowSpan = 1
+                };
+
+                var alias = _conventions.LayoutAreaAlias(layout.Name, area.Alias);
+                area.Key = alias.ToGuid();
+
+                rowAreas.Add(area);
+
+                if (allowed.Any())
+                    gridBlockContext.AllowedEditors[area] = allowed;
+            }
+
+            if (rowAreas.Count == 0) continue;
+
+            var contentTypeAlias = _conventions.LayoutContentTypeAlias(layout.Name);
+
+            var layoutBlock = new BlockGridConfiguration.BlockGridBlockConfiguration
+            {
+                Label = layout?.Name,
+                Areas = rowAreas.ToArray(),
+                ContentElementTypeKey = context.GetContentTypeKeyOrDefault(contentTypeAlias, contentTypeAlias.ToGuid()),
+                GroupKey = gridBlockContext.LayoutsGroup.Key.ToString(),
+				BackgroundColor = Grid.LayoutBlocks.Background,
+				IconColor = Grid.LayoutBlocks.Icon,
+			};
+
+            gridBlockContext.LayoutBlocks.TryAdd(contentTypeAlias, layoutBlock);
+
+            context.AddNewDocType(new NewContentTypeInfo
+            {
+                Key = layoutBlock.ContentElementTypeKey,
+                Alias = contentTypeAlias,
+                Name = layout?.Name ?? contentTypeAlias,
+                Description = "Grid Layoutblock",
+                Folder = "BlockGrid/Layouts",
+                Icon = "icon-layout color-purple",
+                IsElement = true
+            });
+        }
+
+    }
+
+    private void AddContentTypesForLayoutBlocks(GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context)
+    {
+        var rootAllowed = gridBlockContext.GetRootAllowedLayouts();
+
+        foreach (var (alias, block) in gridBlockContext.LayoutBlocks)
+        {
+            if (rootAllowed.Contains(block.Label))
+            {
+                block.AllowAtRoot = true;
+            }
+
+            foreach (var area in block.Areas)
+            {
+                var areaAllowed = gridBlockContext.GetAllowedLayouts(area);
+
+                if (!areaAllowed.Any()) continue;
+
+                var layoutContentTypeAliases = areaAllowed
+                    .Select(x => _conventions.LayoutContentTypeAlias(x));
+
+                var specificedAllowance = new List<BlockGridConfiguration.BlockGridAreaConfigurationSpecifiedAllowance>(area.SpecifiedAllowance);
+
+                foreach (var layoutContentTypeAlias in layoutContentTypeAliases)
+                {
+                    var contentTypeKey = context.GetContentTypeKey(layoutContentTypeAlias);
+                    if (contentTypeKey != Guid.Empty)
+                    {
+                        specificedAllowance.Add(new()
+                        {
+                            ElementTypeKey = contentTypeKey
+                        });
+                    }
+                }
+
+                area.SpecifiedAllowance = specificedAllowance.ToArray();
+            }
+
+            if (block.ContentElementTypeKey == Guid.Empty)
+            {
+                block.ContentElementTypeKey = alias.ToGuid();
+                context.AddContentTypeKey(alias, block.ContentElementTypeKey);
+            }
+
+            context.AddElementType(block.ContentElementTypeKey);
+        }
+    }
+
+
+
+
+}

--- a/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -1,0 +1,231 @@
+﻿using Newtonsoft.Json.Linq;
+
+using NUglify.Helpers;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Extensions;
+
+using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+using uSync.Migrations.Migrators.BlockGrid.Extensions;
+using uSync.Migrations.Migrators.BlockGrid.Models;
+using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Models;
+
+using static Umbraco.Cms.Core.PropertyEditors.ListViewConfiguration;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Content;
+
+/// <summary>
+///  helper class that actually gets content from the grid and puts it into the blocklist. 
+/// </summary>
+internal class GridToBlockContentHelper
+{
+    private readonly SyncBlockMigratorCollection _blockMigrators;
+    private readonly GridConventions _conventions;
+
+    public GridToBlockContentHelper(
+        GridConventions gridConventions,
+        SyncBlockMigratorCollection blockMigrators)
+    {
+        _blockMigrators = blockMigrators;
+        _conventions = gridConventions;
+    }
+
+    /// <summary>
+    ///  convert a grid value (so with sections, rows, areas and controls) into a block value for a grid.
+    /// </summary>
+    public BlockValue? ConvertToBlockValue(GridValue source, SyncMigrationContext context)
+    {
+        // empty grid check
+        if (source.Sections.Any() != true) return null;
+
+
+        var sectionContentTypeAlias = _conventions.SectionContentTypeAlias(source.Name);
+
+        var sections = source.Sections
+            .Select(x => (Grid: x.Grid.GetIntOrDefault(0), x.Rows))
+            .ToArray();
+
+        var gridColumns = sections.Sum(x => x.Grid);
+
+        var block = new BlockValue();
+
+        var blockLayouts = new List<BlockGridLayoutItem>();
+
+        foreach (var (sectionColums, rows) in sections)
+        {
+            var sectionIsFullWidth = sectionColums == gridColumns;
+
+            foreach (var row in rows)
+            {
+                var areas = row.Areas.Select((x, i) => (x, i));
+
+                var rowColumns = row.Areas.Sum(x => x.Grid.GetIntOrDefault(0));
+                var rowIsFullWidth = sectionIsFullWidth && rowColumns == gridColumns;
+
+                var rowLayoutAreas = new List<BlockGridLayoutAreaItem>();
+
+                foreach (var area in row.Areas.Select((value, index) => (value, index)))
+                {
+                    var areaIsFullWidth = rowIsFullWidth && area.value.Grid.GetIntOrDefault(0) == gridColumns;
+
+                    // get the content
+                    var contentAndSettings = GetGridAreaBlockContent(area.value, context).ToList();
+                    if (!contentAndSettings.Any()) continue;
+
+                    // get the layouts 
+                    var layouts = GetGridAreaBlockLayouts(area.value, contentAndSettings).ToList();
+                    if (!layouts.Any()) continue;
+
+                    if (areaIsFullWidth)
+                    {
+                        blockLayouts.AddRange(layouts);
+                    }
+                    else
+                    {
+                        var areaItem = new BlockGridLayoutAreaItem
+                        {
+                            Key =  _conventions.LayoutAreaAlias(row.Name, _conventions.AreaAlias(area.index)).ToGuid(),
+                            Items = layouts.ToArray()
+                        };
+
+                        rowLayoutAreas.Add(areaItem);
+                    }
+
+                    // add the content and settings to the block. 
+                    contentAndSettings.ForEach(x =>
+                    {
+                        block.ContentData.Add(x.Content);
+                        if (x.Settings != null)
+                        {
+                            block.SettingsData.Add(x.Settings);
+                        }
+                    });
+                }
+
+                // row 
+                if (!rowLayoutAreas.Any()) continue;
+
+                var rowContent = GetGridRowBlockContent(row, context);
+
+                block.ContentData.Add(rowContent);
+                blockLayouts.Add(GetGridRowBlockLayout(rowContent, rowLayoutAreas, rowColumns));
+            }
+
+            // section 
+        }
+
+        // end - process layouts into block format. 
+        block.Layout = new Dictionary<string, JToken>
+        {
+            { UmbConstants.PropertyEditors.Aliases.BlockGrid, JToken.FromObject(blockLayouts) }
+        };
+
+        return block;
+    }
+
+    private IEnumerable<BlockContentPair> GetGridAreaBlockContent(GridValue.GridArea area, SyncMigrationContext context)
+    {
+        foreach (var control in area.Controls)
+        {
+            var content = GetBlockItemDataFromGridControl(control, context);
+            if (content == null) continue;
+
+            BlockItemData? settings = null;
+            // TODO Settings ? 
+
+            yield return new BlockContentPair(content, settings);
+        }
+    }
+
+    private IEnumerable<BlockGridLayoutItem> GetGridAreaBlockLayouts(GridValue.GridArea area, IEnumerable<BlockContentPair> contentAndSettings)
+    {
+        foreach (var item in contentAndSettings)
+        {
+            var layout = new BlockGridLayoutItem
+            {
+                ContentUdi = item.Content.Udi,
+                SettingsUdi = item.Settings?.Udi,
+                ColumnSpan = area.Grid.GetIntOrDefault(0),
+                RowSpan = 1
+            };
+
+            yield return layout;
+        }
+    }
+
+    private BlockItemData GetGridRowBlockContent(GridValue.GridRow row, SyncMigrationContext context)
+    {
+        var rowLayoutContentTypeAlias = _conventions.LayoutContentTypeAlias(row.Name);
+        var rowContentTypeKey = context.GetContentTypeKeyOrDefault(rowLayoutContentTypeAlias, rowLayoutContentTypeAlias.ToGuid()); 
+
+        return new BlockItemData
+        {
+            Udi = Udi.Create(UmbConstants.UdiEntityType.Element, row.Id),
+            ContentTypeKey = rowContentTypeKey,
+            ContentTypeAlias = rowLayoutContentTypeAlias
+        };
+    }
+
+    private BlockGridLayoutItem GetGridRowBlockLayout(BlockItemData rowContent, List<BlockGridLayoutAreaItem> rowLayoutAreas, int? rowColumns)
+    {
+        return new BlockGridLayoutItem
+        {
+            ContentUdi = rowContent.Udi,
+            Areas = rowLayoutAreas.ToArray(),
+            ColumnSpan = rowColumns,
+            RowSpan = 1,
+        };
+
+    }
+
+    private BlockItemData? GetBlockItemDataFromGridControl(GridValue.GridControl control, SyncMigrationContext context)
+    {
+        if (control.Value == null) return null;
+
+        var blockMigrator = _blockMigrators.GetMigrator(control.Editor);
+        if (blockMigrator == null) return null;
+
+        var contentTypeAlias = blockMigrator.GetContentTypeAlias(control);
+        if (contentTypeAlias == null) return null;
+
+        var contentTypeKey = context.GetContentTypeKey(contentTypeAlias);
+        if (contentTypeKey == Guid.Empty) return null;
+
+        var data = new BlockItemData
+        {
+            Udi = Udi.Create(UmbConstants.UdiEntityType.Element, Guid.NewGuid()),
+            ContentTypeAlias = contentTypeAlias,
+            ContentTypeKey = contentTypeKey
+        };
+
+
+        foreach (var (propertyAlias, value) in blockMigrator.GetPropertyValues(control, context))
+        {
+            var editorAlias = context.GetEditorAlias(contentTypeAlias, propertyAlias);
+            var propertyValue = value;
+            if (editorAlias != null)
+            {
+
+                var migrator = context.TryGetMigrator(editorAlias.OriginalEditorAlias);
+                if (migrator != null)
+                {
+                    var property = new SyncMigrationContentProperty(editorAlias.OriginalEditorAlias, value?.ToString() ?? string.Empty);
+                    propertyValue = migrator.GetContentValue(property, context);
+                }
+            }
+
+            data.RawPropertyValues[propertyAlias] = propertyValue;
+        }
+
+        return data;
+    }
+}
+
+internal static class GridToBlockContentExtensions
+{
+    public static int GetIntOrDefault(this string? value, int defaultValue)
+        => int.TryParse(value, out var intValue) ? intValue : defaultValue;
+}

--- a/uSync.Migrations/Migrators/BlockGrid/Extensions/GridConventions.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Extensions/GridConventions.cs
@@ -1,0 +1,34 @@
+﻿using Umbraco.Cms.Core.Strings;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Extensions;
+
+internal class GridConventions
+{
+    public IShortStringHelper ShortStringHelper { get; }
+
+    public GridConventions(IShortStringHelper shortStringHelper)
+    {
+        ShortStringHelper = shortStringHelper;
+    }
+
+    public string AreaAlias(int index)
+        => $"area_{index}";
+
+    public string SectionContentTypeAlias(string? name)
+        => $"section_{name}".GetBlockGridLayoutContentTypeAlias(ShortStringHelper);
+
+    public string RowLayoutContentTypeAlias(string? name)
+        => $"{name}".GetBlockElementContentTypeAlias(ShortStringHelper);
+
+    public string GridAreaConfigAlias(string areaAlias)
+        => areaAlias.GetBlockGridAreaConfigurationAlias(ShortStringHelper);
+
+    public string TemplateContentTypeAlias(string template)
+        => template.GetBlockElementContentTypeAlias(ShortStringHelper);
+
+    public string LayoutAreaAlias(string layout, string areaAlias)
+        => $"layout_{layout}_{areaAlias}".GetBlockGridAreaConfigurationAlias(ShortStringHelper);
+
+    public string LayoutContentTypeAlias(string layout)
+        => layout.GetBlockGridLayoutContentTypeAlias(ShortStringHelper);
+}

--- a/uSync.Migrations/Migrators/BlockGrid/Extensions/GridToBlockGridNameExtensions.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Extensions/GridToBlockGridNameExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Extensions;
+
+internal static class GridToBlockGridNameExtensions
+{
+    public static string GetBlockElementContentTypeAlias(this string name, IShortStringHelper shortStringHelper)
+        => name.GetContentTypeAlias("BlockElement_", shortStringHelper);
+
+    public static string GetBlockSettingsContentTypeAlias(this string name, IShortStringHelper shortStringHelper)
+        => name.GetContentTypeAlias("BlockSettings_", shortStringHelper);
+
+    public static string GetBlockGridLayoutContentTypeAlias(this string name, IShortStringHelper shortStringHelper)
+        => name.GetContentTypeAlias("BlockGridLayout_", shortStringHelper);
+
+    public static string GetBlockGridAreaConfigurationAlias(this string name, IShortStringHelper shortStringHelper)
+        => name.GetContentTypeAlias("BlockGridArea_", shortStringHelper);
+
+    private static string GetContentTypeAlias(this string name, string prefix, IShortStringHelper shortStringHelper)
+    {
+        return $"{prefix}{name}".ToSafeAlias(shortStringHelper);
+    }
+
+    public static Guid GetContentTypeKeyOrDefault(this SyncMigrationContext context, string alias, Guid defaultKey)
+    {
+        var key = context.GetContentTypeKey(alias);
+        if (key != Guid.Empty) return key;
+
+        context.AddContentKey(defaultKey, alias);
+        return defaultKey;
+    }
+
+
+}

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -1,0 +1,96 @@
+﻿using Newtonsoft.Json;
+
+using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Strings;
+
+using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+using uSync.Migrations.Migrators.BlockGrid.Content;
+using uSync.Migrations.Migrators.BlockGrid.Config;
+using uSync.Migrations.Migrators.BlockGrid.Extensions;
+using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid;
+
+[SyncMigrator(UmbConstants.PropertyEditors.Aliases.Grid)]
+[SyncMigratorVersion(8)]
+public class GridToBlockGridMigrator : SyncPropertyMigratorBase
+{
+	private readonly IGridConfig _gridConfig;
+	private readonly SyncBlockMigratorCollection _blockMigrators;
+
+	private readonly GridConventions _conventions;
+
+	public GridToBlockGridMigrator(
+		IGridConfig gridConfig,
+		SyncBlockMigratorCollection blockMigrators,
+		IShortStringHelper shortStringHelper)
+	{
+		_gridConfig = gridConfig;
+		_blockMigrators = blockMigrators;
+		_conventions = new GridConventions(shortStringHelper);
+	}
+
+	public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+		=> UmbConstants.PropertyEditors.Aliases.BlockGrid;
+
+	public override string GetDatabaseType(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+		=> nameof(ValueStorageType.Ntext);
+
+	public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+	{
+		if (dataTypeProperty.ConfigAsString == null)
+			return new BlockGridConfiguration();
+
+		var gridConfiguration = JsonConvert
+			.DeserializeObject<GridConfiguration>(dataTypeProperty.ConfigAsString);
+
+		if (gridConfiguration == null)
+			return new BlockGridConfiguration();
+
+		var gridToBlockContext = new GridToBlockGridConfigContext(gridConfiguration, _gridConfig);
+
+		var contentBlockHelper = new GridToBlockGridConfigBlockHelper(_blockMigrators);
+		var layoutBlockHelper = new GridToBlockGridConfigLayoutBlockHelper(_conventions);
+
+		// adds content types for the core elements (headline, rte, etc)
+		contentBlockHelper.AddConfigDataTypes(gridToBlockContext, context);
+
+		// prep the layouts 
+		layoutBlockHelper.AddLayoutBlocks(gridToBlockContext, context);
+
+		// Add the content blocks
+		contentBlockHelper.AddContentBlocks(gridToBlockContext, context);
+
+		// Get resultant configuration
+		var result = gridToBlockContext.ConvertToBlockGridConfiguration();
+
+		// Make sure all the block elements have been added to the migration context.
+		context.AddElementTypes(result.Blocks.Select(x => x.ContentElementTypeKey), true);
+
+		return result;
+	}
+
+	public override string GetContentValue(SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
+	{
+		if (string.IsNullOrWhiteSpace(contentProperty.Value))
+			return string.Empty;
+
+		// has already been converted. 
+		if(contentProperty.Value.Contains("\"Umbraco.BlockGrid\"")) 
+			return contentProperty.Value;
+
+		var source = JsonConvert.DeserializeObject<GridValue>(contentProperty.Value);
+		if (source == null) return string.Empty;
+
+		var helper = new GridToBlockContentHelper(_conventions, _blockMigrators);
+		var blockValue = helper.ConvertToBlockValue(source, context);
+
+		if (blockValue == null) return string.Empty;
+
+		return JsonConvert.SerializeObject(blockValue, Formatting.Indented);
+	}
+}
+

--- a/uSync.Migrations/Migrators/BlockGrid/Models/GridModels.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Models/GridModels.cs
@@ -1,0 +1,82 @@
+﻿using Newtonsoft.Json;
+
+using Umbraco.Cms.Core.Models.Blocks;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Models;
+
+internal static class Grid 
+{ 
+    internal static class LayoutBlocks
+    {
+        public const string Background = "#cfe2f3";
+        public const string Icon = "#2986cc";
+	}
+
+    internal static class GridBlocks
+    {
+        public const string Background = "#fce5cd";
+        public const string Icon = "#ce7e00"; 
+    }
+}
+
+
+
+internal class GridTemplateConfiguration
+{
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("sections")]
+    public IEnumerable<GridSectionConfiguration>? Sections { get; set; }
+}
+
+internal class GridSectionConfiguration
+{
+    [JsonProperty("grid")]
+    public int Grid { get; set; }
+
+    [JsonProperty("allowAll")]
+    public bool? AllowAll { get; set; }
+
+    [JsonProperty("allowed")]
+    public string[]? Allowed { get; set; }
+}
+
+internal class GridLayoutConfiguration
+{
+    [JsonProperty("label")]
+    public string? Label { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("areas")]
+    public IEnumerable<GridAreaConfiguration>? Areas { get; set; }
+}
+
+internal class GridAreaConfiguration
+{
+    [JsonProperty("grid")]
+    public int Grid { get; set; }
+
+    [JsonProperty("allowAll")]
+    public bool? AllowAll { get; set; }
+
+    [JsonProperty("allowed")]
+    public string[]? Allowed { get; set; }
+}
+
+/// <summary>
+///  contains the data for a block (content and settings)
+/// </summary>
+internal class BlockContentPair
+{
+    public BlockItemData Content { get; set; }
+    public BlockItemData? Settings { get; set; }
+
+    public BlockContentPair(BlockItemData content, BlockItemData? settings)
+    {
+        Content = content;
+        Settings = settings;
+    }
+}

--- a/uSync.Migrations/Migrators/Core/GridMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/GridMigrator.cs
@@ -18,7 +18,7 @@ namespace uSync.Migrations.Migrators;
 ///  
 ///  and then in the mapping if you have custom things (like DTGE) it will need a migrator too.
 /// </remarks>
-[SyncMigrator(UmbConstants.PropertyEditors.Aliases.Grid, typeof(GridConfiguration))]
+[SyncMigrator(UmbConstants.PropertyEditors.Aliases.Grid, typeof(GridConfiguration), IsDefaultAlias = true)]
 public class GridMigrator : SyncPropertyMigratorBase
 {
     // TODO: [KJ] This only really matters if there are custom things and they need config.

--- a/uSync.Migrations/Migrators/Optional/NestedToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Optional/NestedToBlockListMigrator.cs
@@ -1,9 +1,5 @@
-﻿using Lucene.Net.Codecs;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
-using Polly;
 
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.Blocks;

--- a/uSync.Migrations/uSync.Migrations.csproj
+++ b/uSync.Migrations/uSync.Migrations.csproj
@@ -13,10 +13,10 @@
 	</PropertyGroup>	
 	
 	<ItemGroup>
-		<PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.0.0" />
-		<PackageReference Include="Umbraco.Cms.Web.Website" Version="10.0.0" />
+		<PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.4.0" />
+		<PackageReference Include="Umbraco.Cms.Web.Website" Version="10.4.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-		<PackageReference Include="uSync.BackOffice" Version="10.3.1-beta001" />
+		<PackageReference Include="uSync.BackOffice" Version="10.3.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/uSyncMigrationSite/.config/dotnet-tools.json
+++ b/uSyncMigrationSite/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "7.0.2",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}

--- a/uSyncMigrationSite/uSyncMigrationSite.csproj
+++ b/uSyncMigrationSite/uSyncMigrationSite.csproj
@@ -6,10 +6,11 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Umbraco.Cms" Version="10.2.1" />
+		<PackageReference Include="Umbraco.Cms" Version="10.4.0" />
 		<PackageReference Include="Umbraco.TheStarterKit" Version="10.0.0" />
-		<PackageReference Include="uSync" Version="10.3.1-beta001" />
+		<PackageReference Include="uSync" Version="10.3.2" />
 		<PackageReference Include="Umbraco.Forms" Version="10.2.0" />
+		<PackageReference Include="Our.Umbraco.DocTypeGridEditor" Version="10.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
A BIG Grid to DTGE re-org based on PR #66 by @soreng 

- took lots of the PR from @soreng and split it out so block grid converter is a little less one massive file. 
- built the `ISyncBlockMigrators` which allow us to farm off each individual control in a grid into a migrator (so like baby property migrators) _
- then build the core migrators and the DTGE one. So, we can in theory add new ones as needed 

This only really works for v8 at the moment (because we don't have the grid.config.js file when we migrate v7) so that is something we need to work out (its more than just the file as its combined from all over the place. we could say v7 will migrate if your grid is in order has same packages (e.g dtge).

but upshot is this now migrates core grid stuff and DTGE to block grid 🥳 

Will create elements and layouts (from the grid)

![image](https://user-images.githubusercontent.com/431231/217851682-b6e3af61-ff80-4a80-af7c-8e96ffac47b4.png)

and put them in groups in the BlockGrid 

![image](https://user-images.githubusercontent.com/431231/217851861-8f3c0a25-6893-4a8d-86e9-d909c85289f5.png)


for each simple one we create a single property to take the grid value 👍 

![image](https://user-images.githubusercontent.com/431231/217852083-169aabfb-0f6a-40c9-be15-3958d989fbb0.png)

For the DTGE it doesn't need to do this because the DocType will already exist. 

for more advanced this is a post migration task. 






