### PR TITLE
Changes to some migrator dbtypes to allow more data during migration

### DIFF
--- a/uSync.Migrations/Migrators/Core/ContentPickerMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/ContentPickerMigrator.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Core.PropertyEditors;
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
 using uSync.Migrations.Context;
 using uSync.Migrations.Extensions;
 using uSync.Migrations.Migrators.Models;
@@ -11,6 +12,8 @@ public class ContentPicker1Migrator : SyncPropertyMigratorBase
 {
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => UmbConstants.PropertyEditors.Aliases.ContentPicker;
+    public override string GetDatabaseType(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+=> nameof(ValueStorageType.Ntext);
 
     public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
     {

--- a/uSync.Migrations/Migrators/Core/MultiNodeTreePickerMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/MultiNodeTreePickerMigrator.cs
@@ -1,4 +1,5 @@
 ﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Extensions;
 using uSync.Migrations.Context;
@@ -11,6 +12,9 @@ namespace uSync.Migrations.Migrators;
 [SyncMigrator("Umbraco.MultiNodeTreePicker2")]
 public class MultiNodeTreePickerMigrator : SyncPropertyMigratorBase
 {
+    public override string GetDatabaseType(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+=> nameof(ValueStorageType.Ntext);
+
     public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
     {
         var config = new MultiNodePickerConfiguration();


### PR DESCRIPTION
Found during migration of live data that the amount stored on these fields can bypass the default, so minor changes to the dbtype to allow for a larger amount of data.