### PR TITLE
Migrators for Crumpled Dog produced data types

### DIFF
--- a/uSync.Migrations/Helpers/MarkdownEditorHelper.cs
+++ b/uSync.Migrations/Helpers/MarkdownEditorHelper.cs
@@ -1,0 +1,134 @@
+﻿using System.Web;
+
+using HtmlAgilityPack;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Extensions;
+
+namespace uSync.Migrations.Helpers
+{
+    public static class MarkdownEditorHelper
+    {
+        public static string ParseUmbracoMarkDownLinks(this string html, UmbracoContextReference umbracoContextReference)
+        {
+            try
+            {
+                var doc = new HtmlDocument();
+                doc.LoadHtml(html);
+
+                // Find all images with rel attribute
+                var linkNodes = doc.DocumentNode.SelectNodes("//a[@href]");
+
+                if (linkNodes != null)
+                {
+                    var modified = false;
+
+                    foreach (var link in linkNodes)
+                    {
+                        var firstOrDefault = link.Attributes.FirstOrDefault(x => x.Name.Equals("href"));
+                        if (firstOrDefault != null && firstOrDefault.Value.StartsWith("/umbLink:true"))
+                        {
+                            var value = firstOrDefault.Value.Substring(13);
+
+                            if (value.Contains("/extLink:"))
+                            {
+                                var posExt = value.IndexOf("/extLink:");
+                                var extLink = value.Substring(posExt + 9);
+                                value = value.Substring(0, posExt);
+                                firstOrDefault.Value = extLink;
+                            }
+
+                            if (value.Length > 0)
+                            {
+
+                                var linkVariables =
+                                    value.Substring(1)
+                                        .Split('/')
+                                        .Select(variable => variable.Split(':'))
+                                        .ToDictionary(pair => pair[0], pair => pair[1]);
+
+                                if (linkVariables.ContainsKey("target"))
+                                {
+                                    var parseTarget = linkVariables.FirstOrDefault(x => x.Key == "target");
+                                    link.Attributes.Add("target", parseTarget.Value);
+                                }
+
+                                if (linkVariables.ContainsKey("title"))
+                                {
+                                    var parseTitle = linkVariables.FirstOrDefault(x => x.Key == "title");
+
+                                    var title = HttpUtility.UrlDecode(parseTitle.Value);
+
+                                    link.Attributes.Add("title", title);
+                                }
+
+                                if (linkVariables.ContainsKey("localLink"))
+                                {
+                                    int nodeId;
+                                    int.TryParse(
+                                        linkVariables.FirstOrDefault(x => x.Key == "localLink").Value,
+                                        out nodeId);
+
+                                    // this should always be changed except for NUnit tests
+                                    var newLinkUrl = "/testing/";
+                                    if (umbracoContextReference != null)
+                                    {
+                                        IPublishedContentCache contentCache = umbracoContextReference.UmbracoContext.Content;
+                                        IPublishedContent siteRoot = contentCache.GetAtRoot().FirstOrDefault();
+                                        if (siteRoot != null && siteRoot.Children.Any())
+                                        {
+                                            newLinkUrl = (siteRoot?.Children.Where(x => x.Id == nodeId).FirstOrDefault())?.Url() ?? string.Empty;
+                                        }
+                                        else
+                                        {
+                                            newLinkUrl = "Could not find node for link - Node Id:" + nodeId;
+                                        }
+                                    }
+
+                                    if (newLinkUrl == "#")
+                                    {
+                                        IPublishedMediaCache mediaCache = umbracoContextReference.UmbracoContext.Media;
+                                        IPublishedContent siteRoot = mediaCache.GetAtRoot().FirstOrDefault();
+
+                                        var mediaItem = siteRoot?.FirstChild(f => f.Id == nodeId) ?? null;
+                                        if (mediaItem != null)
+                                        {
+                                            newLinkUrl = mediaItem.Url();
+                                        }
+                                        else
+                                        {
+                                            newLinkUrl = null;
+                                        }
+                                    }
+                                    if (newLinkUrl != null)
+                                    {
+                                        firstOrDefault.Value = newLinkUrl;
+                                    }
+                                    else
+                                    {
+                                        // Link is invalid lets remove it and log
+                                        link.ParentNode.RemoveChild(link, true);
+                                    }
+                                }
+                            }
+
+                            modified = true;
+                        }
+                    }
+
+                    if (modified)
+                    {
+                        return doc.DocumentNode.OuterHtml;
+                    }
+                }
+
+                return html;
+            }
+            catch (Exception ex)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/uSync.Migrations/Migrators/Community/CrumpledCharLimitEditorToTextboxMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/CrumpledCharLimitEditorToTextboxMigrator.cs
@@ -1,0 +1,26 @@
+﻿using Umbraco.Cms.Core.PropertyEditors;
+
+using uSync.Migrations.Context;
+using uSync.Migrations.Extensions;
+using uSync.Migrations.Migrators.Models;
+
+namespace uSync.Migrations.Migrators.Community
+{
+    [SyncMigrator("Crumpled.CharLimitEditor")]
+    public class CrumpledCharLimitEditorToTextboxMigrator : SyncPropertyMigratorBase
+    {
+        public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+      => UmbConstants.PropertyEditors.Aliases.TextBox;
+        public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        {
+            var config = new TextboxConfiguration();
+
+            var mappings = new Dictionary<string, string>
+            {
+                { "limit", nameof(config.MaxChars) }
+            };
+
+            return config.MapPreValues(dataTypeProperty.PreValues, mappings);
+        }
+    }
+}

--- a/uSync.Migrations/Migrators/Community/CrumpledMarkdownEditorToRichTextEditorMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/CrumpledMarkdownEditorToRichTextEditorMigrator.cs
@@ -1,0 +1,56 @@
+﻿using HeyRed.MarkdownSharp;
+using Newtonsoft.Json;
+
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Core;
+
+using uSync.Migrations.Context;
+using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Helpers;
+
+namespace uSync.Migrations.Migrators.Community
+{
+    [SyncMigrator("Crumpled.MarkdownEditor")]
+    public class CrumpledMarkdownEditorToRichTextEditorMigrator : SyncPropertyMigratorBase
+    {
+        private readonly IUmbracoContextFactory _umbracoContextFactory;
+
+        public CrumpledMarkdownEditorToRichTextEditorMigrator(
+            IUmbracoContextFactory umbracoContextFactory)
+        {
+            _umbracoContextFactory = umbracoContextFactory;
+        }
+
+        public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+      => UmbConstants.PropertyEditors.Aliases.TinyMce;
+        public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        {
+            var config = new RichTextConfiguration();
+            return config;
+        }
+
+        public override string GetContentValue(SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
+        {
+            var markdownContent = JsonConvert.DeserializeObject<CrumpledMarkDown>(contentProperty.Value)?.Editor.Content;
+
+            //If the markdown can't be deserialised then return an empty string.
+            if (markdownContent == null) return string.Empty;
+
+            var markdown = new Markdown();
+            markdownContent = markdown.Transform(markdownContent);
+
+            using (UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext())
+            {
+                markdownContent = MarkdownEditorHelper.ParseUmbracoMarkDownLinks(markdownContent, umbracoContextReference);
+            }
+
+            if (!string.IsNullOrWhiteSpace(markdownContent))
+            {
+                //Return and remove any random whitespaces from the end.
+                return markdownContent.Trim();
+            }
+            return markdownContent;
+        }
+    }
+}

--- a/uSync.Migrations/Migrators/Models/CrumpledMarkDown.cs
+++ b/uSync.Migrations/Migrators/Models/CrumpledMarkDown.cs
@@ -1,0 +1,9 @@
+﻿namespace uSync.Migrations.Migrators.Models
+{
+    internal class CrumpledMarkDown
+    {
+        public CrumpledMarkdownEditor Editor { get; set; }
+        public string UniqueId { get; set; }
+
+    }
+}

--- a/uSync.Migrations/Migrators/Models/CrumpledMarkdownEditor.cs
+++ b/uSync.Migrations/Migrators/Models/CrumpledMarkdownEditor.cs
@@ -1,0 +1,8 @@
+﻿namespace uSync.Migrations.Migrators.Models
+{
+    internal class CrumpledMarkdownEditor
+    {
+        public string Alias { get; set; }
+        public string Content { get; set; }
+    }
+}


### PR DESCRIPTION
Primarily used internally, these are migrators for data types that were constructed by Crumpled Dog in the past.  They might be useful for anyone who has picked them up or finds them in an inherited project!