### PR TITLE
Allows us to pass contenttype and propertytype alises to content mapp…

### DIFF
--- a/uSync.Migrations.Tests/Migrators/CheckboxListTests.cs
+++ b/uSync.Migrations.Tests/Migrators/CheckboxListTests.cs
@@ -36,10 +36,10 @@ public class CheckboxListTests : MigratiorTestBase
         => EditorAliasAsExpectedbase(UmbConstants.PropertyEditors.Aliases.CheckBoxList);
 
     protected override SyncMigrationContentProperty GetMigrationContentProperty(string value)
-        => new SyncMigrationContentProperty(UmbConstants.PropertyEditors.Aliases.CheckBoxList, value);
+        => new SyncMigrationContentProperty("Test", "Checkbox list", UmbConstants.PropertyEditors.Aliases.CheckBoxList, value);
 
     protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty()
-        => new SyncMigrationDataTypeProperty(UmbConstants.PropertyEditors.Aliases.CheckBoxList,
+        => new SyncMigrationDataTypeProperty("Checkbox", UmbConstants.PropertyEditors.Aliases.CheckBoxList,
             "Nvarchar",
             new List<PreValue>
             {

--- a/uSync.Migrations.Tests/Migrators/ColourPickerMigratorTests.cs
+++ b/uSync.Migrations.Tests/Migrators/ColourPickerMigratorTests.cs
@@ -51,10 +51,10 @@ public class ColourPickerMigratorTests : MigratiorTestBase
     }
 
     protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty()
-        => new SyncMigrationDataTypeProperty("Umbraco.ColorPickerAlias", "Nvarchar", _preValues);
+        => new SyncMigrationDataTypeProperty("Colour Picker", "Umbraco.ColorPickerAlias", "Nvarchar", _preValues);
 
     protected override SyncMigrationContentProperty GetMigrationContentProperty(string value)
-        => new SyncMigrationContentProperty("Umbraco.ColorPickerAlias", value);
+        => new SyncMigrationContentProperty("Test", "Colour picker", "Umbraco.ColorPickerAlias", value);
 
     [Test]
     public override void ConfigValueAsExpected()

--- a/uSync.Migrations.Tests/Migrators/MigratiorTestBase.cs
+++ b/uSync.Migrations.Tests/Migrators/MigratiorTestBase.cs
@@ -14,7 +14,7 @@ namespace uSync.Migrations.Tests.Migrators;
 public abstract class MigratiorTestBase
 {
     protected SyncMigrationContext _context;
-    protected ISyncPropertyMigrator _migrator;
+    protected ISyncPropertyMigrator  _migrator;
 
     [SetUp]
     public virtual void Setup()

--- a/uSync.Migrations.Tests/Migrators/TextBoxMigratorTests.cs
+++ b/uSync.Migrations.Tests/Migrators/TextBoxMigratorTests.cs
@@ -40,10 +40,10 @@ internal class TextBoxMigratorTests : MigratiorTestBase
         => EditorAliasAsExpectedbase(UmbEditors.Aliases.TextBox);
 
     protected override SyncMigrationContentProperty GetMigrationContentProperty(string value)
-        => new SyncMigrationContentProperty(UmbEditors.Aliases.TextBox, value);
+        => new SyncMigrationContentProperty("Test", "Textbox", UmbEditors.Aliases.TextBox, value);
 
     protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty()
-        => new SyncMigrationDataTypeProperty(UmbEditors.Aliases.TextBox, "Nvarchar",
+        => new SyncMigrationDataTypeProperty("Textstring", UmbEditors.Aliases.TextBox, "Nvarchar",
             new List<PreValue>
             {
                 new PreValue { SortOrder = 1, Alias = "maxChars", Value = "128" }

--- a/uSync.Migrations.Tests/Migrators/TrueFalseMigratorTests.cs
+++ b/uSync.Migrations.Tests/Migrators/TrueFalseMigratorTests.cs
@@ -19,10 +19,11 @@ internal class TrueFalseMigratorTests : MigratiorTestBase
     }
 
     protected override SyncMigrationContentProperty GetMigrationContentProperty(string value)
-        => new SyncMigrationContentProperty(UmbConstants.PropertyEditors.Aliases.Boolean, value);
+        => new SyncMigrationContentProperty("Test", "True/False", UmbConstants.PropertyEditors.Aliases.Boolean, value);
 
     protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty()
         => new SyncMigrationDataTypeProperty(
+            "True/False",
             UmbConstants.PropertyEditors.Aliases.Boolean,
             "Integer",
             new List<PreValue>());

--- a/uSync.Migrations/Context/ContentTypeMigrationContext.cs
+++ b/uSync.Migrations/Context/ContentTypeMigrationContext.cs
@@ -21,6 +21,10 @@ public class ContentTypeMigrationContext
 	private Dictionary<string, NewContentTypeInfo> _newDocTypes
 			= new Dictionary<string, NewContentTypeInfo>(StringComparer.OrdinalIgnoreCase);
 
+	/// <summary>
+	///  allows you to map property aliases in a content type to the specific datatype
+	/// </summary>
+	private Dictionary<string, string> _dataTypeAliases = new (StringComparer.OrdinalIgnoreCase);
 
     // tabs that are to be changed
     private List<TabOptions> _changedTabs { get; set; } = new List<TabOptions>();
@@ -220,6 +224,15 @@ public class ContentTypeMigrationContext
     public List<TabOptions> GetChangedTabs()
         => _changedTabs;
 
+	/// <summary>
+	///  add a mapping for a content types property to the named datatype.
+	/// </summary>
+	public void AddDataTypeAlias(string contentTypeAlias, string propertyAlias, string dataTypeAlias)
+		=> _ = _dataTypeAliases.TryAdd($"{contentTypeAlias}_{propertyAlias}", dataTypeAlias);
+
+	public string GetDataTypeAlias(string contentTypeAlias, string propertyAlias)
+		=> _dataTypeAliases.TryGetValue($"{contentTypeAlias}_{propertyAlias}", out var alias) == true
+			? alias : string.Empty;
 
 
 }

--- a/uSync.Migrations/Context/DataTypeMigrationContext.cs
+++ b/uSync.Migrations/Context/DataTypeMigrationContext.cs
@@ -28,6 +28,28 @@ public class DataTypeMigrationContext
 
 
 	/// <summary>
+	///  contains a lookup from defition (guid) to alias, so we can pass that along. 
+	/// </summary>
+	private Dictionary<Guid, string> _dataTypeAliases { get; set; } = new();	
+
+	/// <summary>
+	///  add a datatype alias to the lookup
+	/// </summary>
+	/// <param name="dtd"></param>
+	/// <param name="alias"></param>
+	public void AddAlias(Guid dtd, string alias)
+		=> _ = _dataTypeAliases.TryAdd(dtd, alias);
+
+	/// <summary>
+	///  get the alias based on the DTD value (which we have in contenttype).
+	/// </summary>
+	/// <param name="dtd"></param>
+	/// <returns></returns>
+	public string GetAlias(Guid dtd)
+		=> _dataTypeAliases?.TryGetValue(dtd, out var alias) == true
+			? alias : string.Empty;
+
+	/// <summary>
 	///  add a datatypedefinion (aka datatype key) to the context.
 	/// </summary>
 	public void AddDefinition(Guid dtd, string editorAlias)

--- a/uSync.Migrations/Context/MigratorsContext.cs
+++ b/uSync.Migrations/Context/MigratorsContext.cs
@@ -38,4 +38,29 @@ public class MigratorsContext
 		return null;
 	}
 
+	/// <summary>
+	/// A cache of dictionary items that can be used if you need to store/retrieve custom data between 
+	/// config and content mappings
+	/// </summary>
+	private Dictionary<string, Dictionary<string, object>> _migratorCache = new(StringComparer.OrdinalIgnoreCase);
+
+	/// <summary>
+	///  add a dictionary of custom values for this datatype alias.
+	/// </summary>
+	/// <remarks>
+	///  It is the migrators responsibility to make sure this custom set of values is uniqe and 
+	///  does not clash. recommendation is to use the datatype's alias. 
+	/// </remarks>
+	public void AddCustomValues(string alias, Dictionary<string, object> values)
+		=> _ = _migratorCache.TryAdd(alias, values);
+
+	/// <summary>
+	///  retreive a dictionary of custom values.
+	/// </summary>
+	/// <param name="alias"></param>
+	/// <returns></returns>
+	public Dictionary<string, object> GetCustomValues(string alias)
+		=> _migratorCache.TryGetValue(alias, out Dictionary<string, object>? values)
+			? values : new Dictionary<string, object>();
+
 }

--- a/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/DataTypeMigrationHandler.cs
@@ -41,10 +41,11 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
     protected override string GetDataTypeName(XElement source)
         => source.Element("Info")?.Element(uSyncConstants.Xml.Name).ValueOrDefault(string.Empty) ?? string.Empty;
 
-    protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty(string editorAlias, string database, XElement source)
-        => new SyncMigrationDataTypeProperty(editorAlias, database, GetXmlConfig(source));
+    protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty(
+        string alias, string editorAlias, string database, XElement source)
+        => new SyncMigrationDataTypeProperty(alias, editorAlias, database, GetXmlConfig(source));
 
-    protected override ReplacementDataTypeInfo? GetReplacementInfo(string editorAlias, string databaseType, XElement source, SyncMigrationContext context)
+    protected override ReplacementDataTypeInfo? GetReplacementInfo(string dataTypeAlias, string editorAlias, string databaseType, XElement source, SyncMigrationContext context)
     {
         // replacements
         //
@@ -52,7 +53,7 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
         if (migrator != null && migrator is ISyncReplacablePropertyMigrator replacablePropertyMigrator)
         {
             return replacablePropertyMigrator.GetReplacementEditorId(
-                new SyncMigrationDataTypeProperty(editorAlias, databaseType, GetXmlConfig(source)),
+                new SyncMigrationDataTypeProperty(dataTypeAlias, editorAlias, databaseType, GetXmlConfig(source)),
                 context);
         }
 

--- a/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
@@ -46,7 +46,7 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
             key: source.Attribute("Key").ValueOrDefault(Guid.Empty)
         );
 
-    protected override ReplacementDataTypeInfo? GetReplacementInfo(string editorAlias, string databaseType, XElement source, SyncMigrationContext context)
+    protected override ReplacementDataTypeInfo? GetReplacementInfo(string dataTypeAlias, string editorAlias, string databaseType, XElement source, SyncMigrationContext context)
     {
         //
         // replacements
@@ -55,7 +55,7 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
         if (migrator != null && migrator is ISyncReplacablePropertyMigrator replacablePropertyMigrator)
         {
             return replacablePropertyMigrator.GetReplacementEditorId(
-                new SyncMigrationDataTypeProperty(editorAlias, databaseType, GetPreValues(source)),
+                new SyncMigrationDataTypeProperty(dataTypeAlias, editorAlias, databaseType, GetPreValues(source)),
                 context);
         }
 
@@ -76,10 +76,11 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
 
     protected override int GetLevel(XElement source, int level) => level;
 
-    protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty(string editorAlias, string database, XElement source)
+    protected override SyncMigrationDataTypeProperty GetMigrationDataTypeProperty(
+        string dataTypeAlias, string editorAlias, string database, XElement source)
     {
         var preValues = GetPreValues(source);
-        return new SyncMigrationDataTypeProperty(editorAlias, database, preValues);
+        return new SyncMigrationDataTypeProperty(dataTypeAlias, editorAlias, database, preValues);
     }
 
     private static IList<PreValue> GetPreValues(XElement source)

--- a/uSync.Migrations/Handlers/Shared/SharedContentBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentBaseHandler.cs
@@ -115,14 +115,16 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
 
         // convert the property .
 
-        var migrationProperty = new SyncMigrationContentProperty(editorAlias, property.Value);
+        var migrationProperty = new SyncMigrationContentProperty(
+            contentType, property.Name.LocalName, editorAlias, property.Value);
+
         var migrator = context.Migrators.TryGetVariantMigrator(editorAlias);
         if (migrator != null && itemType == "Content")
         {
             // it might be the case that the property needs to be split into variants. 
             // if this is the case a ISyncVariationPropertyEditor will exist and it can 
             // split a single value into a collection split by culture
-            var vortoElement = GetVariedValueNode(migrator, property.Name.LocalName, migrationProperty, context);
+            var vortoElement = GetVariedValueNode(migrator, contentType, property.Name.LocalName, migrationProperty, context);
             if (vortoElement != null) return vortoElement;
         }
 
@@ -137,7 +139,7 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
     ///  special case, spit a vorto value into multiple cultures, 
     ///  and return them back as a blob of xml values
     /// </summary>
-    protected virtual XElement? GetVariedValueNode(ISyncVariationPropertyMigrator migrator, string propertyName, SyncMigrationContentProperty migrationProperty, SyncMigrationContext context)
+    protected virtual XElement? GetVariedValueNode(ISyncVariationPropertyMigrator migrator, string contentTypeAlias, string propertyName, SyncMigrationContentProperty migrationProperty, SyncMigrationContext context)
     {
         // Get varied elements from the migrator.
         var attempt = migrator.GetVariedElements(migrationProperty, context);
@@ -154,7 +156,9 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
             {
                 foreach (var variation in attempt.Result.Values)
                 {
-                    var variationProperty = new SyncMigrationContentProperty(variantEditorAlias, variation.Value);
+                    var variationProperty = new SyncMigrationContentProperty(
+                        contentTypeAlias, propertyName,
+                        variantEditorAlias, variation.Value);
 
                     var migratedValue = MigrateContentValue(variationProperty, context);
 

--- a/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -50,6 +50,9 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
             context.ContentTypes.AddProperty(contentTypeAlias, alias,
                     editorAlias, context.DataTypes.GetByDefinition(definition));
 
+            context.ContentTypes.AddDataTypeAlias(contentTypeAlias, alias,
+                context.DataTypes.GetAlias(definition));
+
             //
             // for now we are doing this just for media folders, but it might be
             // that all list view properties should be ignored ??

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/DocTypeGridEditorBlockMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/DocTypeGridEditorBlockMigrator.cs
@@ -103,6 +103,8 @@ internal class DocTypeGridEditorBlockMigrator : ISyncBlockMigrator
 
 			if (migrator != null) { 
 				var property = new SyncMigrationContentProperty(
+					$"Grid.{editorAlias.OriginalEditorAlias}",
+					propertyAlias,
 					editorAlias.OriginalEditorAlias,
 					value?.ToString() ?? string.Empty);
 

--- a/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -224,7 +224,9 @@ internal class GridToBlockContentHelper
                 var migrator = context.Migrators.TryGetMigrator(editorAlias.OriginalEditorAlias);
                 if (migrator != null)
                 {
-                    var property = new SyncMigrationContentProperty(editorAlias.OriginalEditorAlias, value?.ToString() ?? string.Empty);
+                    var property = new SyncMigrationContentProperty(
+                        contentTypeAlias, propertyAlias,
+                        editorAlias.OriginalEditorAlias, value?.ToString() ?? string.Empty);
                     propertyValue = migrator.GetContentValue(property, context);
                     _logger.LogDebug("Migrator: {migrator} returned {value}", migrator.GetType().Name, propertyValue); 
                 }

--- a/uSync.Migrations/Migrators/Community/StackedContentToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/StackedContentToBlockListMigrator.cs
@@ -97,6 +97,7 @@ public class StackedContentToBlockListMigrator : SyncPropertyMigratorBase
                 }
 
                 var childProperty = new SyncMigrationContentProperty(editorAlias.OriginalEditorAlias,
+                    contentTypeAlias, propertyAlias,
                     value?.ToString() ?? string.Empty);
 
                 item.Values[propertyAlias] = migrator.GetContentValue(childProperty, context);

--- a/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
@@ -56,7 +56,10 @@ public class NestedContentMigrator : SyncPropertyMigratorBase
                 var migrator = context.Migrators.TryGetMigrator(editorAlias.OriginalEditorAlias);
                 if (migrator != null)
                 {
-                    row.RawPropertyValues[property.Key] = migrator.GetContentValue(new SyncMigrationContentProperty(row.ContentTypeAlias, property.Value?.ToString()), context);
+                    row.RawPropertyValues[property.Key] = migrator.GetContentValue(
+                        new SyncMigrationContentProperty(
+                            row.ContentTypeAlias, property.Key, row.ContentTypeAlias, property.Value?.ToString()),
+                            context);
                 }
             }
         }

--- a/uSync.Migrations/Migrators/Models/SyncMigrationContentProperty.cs
+++ b/uSync.Migrations/Migrators/Models/SyncMigrationContentProperty.cs
@@ -5,10 +5,29 @@
 /// </summary>
 public sealed class SyncMigrationContentProperty : SyncMigrationPropertyBase
 {
-    public SyncMigrationContentProperty(string editorAlias, string? value)
+    public string ContentTypeAlias { get; set; }
+    public string PropertyAlias { get; set; }
+
+    [Obsolete("Pass in ContentTypeAlias and PropertyAlias to enable more granular control")]
+    public SyncMigrationContentProperty(
+        string editorAlias, string? value)
         : base(editorAlias)
     {
         Value = value;
+
+        // fallback values
+        ContentTypeAlias = editorAlias;
+        PropertyAlias = editorAlias;
+    }
+
+    public SyncMigrationContentProperty(
+        string contentTypeAlias,
+        string propertyAlias,
+        string editorAlias, string? value)
+        : this(editorAlias, value)
+    {
+        ContentTypeAlias = contentTypeAlias;
+        PropertyAlias = propertyAlias;  
     }
 
     public string? Value { get; private set; }

--- a/uSync.Migrations/Migrators/Models/SyncMigrationDataTypeProperty.cs
+++ b/uSync.Migrations/Migrators/Models/SyncMigrationDataTypeProperty.cs
@@ -6,19 +6,23 @@ namespace uSync.Migrations.Migrators.Models;
 
 public sealed class SyncMigrationDataTypeProperty : SyncMigrationPropertyBase
 {
-    public SyncMigrationDataTypeProperty(string editorAlias, string databaseType, IList<PreValue> preValues)
+    public SyncMigrationDataTypeProperty(string dataTypeAlias, string editorAlias, string databaseType, IList<PreValue> preValues)
         : base(editorAlias)
     {
         DatabaseType = databaseType;
+        DataTypeAlias = dataTypeAlias;
         PreValues = new ReadOnlyCollection<PreValue>(preValues);
     }
 
-    public SyncMigrationDataTypeProperty(string editorAlias, string databaseType, string? config)
+    public SyncMigrationDataTypeProperty(string dataTypeAlias, string editorAlias, string databaseType, string? config)
         : base(editorAlias) 
     {
+        DataTypeAlias = dataTypeAlias;
         DatabaseType = databaseType;
         ConfigAsString = config;
     }
+
+    public string DataTypeAlias { get; private set; }   
 
     public string DatabaseType { get; private set; }
 

--- a/uSync.Migrations/Migrators/Optional/NestedToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Optional/NestedToBlockListMigrator.cs
@@ -133,7 +133,11 @@ public class NestedToBlockListMigrator : SyncPropertyMigratorBase
                 var migrator = context.Migrators.TryGetMigrator(editorAlias.OriginalEditorAlias);
                 if (migrator != null)
                 {
-                    block.RawPropertyValues[property.Key] = migrator.GetContentValue(new SyncMigrationContentProperty(row.ContentTypeAlias, property.Value.ToString()), context);
+                    block.RawPropertyValues[property.Key] = migrator.GetContentValue(
+                        new SyncMigrationContentProperty(
+                            row.ContentTypeAlias,
+                            property.Key,
+                            row.ContentTypeAlias, property.Value.ToString()), context);
                 }
                 else
                 {


### PR DESCRIPTION
Alters the `SyncMigrationDataTypeProperty` and `SyncMigrationContentProperty` models so we pass contentType alias, 
property alias (and by lookup) the datatype alias to config and content migrator methods. 

also add a new `AddCustomValues` / `GetCustomValues` methods to the context. 

## Theory ! 

this means - in `GetConfigValues` call, you can add custom values to the content, that will be relevant only 
to this exact version of a datatype (e.g a speicifcally named NuPicker list?)

```cs
context.Migrators.AddCustomValues(dataTypeProperty.DataTypeAlias,
    new Dictionary<string, object>
    {
        { "Something", "Value one" },
        { "Another", false }
    });
```

then in the `GetContentValue` call, you can use the context's to get the datatype's defined alias, and retrieve the 
custom mapped values. 

```cs
var customData = context.Migrators.GetCustomValues
    (context.ContentTypes.GetDataTypeAlias(contentProperty.ContentTypeAlias, contentProperty.PropertyAlias));
```

## n.b

it is the responsbility of the migrator to make sure its CustomValues key is unique - the recommended way is to use the datatype alias(name) as above. 

## Warnings

Little concerned this might be too breaking (even for a beta) it does change the constructors of a few classes so we can pass things along
