### PR TITLE
ContentPicker1Migrator support for Keys not UDIs

### DIFF
--- a/uSync.Migrations/Migrators/Core/ContentPickerMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/ContentPickerMigrator.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Core.Models;
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using uSync.Migrations.Context;
 using uSync.Migrations.Extensions;
@@ -13,7 +14,7 @@ public class ContentPicker1Migrator : SyncPropertyMigratorBase
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => UmbConstants.PropertyEditors.Aliases.ContentPicker;
     public override string GetDatabaseType(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-=> nameof(ValueStorageType.Ntext);
+        => nameof(ValueStorageType.Ntext);
 
     public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
     {
@@ -26,5 +27,16 @@ public class ContentPicker1Migrator : SyncPropertyMigratorBase
         };
 
         return config.MapPreValues(dataTypeProperty.PreValues, mappings);
+    }
+
+    public override string GetContentValue (SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
+    {
+        // A Key should be a UDI
+        if (Guid.TryParse(contentProperty.Value, out var guid))
+        {
+            return new GuidUdi(UmbConstants.UdiEntityType.Document, guid).ToString();
+        }
+
+        return base.GetContentValue(contentProperty, context);
     }
 }


### PR DESCRIPTION
My v7 files have Content Picker data saved as a Guid only. 
e.g.

```
<?xml version="1.0" encoding="utf-8"?>
<Settings guid="17989892-0abc-4241-ad44-1d29d6d207f2" id="1123" nodeName="Settings" isDoc="" updated="2022-12-05T10:47:45.8200000Z" parentGUID="e7ea6873-8661-48ee-8741-e8e9e91264ab" nodeTypeAlias="Settings" templateAlias="" sortOrder="5" published="true" isBlueprint="false">
  <footer>3838ffde-5519-4ed5-8f75-241a40293d8b</footer>
  <header>ac0c2245-9e48-4257-96dd-f45b265a8e40</header>
</Settings>
```

The property then appears empty in the backoffice after migration.

This simple update converts any data that is a straight Guid in to a Udi