### PR TITLE
adds info about v8 'migrations'

### DIFF
--- a/uSync.Migrations/wwwroot/uSyncMigrations/Lang/en-us.xml
+++ b/uSync.Migrations/wwwroot/uSyncMigrations/Lang/en-us.xml
@@ -13,6 +13,8 @@
 			<![CDATA[<p>you can migrate your own way</p>]]>
 		</key>
 
+		<key alias="v8warn"><![CDATA[<strong>You don't need to Migrate uSync v8 files to uSync v9/10+ - simply copy or rename the uSync/v8 folder to uSync/v9</strong>]]></key>
+
 		<key alias="customize">
 			<![CDATA[You can customize this list with your own `ISyncMigrationProfile` or remove and add simple configs with a '/usync/profiles.json' file.]]>
 		</key>

--- a/uSync.Migrations/wwwroot/uSyncMigrations/dashboard.html
+++ b/uSync.Migrations/wwwroot/uSyncMigrations/dashboard.html
@@ -14,6 +14,15 @@
         </umb-box-content>
     </umb-box>
 
+    <umb-box>
+        <umb-box-content class="umb-box flex items-center color-blue">
+            <div class="mr2">
+                <umb-icon icon="icon-alert"></umb-icon>
+            </div>
+            <div><localize key="usyncmigrate_v8warn"></localize></div>
+        </umb-box-content>
+    </umb-box>
+
     <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
 
     <div ng-if="!vm.loading">


### PR DESCRIPTION
We've had a few 'how do i upgrade v8' requests, and the answer is rename the folder. you don't need migrations. 