### PR TITLE
Fix tab structure in migrated Content Type definition files (Umbraco 7)

### DIFF
--- a/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -49,7 +49,7 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
             var newTabs = new XElement("Tabs");
             foreach (var tab in tabs.Elements("Tab"))
             {
-                var newTab = UpdateTab(source, tab.Clone(), context);
+                var newTab = UpdateTab(source, tab.Clone(), context, false);
                 if (newTab != null) newTabs.Add(newTab);
             }
             target.Add(newTabs);
@@ -63,7 +63,7 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
         newProperty.Add(new XElement("LabelOnTop", false));
 
         var tabNode = newProperty.Element("Tab");
-        UpdateTab(source, tabNode, context);
+        UpdateTab(source, tabNode, context, true);
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
     ///  
     ///  we also can rename and remove tabs by setting adding a ChangedTab to the context. 
     /// </remarks>
-    internal XElement? UpdateTab(XElement source, XElement? tab, SyncMigrationContext context)
+    internal XElement? UpdateTab(XElement source, XElement? tab, SyncMigrationContext context, bool useAttributes)
     {
         if (tab == null) return null;
 
@@ -100,8 +100,19 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
         }
 
         // set alias, and type (always tab?)
-        tab.SetAttributeValue("Alias", alias);
-        tab.SetAttributeValue("Type", "Tab");
+        // add caption if the value is there 
+        if (useAttributes)
+        {
+            tab.SetAttributeValue("Alias", alias);
+            tab.SetAttributeValue("Type", "Tab");
+        }
+        else
+        {
+            tab.Elements("Alias").Remove();
+            tab.Add(new XElement("Alias", alias));
+            tab.Elements("Type").Remove();
+            tab.Add(new XElement("Type", "Tab"));
+        }
 
         return tab;
     }


### PR DESCRIPTION
As it stands, when generating the migrated uSync definition for a Content Type in Umbraco 7, the tabs section has `Alias` and `Type` as attributes:

```
  <GenericProperties>
    <GenericProperty>
      <Key>0270d8ba-00c8-4e44-90f2-b4a485ae72da</Key>
      <Name>Description</Name>
      <Alias>description</Alias>
      <Definition>1f540f32-a19a-4fd9-abd1-59886381f1e3</Definition>
      <Type>Umbraco.TinyMCEv3</Type>
      <Mandatory>false</Mandatory>
      <Validation></Validation>
      <Description><![CDATA[]]></Description>
      <SortOrder>1</SortOrder>
      <Tab Alias="Content" Type="Tab">Content</Tab>
      <Variations>Nothing</Variations>
      <MandatoryMessage></MandatoryMessage>
      <ValidationRegExpMessage></ValidationRegExpMessage>
      <LabelOnTop>false</LabelOnTop>
    </GenericProperty>
  </GenericProperties>
  <Tabs>
    <Tab Alias="Content" Type="Tab">
      <Caption>Content</Caption>
      <SortOrder>3</SortOrder>
      <Key>a75ff54d-a630-3d2d-aa99-0cabec365c2b</Key>
    </Tab>
  </Tabs>
```

In regular uSync definition files for content types generated in v10, the tabs section has `Alias` and `Type` as elements rather than attributes.

This discrepancy seems to cause an issue whereby when you try to migrate content types more than once, you get this error on subsequent attempts:
> ContentTypeHandler import fail: Set an alias before adding the property group.

Following this PR, the tabs section for migrated content types will get generated like this:

```
<Tabs>
    <Tab>
      <Caption>Content</Caption>
      <SortOrder>3</SortOrder>
      <Key>a75ff54d-a630-3d2d-aa99-0cabec365c2b</Key>
      <Alias>Content</Alias>
      <Type>Tab</Type>
    </Tab>
  </Tabs>
```