### PR TITLE
Childnode permissions being lost in migration

### DIFF
--- a/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -80,8 +80,23 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
     protected override void UpdateStructure(XElement source, XElement target)
     {
         var sourceStructure = source.Element("Structure");
+
         if (sourceStructure != null)
-            target.Add(XElement.Parse(sourceStructure.ToString()));
+        {
+            var i = 0;
+            var transformedStructure = new XElement("Structure");
+            foreach (var element in sourceStructure.Elements())
+            {
+                var contentType = new XElement("ContentType");
+                contentType.SetAttributeValue("Key", element?.Attribute("Key")?.Value);
+                contentType.SetAttributeValue("SortOrder", i);
+                contentType.Value = element.Value;
+
+                transformedStructure.Add(contentType);
+                i++;
+            }
+            target.Add(XElement.Parse(transformedStructure.ToString()));
+        }
     }
 
     protected override void CheckVariations(XElement target)


### PR DESCRIPTION
When the XML was being transformed, the Structure Element was being copied across, however the old DocumentType element name needed to be renamed to ContentType to stop permissions being lost.  Also added in the SortOrder, seeing as I was there!