### PR TITLE
Mark `BlockMigrationProfile` class as public

### DIFF
--- a/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
+++ b/uSync.Migrations/Configuration/CoreProfiles/BlockMigrationProfile.cs
@@ -1,15 +1,11 @@
-﻿using System.Text.RegularExpressions;
-
-using Umbraco.Cms.Core.Composing;
-
-using uSync.Migrations.Composing;
+﻿using uSync.Migrations.Composing;
 using uSync.Migrations.Configuration.Models;
 using uSync.Migrations.Migrators.BlockGrid;
 using uSync.Migrations.Migrators.Optional;
 
 namespace uSync.Migrations.Configuration.CoreProfiles;
 
-internal class BlockMigrationProfile : ISyncMigrationProfile
+public class BlockMigrationProfile : ISyncMigrationProfile
 {
     private readonly SyncMigrationHandlerCollection _migrationHandlers;
 
@@ -20,7 +16,7 @@ internal class BlockMigrationProfile : ISyncMigrationProfile
 
     public int Order => 200;
 
-	public string Name => "Convert to BlockLists and BlockGrid";
+    public string Name => "Convert to BlockLists and BlockGrid";
 
     public string Icon => "icon-brick color-green";
 
@@ -30,13 +26,13 @@ internal class BlockMigrationProfile : ISyncMigrationProfile
     {
         Group = "Convert",
         Source = "uSync/v9",
-		Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
-		Handlers = _migrationHandlers.SelectGroup(8, string.Empty),
+        Target = $"{uSyncMigrations.MigrationFolder}/{DateTime.Now:yyyyMMdd_HHmmss}",
+        Handlers = _migrationHandlers.SelectGroup(8, string.Empty),
         SourceVersion = 8,
         PreferredMigrators = new Dictionary<string, string>
         {
-			{ UmbConstants.PropertyEditors.Aliases.NestedContent, nameof(NestedToBlockListMigrator) },
-			{ UmbConstants.PropertyEditors.Aliases.Grid, nameof(GridToBlockGridMigrator) }
+            { UmbConstants.PropertyEditors.Aliases.NestedContent, nameof(NestedToBlockListMigrator) },
+            { UmbConstants.PropertyEditors.Aliases.Grid, nameof(GridToBlockGridMigrator) }
         }
     };
 }


### PR DESCRIPTION
This is so the registration can be removed by third-party `Composer` code.
I'd like to lockdown the profiles as much as possible, just to cover myself from any "accidents".

This PR also removed the unused `using` namespaces and whitespace consistency, _(yeah, yeah, Lee can't help himself!)_ 😆 