### PR TITLE
Tabs Without Keys Need a Unique Key (GUID)

### DIFF
--- a/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
@@ -21,7 +21,7 @@ internal class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseH
         : base(eventAggregator, migrationFileService, logger, dataTypeService)
     { }
 
-    protected override void UpdatePropertyXml(XElement newProperty, SyncMigrationContext context)
+    protected override void UpdatePropertyXml(XElement source, XElement newProperty, SyncMigrationContext context)
     {
         // for v8 the properties should match what we are expecting ?
     }

--- a/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -80,7 +80,8 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
             if (tab.Element("Key") == null)
             {
                 var (sourceAlias, sourceKey) = GetAliasAndKey(source);
-                tab.Add(new XElement("Key", sourceAlias.ToGuid().ToString()));
+                var newAlias = sourceAlias + alias;
+                tab.Add(new XElement("Key", newAlias.ToGuid().ToString()));
             }
             if (tab.Element("Caption") != null)
             {

--- a/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -39,24 +39,24 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
             foreach (var tab in tabs.Elements("Tab"))
             {
                 var newTab = XElement.Parse(tab.ToString());
-                newTab = UpdateTab(newTab, context);
+                newTab = UpdateTab(source, newTab, context);
                 if (newTab != null) newTabs.Add(newTab);
             }
             target.Add(newTabs);
         }
     }
 
-    protected override void UpdatePropertyXml(XElement newProperty, SyncMigrationContext context)
+    protected override void UpdatePropertyXml(XElement source, XElement newProperty, SyncMigrationContext context)
     {
         newProperty.Add(new XElement("MandatoryMessage", string.Empty));
         newProperty.Add(new XElement("ValidationRegExpMessage", string.Empty));
         newProperty.Add(new XElement("LabelOnTop", false));
 
         var tabNode = newProperty.Element("Tab");
-        UpdateTab(tabNode, context);
+        UpdateTab(source, tabNode, context);
     }
 
-    internal XElement? UpdateTab(XElement tab, SyncMigrationContext context)
+    internal XElement? UpdateTab(XElement source, XElement tab, SyncMigrationContext context)
     {
         var renamedTabs = context.GetChangedTabs();
 
@@ -79,7 +79,8 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
         {
             if (tab.Element("Key") == null)
             {
-                tab.Add(new XElement("Key", alias.ToGuid().ToString()));
+                var (sourceAlias, sourceKey) = GetAliasAndKey(source);
+                tab.Add(new XElement("Key", sourceAlias.ToGuid().ToString()));
             }
             if (tab.Element("Caption") != null)
             {

--- a/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -130,7 +130,7 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
                 // update the datatype we are using (this might be new). 
                 UpdatePropertyEditor(alias, newProperty, context);
 
-                UpdatePropertyXml(newProperty, context);
+                UpdatePropertyXml(source, newProperty, context);
 
                 newProperties.Add(newProperty);
             }
@@ -164,7 +164,7 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
         }
 
     }
-    protected abstract void UpdatePropertyXml(XElement newProperty, SyncMigrationContext context);
+    protected abstract void UpdatePropertyXml(XElement source, XElement newProperty, SyncMigrationContext context);
 
 
     /// <summary>


### PR DESCRIPTION
This pull request fixes issue #89. My approach was to keep a reference to the original XElement (`source`), and if a **tab** is discovered without a key value, create the GUID using the `source alias`. 

Please closely review this PR. I'm not a C# developer. I'd be happy to receive any feedback & suggestions, as well as make improvements until this can be merged.

Thank you, 