### PR TITLE
Manipulate tabs on migration

### DIFF
--- a/MyMigrations/MyMigrationProfile.cs
+++ b/MyMigrations/MyMigrationProfile.cs
@@ -79,5 +79,36 @@ public class MyMigrationProfile : ISyncMigrationProfile
                 }
             }
         },
+
+        // change the tabs around a bit if needed/
+        RenamedTabs = new List<TabOptions>
+        {
+            {
+                //Rename the Meta Data tab to SEO with the alias of seo
+                new TabOptions{
+                    OriginalName = "Meta Data",
+                    NewName = "SEO",
+                    Alias = "seo" }
+            },
+            {
+                //Move the contents of the tab Carousel into the Content tab.  If content doesn't exist it will
+                //be created with the alias "Content"
+                new TabOptions
+                {
+                    OriginalName = "Carousel",
+                    NewName = "Content",
+                    Alias = string.Empty
+                }
+            },
+            {
+                //No new name or alias means delete the tab, so delete the "Cookie Law" tab in this example
+                new TabOptions
+                {
+                    OriginalName = "Cookie Law",
+                    NewName = string.Empty,
+                    Alias = string.Empty
+                }
+            }
+        },
     };
 }

--- a/MyMigrations/MyMigrationProfile.cs
+++ b/MyMigrations/MyMigrationProfile.cs
@@ -81,7 +81,7 @@ public class MyMigrationProfile : ISyncMigrationProfile
         },
 
         // change the tabs around a bit if needed/
-        RenamedTabs = new List<TabOptions>
+        ChangeTabs = new List<TabOptions>
         {
             {
                 //Rename the Meta Data tab to SEO with the alias of seo

--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -35,9 +35,9 @@ public class MigrationOptions
     public Dictionary<string, List<string>>? IgnoredPropertiesByContentType { get; set; }
 
     /// <summary>
-    /// List of tabs that will be renamed
+    /// List of tabs that will be changed
     /// </summary>
-    public List<TabOptions>? RenamedTabs { get; set; }
+    public List<TabOptions>? ChangeTabs { get; set; }
 }
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]

--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -33,6 +33,11 @@ public class MigrationOptions
     public List<string>? IgnoredProperties { get; set; }
 
     public Dictionary<string, List<string>>? IgnoredPropertiesByContentType { get; set; }
+
+    /// <summary>
+    /// List of tabs that will be renamed
+    /// </summary>
+    public List<TabOptions>? RenamedTabs { get; set; }
 }
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]

--- a/uSync.Migrations/Configuration/Models/TabOptions.cs
+++ b/uSync.Migrations/Configuration/Models/TabOptions.cs
@@ -3,7 +3,7 @@
     public class TabOptions
     {
         /// <summary>
-        /// The name of the tab you want to rename/delete.  This is the name NOT the alias.
+        /// The name of the tab you want to change.  This is the name NOT the alias.
         /// </summary>
         public string OriginalName { get; set; }
         /// <summary>

--- a/uSync.Migrations/Configuration/Models/TabOptions.cs
+++ b/uSync.Migrations/Configuration/Models/TabOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace uSync.Migrations.Configuration.Models
+{
+    public class TabOptions
+    {
+        /// <summary>
+        /// The name of the tab you want to rename/delete.  This is the name NOT the alias.
+        /// </summary>
+        public string OriginalName { get; set; }
+        /// <summary>
+        /// The name of the tab you want to create or move properties too.  This is the name NOT the alias.
+        /// </summary>
+        public string NewName { get; set; }
+        /// <summary>
+        /// An alias for the tab.  If none is set, the alias will default to the new name in camel case.
+        /// </summary>
+        public string Alias { get; set; }
+    }
+}

--- a/uSync.Migrations/Context/SyncMigrationContext.cs
+++ b/uSync.Migrations/Context/SyncMigrationContext.cs
@@ -48,8 +48,8 @@ public class SyncMigrationContext : IDisposable
     private HashSet<string> _blockedTypes = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<int, Guid> _idKeyMap { get; set; } = new();
 
-    // tabs that are to be manipulated
-    private List<TabOptions> _renamedTabs { get; set; } = new List<TabOptions>();
+    // tabs that are to be changed
+    private List<TabOptions> _changedTabs { get; set; } = new List<TabOptions>();
 
     /// <summary>
     ///  is this item blocked based on alias and type. 
@@ -78,10 +78,10 @@ public class SyncMigrationContext : IDisposable
     /// Add changed tabs to the context.
     /// </summary>
     public void AddChangedTabs(TabOptions tab)
-        => _renamedTabs.Add(tab);
+        => _changedTabs.Add(tab);
 
     public List<TabOptions> GetChangedTabs()
-        => _renamedTabs;
+        => _changedTabs;
     
     public void Dispose()
     { }

--- a/uSync.Migrations/Context/SyncMigrationContext.cs
+++ b/uSync.Migrations/Context/SyncMigrationContext.cs
@@ -75,12 +75,12 @@ public class SyncMigrationContext : IDisposable
     public Guid GetKey(int id)
         => _idKeyMap?.TryGetValue(id, out var key) == true ? key : Guid.Empty;
     /// <summary>
-    /// Add renamed tabs to the context.
+    /// Add changed tabs to the context.
     /// </summary>
-    public void AddRenamedTabs(TabOptions tab)
+    public void AddChangedTabs(TabOptions tab)
         => _renamedTabs.Add(tab);
 
-    public List<TabOptions> GetRenamedTabs()
+    public List<TabOptions> GetChangedTabs()
         => _renamedTabs;
     
     public void Dispose()

--- a/uSync.Migrations/Context/SyncMigrationContext.cs
+++ b/uSync.Migrations/Context/SyncMigrationContext.cs
@@ -1,4 +1,6 @@
-﻿namespace uSync.Migrations.Context;
+﻿using uSync.Migrations.Configuration.Models;
+
+namespace uSync.Migrations.Context;
 
 /// <summary>
 ///  A uSync migration context, lets us keep a whole list of things in memory while we do the migration.
@@ -46,6 +48,9 @@ public class SyncMigrationContext : IDisposable
     private HashSet<string> _blockedTypes = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<int, Guid> _idKeyMap { get; set; } = new();
 
+    // tabs that are to be manipulated
+    private List<TabOptions> _renamedTabs { get; set; } = new List<TabOptions>();
+
     /// <summary>
     ///  is this item blocked based on alias and type. 
     /// </summary>
@@ -69,7 +74,15 @@ public class SyncMigrationContext : IDisposable
     /// </summary>
     public Guid GetKey(int id)
         => _idKeyMap?.TryGetValue(id, out var key) == true ? key : Guid.Empty;
+    /// <summary>
+    /// Add renamed tabs to the context.
+    /// </summary>
+    public void AddRenamedTabs(TabOptions tab)
+        => _renamedTabs.Add(tab);
 
+    public List<TabOptions> GetRenamedTabs()
+        => _renamedTabs;
+    
     public void Dispose()
     { }
 

--- a/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
@@ -21,7 +21,7 @@ internal class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseH
         : base(eventAggregator, migrationFileService, logger, dataTypeService)
     { }
 
-    protected override void UpdatePropertyXml(XElement newProperty)
+    protected override void UpdatePropertyXml(XElement newProperty, SyncMigrationContext context)
     {
         // for v8 the properties should match what we are expecting ?
     }
@@ -43,7 +43,7 @@ internal class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseH
             target.Add(XElement.Parse(sourceStructure.ToString()));
     }
 
-    protected override void UpdateTabs(XElement source, XElement target)
+    protected override void UpdateTabs(XElement source, XElement target, SyncMigrationContext context)
     {
         var sourceTabs = source.Element("Tabs");
         if (sourceTabs != null)

--- a/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -32,7 +32,7 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
 
     protected override void UpdateTabs(XElement source, XElement target, SyncMigrationContext context)
     {
-        var renamedTabs = context.GetRenamedTabs();
+        var renamedTabs = context.GetChangedTabs();
 
         var tabs = source.Element("Tabs");
         if (tabs != null)
@@ -77,7 +77,7 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
         var tabNode = newProperty.Element("Tab");
         var caption = tabNode.ValueOrDefault(string.Empty);
         var alias = tabNode.ValueOrDefault(string.Empty).Replace(" ", "").ToFirstLower();
-        var renamedTabs = context.GetRenamedTabs();
+        var renamedTabs = context.GetChangedTabs();
 
         if (renamedTabs.Select(x => x.OriginalName).Contains(caption))
         {

--- a/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -93,7 +93,7 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
 
 
         // tabs
-        UpdateTabs(source, target);
+        UpdateTabs(source, target, context);
 
         if (ItemType == nameof(ContentType))
         {
@@ -106,7 +106,7 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
 
     protected abstract void UpdateInfoSection(XElement? info, XElement target, Guid key, SyncMigrationContext context);
     protected abstract void UpdateStructure(XElement source, XElement target);
-    protected abstract void UpdateTabs(XElement source, XElement target);
+    protected abstract void UpdateTabs(XElement source, XElement target, SyncMigrationContext context);
     protected abstract void CheckVariations(XElement target);
 
     protected virtual void UpdateProperties(XElement source, XElement target, string alias, SyncMigrationContext context)
@@ -130,7 +130,7 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
                 // update the datatype we are using (this might be new). 
                 UpdatePropertyEditor(alias, newProperty, context);
 
-                UpdatePropertyXml(newProperty);
+                UpdatePropertyXml(newProperty, context);
 
                 newProperties.Add(newProperty);
             }
@@ -164,7 +164,7 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
         }
 
     }
-    protected abstract void UpdatePropertyXml(XElement newProperty);
+    protected abstract void UpdatePropertyXml(XElement newProperty, SyncMigrationContext context);
 
 
     /// <summary>

--- a/uSync.Migrations/Services/SyncMigrationService.cs
+++ b/uSync.Migrations/Services/SyncMigrationService.cs
@@ -173,8 +173,8 @@ internal class SyncMigrationService : ISyncMigrationService
                 kvp.Value?.ForEach(value => context.ContentTypes.AddIgnoredProperty(kvp.Key, value)));
 
         // tabs that we might want to rename, delete or move properties from/to
-        options.RenamedTabs?
-            .ForEach(x => context.AddRenamedTabs(x));
+        options.ChangeTabs?
+            .ForEach(x => context.AddChangedTabs(x));
 
         AddMigrators(context, options.PreferredMigrators);
 

--- a/uSync.Migrations/Services/SyncMigrationService.cs
+++ b/uSync.Migrations/Services/SyncMigrationService.cs
@@ -172,6 +172,10 @@ internal class SyncMigrationService : ISyncMigrationService
             .ForEach(kvp =>
                 kvp.Value?.ForEach(value => context.ContentTypes.AddIgnoredProperty(kvp.Key, value)));
 
+        // tabs that we might want to rename, delete or move properties from/to
+        options.RenamedTabs?
+            .ForEach(x => context.AddRenamedTabs(x));
+
         AddMigrators(context, options.PreferredMigrators);
 
         // let the handlers run through their prep (populate all the lookups)


### PR DESCRIPTION
Allows for changing the name and alias of a tab, merging the properties of one tab into another and deleting a tab.  Doesn't do sorting though!  At present, only been tested on a v7 migration.