### PR TITLE
NC key can be empty

### DIFF
--- a/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
@@ -48,6 +48,11 @@ public class NestedContentMigrator : SyncPropertyMigratorBase
 
         foreach (var row in rowValues)
         {
+            if (row.Id == default)
+            {
+                row.Id = Guid.NewGuid();
+            }
+
             foreach (var property in row.RawPropertyValues)
             {
                 var editorAlias = context.ContentTypes.GetEditorAliasByTypeAndProperty(row.ContentTypeAlias, property.Key);


### PR DESCRIPTION
I've got empty keys in my old v7 data, which works in the backoffice but breaks on published content model ctor.

Enforcing a key resolves the issue.