### PR TITLE
Add Archetype migrator

### DIFF
--- a/uSync.Migrations/Composing/SyncMigrationsComposer.cs
+++ b/uSync.Migrations/Composing/SyncMigrationsComposer.cs
@@ -10,6 +10,7 @@ using uSync.Migrations.Handlers;
 using uSync.Migrations.Migrators;
 using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
 using uSync.Migrations.Migrators.BlockGrid.Extensions;
+using uSync.Migrations.Migrators.Community.Archetype;
 using uSync.Migrations.Notifications;
 using uSync.Migrations.Services;
 using uSync.Migrations.Validation;
@@ -64,6 +65,10 @@ public static class SyncMigrationsBuilderExtensions
         builder
             .WithCollectionBuilder<SyncMigrationValidatorCollectionBuilder>()
                 .Add(() => builder.TypeLoader.GetTypes<ISyncMigrationValidator>());
+
+        builder
+            .WithCollectionBuilder<ArchetypeMigrationConfigurerCollectionBuilder>()
+                .Add(() => builder.TypeLoader.GetTypes<IArchetypeMigrationConfigurer>());
 
         builder.Services.AddTransient<ISyncMigrationService, SyncMigrationService>();
         builder.Services.AddTransient<ISyncMigrationConfigurationService, SyncMigrationConfigurationService>();

--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -38,6 +38,8 @@ public class MigrationOptions
     /// List of tabs that will be changed
     /// </summary>
     public List<TabOptions>? ChangeTabs { get; set; }
+
+    public string? ArchetypeMigrationConfigurer { get; set; }
 }
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]

--- a/uSync.Migrations/Context/ContentTypeMigrationContext.cs
+++ b/uSync.Migrations/Context/ContentTypeMigrationContext.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Migrators.Community.Archetype;
 using uSync.Migrations.Models;
 
 namespace uSync.Migrations.Context;
@@ -33,14 +34,15 @@ public class ContentTypeMigrationContext
     ///  list of content types that need to be set as element types. 
     /// </summary>
     private HashSet<Guid> _elementContentTypes = new HashSet<Guid>();
+    public IArchetypeMigrationConfigurer ArchetypeMigrationConfigurer { get; set; } = new DefaultArchetypeMigrationConfigurer();
 
-	/// <summary>
-	///  Add a ccontent type key to the context.
-	/// </summary>
-	/// <param name="contentTypeAlias"></param>
-	/// <param name="contentTypeKey"></param>
+    /// <summary>
+    ///  Add a ccontent type key to the context.
+    /// </summary>
+    /// <param name="contentTypeAlias"></param>
+    /// <param name="contentTypeKey"></param>
 
-	public void AddAliasAndKey(string? contentTypeAlias, Guid? contentTypeKey)
+    public void AddAliasAndKey(string? contentTypeAlias, Guid? contentTypeKey)
 	{
 		_ = string.IsNullOrWhiteSpace(contentTypeAlias) == false &&
 			contentTypeKey.HasValue == true &&

--- a/uSync.Migrations/Context/DataTypeMigrationContext.cs
+++ b/uSync.Migrations/Context/DataTypeMigrationContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using uSync.Migrations.Models;
 
 namespace uSync.Migrations.Context;
 
@@ -14,7 +15,7 @@ public class DataTypeMigrationContext
 	/// <summary>
 	///  list of keys to editor aliases used to lookup datatypes in content types !
 	/// </summary>
-	private Dictionary<Guid, string> _dataTypeDefinitions { get; set; } = new();
+	private Dictionary<Guid, DataTypeInfo> _dataTypeDefinitions { get; set; } = new();
 
 	/// <summary>
 	///  when we replace an datatype with something else .
@@ -52,16 +53,16 @@ public class DataTypeMigrationContext
 	/// <summary>
 	///  add a datatypedefinion (aka datatype key) to the context.
 	/// </summary>
-	public void AddDefinition(Guid dtd, string editorAlias)
-		=> _ = _dataTypeDefinitions.TryAdd(dtd, editorAlias);
+	public void AddDefinition(Guid dtd, DataTypeInfo def)
+		=> _ = _dataTypeDefinitions.TryAdd(dtd, def);
 
 	/// <summary>
 	///  get a datatype definiton from the context.
 	/// </summary>
-	public string GetByDefinition(Guid guid)
-		=> _dataTypeDefinitions?.TryGetValue(guid, out var editorAlias) == true
-			? editorAlias
-			: string.Empty;
+	public DataTypeInfo? GetByDefinition(Guid guid)
+		=> _dataTypeDefinitions?.TryGetValue(guid, out var def) == true
+			? def
+			: null;
 
 	/// <summary>
 	///  add the key that replaces a datatype to the context.

--- a/uSync.Migrations/Context/SyncMigrationContext.cs
+++ b/uSync.Migrations/Context/SyncMigrationContext.cs
@@ -48,7 +48,6 @@ public class SyncMigrationContext : IDisposable
 
     private HashSet<string> _blockedTypes = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<int, Guid> _idKeyMap { get; set; } = new();
-    public IArchetypeMigrationConfigurer ArchetypeMigrationConfigurer { get; set; } = new DefaultArchetypeMigrationConfigurer();
 
     /// <summary>
     ///  is this item blocked based on alias and type. 

--- a/uSync.Migrations/Context/SyncMigrationContext.cs
+++ b/uSync.Migrations/Context/SyncMigrationContext.cs
@@ -1,4 +1,5 @@
 ﻿using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Migrators.Community.Archetype;
 
 namespace uSync.Migrations.Context;
 
@@ -47,6 +48,7 @@ public class SyncMigrationContext : IDisposable
 
     private HashSet<string> _blockedTypes = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<int, Guid> _idKeyMap { get; set; } = new();
+    public IArchetypeMigrationConfigurer ArchetypeMigrationConfigurer { get; set; } = new DefaultArchetypeMigrationConfigurer();
 
     /// <summary>
     ///  is this item blocked based on alias and type. 

--- a/uSync.Migrations/Extensions/ContentTypeExtensions.cs
+++ b/uSync.Migrations/Extensions/ContentTypeExtensions.cs
@@ -51,7 +51,7 @@ internal static class ContentTypeExtensions
 				if (dataType == null) continue;
 
 				var propNode = new XElement("GenericProperty",
-				new XElement("Key", property.Name.ToGuid()),
+				new XElement("Key", $"{newDocType.Alias}_{property.Alias}".ToGuid()),
 					new XElement("Name", property.Name),
 					new XElement("Alias", property.Alias),
 					new XElement("Definition", dataType.Key),

--- a/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using uSync.Migrations.Composing;
 using uSync.Migrations.Context;
 using uSync.Migrations.Extensions;
 using uSync.Migrations.Handlers.Shared;
@@ -18,8 +19,9 @@ internal class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseH
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         ILogger<ContentTypeBaseMigrationHandler<TEntity>> logger,
-        IDataTypeService dataTypeService) 
-        : base(eventAggregator, migrationFileService, logger, dataTypeService)
+        IDataTypeService dataTypeService,
+        Lazy<SyncMigrationHandlerCollection> migrationHandlers) 
+        : base(eventAggregator, migrationFileService, logger, dataTypeService, migrationHandlers)
     { }
 
     protected override void UpdatePropertyXml(XElement source, XElement newProperty, SyncMigrationContext context)

--- a/uSync.Migrations/Handlers/Eight/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeMigrationHandler.cs
@@ -3,7 +3,7 @@
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-
+using uSync.Migrations.Composing;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Eight;
@@ -18,7 +18,8 @@ internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<Con
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         ILogger<ContentTypeMigrationHandler> logger,
-        IDataTypeService dataTypeService) 
-        : base(eventAggregator, migrationFileService, logger, dataTypeService)
+        IDataTypeService dataTypeService,
+        Lazy<SyncMigrationHandlerCollection> migrationHandlers) 
+        : base(eventAggregator, migrationFileService, logger, dataTypeService, migrationHandlers)
     { }
 }

--- a/uSync.Migrations/Handlers/Eight/MediaTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/MediaTypeMigrationHandler.cs
@@ -3,7 +3,7 @@
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-
+using uSync.Migrations.Composing;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Eight;
@@ -18,8 +18,9 @@ internal class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<Media
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         ILogger<MediaTypeMigrationHandler> logger,
-		IDataTypeService dataTypeService)
-		: base(eventAggregator, migrationFileService, logger, dataTypeService)
+		IDataTypeService dataTypeService, 
+        Lazy<SyncMigrationHandlerCollection> migrationHandlers)
+		: base(eventAggregator, migrationFileService, logger, dataTypeService, migrationHandlers)
 	{
     }
 }

--- a/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
 using uSync.Core;
+using uSync.Migrations.Composing;
 using uSync.Migrations.Context;
 using uSync.Migrations.Extensions;
 using uSync.Migrations.Handlers.Shared;
@@ -29,8 +30,9 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
         ISyncMigrationFileService migrationFileService,
         ILogger<ContentTypeBaseMigrationHandler<TEntity>> logger,
         IDataTypeService dataTypeService,
-        IShortStringHelper shortStringHelper)
-        : base(eventAggregator, migrationFileService, logger, dataTypeService)
+        IShortStringHelper shortStringHelper,
+        Lazy<SyncMigrationHandlerCollection> migrationHandlers)
+        : base(eventAggregator, migrationFileService, logger, dataTypeService, migrationHandlers)
     {
         _shortStringHelper = shortStringHelper;
     }

--- a/uSync.Migrations/Handlers/Seven/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeMigrationHandler.cs
@@ -4,8 +4,7 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
-
-using uSync.Migrations.Handlers.Seven;
+using uSync.Migrations.Composing;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
@@ -21,7 +20,8 @@ internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<Con
         ISyncMigrationFileService migrationFileService,
         ILogger<ContentTypeMigrationHandler> logger,
 		IDataTypeService dataTypeService,
-        IShortStringHelper shortStringHelper)
-		: base(eventAggregator, migrationFileService, logger, dataTypeService, shortStringHelper)
+        IShortStringHelper shortStringHelper, 
+        Lazy<SyncMigrationHandlerCollection> migrationHandlers)
+		: base(eventAggregator, migrationFileService, logger, dataTypeService, shortStringHelper, migrationHandlers)
 	{ }
 }

--- a/uSync.Migrations/Handlers/Seven/MediaTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/MediaTypeMigrationHandler.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
-
+using uSync.Migrations.Composing;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
@@ -20,7 +20,8 @@ internal class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<Media
         ISyncMigrationFileService migrationFileService,
         ILogger<MediaTypeMigrationHandler> logger,
 		IDataTypeService dataTypeService,
-        IShortStringHelper shortStringHelper)
-		: base(eventAggregator, migrationFileService, logger, dataTypeService, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        Lazy<SyncMigrationHandlerCollection> migrationHandlers)
+		: base(eventAggregator, migrationFileService, logger, dataTypeService, shortStringHelper, migrationHandlers)
 	{ }
 }

--- a/uSync.Migrations/Handlers/Shared/SharedContentBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentBaseHandler.cs
@@ -151,14 +151,14 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
             var newProperty = new XElement(propertyName);
 
             // get editor alias from dtdguid
-            var variantEditorAlias = context.DataTypes.GetByDefinition(attempt.Result.DtdGuid);
-            if (variantEditorAlias != null)
+            var variantDataType = context.DataTypes.GetByDefinition(attempt.Result.DtdGuid);
+            if (variantDataType != null)
             {
                 foreach (var variation in attempt.Result.Values)
                 {
                     var variationProperty = new SyncMigrationContentProperty(
                         contentTypeAlias, propertyName,
-                        variantEditorAlias, variation.Value);
+                        variantDataType.EditorAlias, variation.Value);
 
                     var migratedValue = MigrateContentValue(variationProperty, context);
 

--- a/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
@@ -44,7 +44,7 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
     {
         foreach (var datatype in _dataTypeService.GetAll())
         {
-            context.DataTypes.AddDefinition(datatype.Key, datatype.EditorAlias);
+            context.DataTypes.AddDefinition(datatype.Key, new Models.DataTypeInfo(datatype.EditorAlias, datatype.Name ?? datatype.EditorAlias));
         }
     }
 
@@ -60,13 +60,14 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
         if (dtd == Guid.Empty || string.IsNullOrEmpty(editorAlias)) return;
 
         var databaseType = GetDatabaseType(source);
+        var dataTypeName = GetDataTypeName(source);
 
         // replacements
         var replacementInfo = GetReplacementInfo(alias, editorAlias, databaseType, source, context);
         if (replacementInfo != null)
         {
             context.DataTypes.AddReplacement(dtd, replacementInfo.Key);
-            context.DataTypes.AddDefinition(dtd, replacementInfo.EditorAlias);
+            context.DataTypes.AddDefinition(dtd, new Models.DataTypeInfo(replacementInfo.EditorAlias, dataTypeName));
 
             if (string.IsNullOrWhiteSpace(replacementInfo.Variation) == false)
             {
@@ -75,7 +76,7 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
         }
 
         // add alias, (won't update if replacement was added)
-        context.DataTypes.AddDefinition(dtd, editorAlias);
+        context.DataTypes.AddDefinition(dtd, new Models.DataTypeInfo(editorAlias, dataTypeName));
         context.DataTypes.AddAlias(dtd, alias);
     }
 

--- a/uSync.Migrations/Migrators/Community/Archetype/ArchetypeMigrationConfigurerCollectionBuilder.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/ArchetypeMigrationConfigurerCollectionBuilder.cs
@@ -1,0 +1,16 @@
+﻿using Umbraco.Cms.Core.Composing;
+
+namespace uSync.Migrations.Migrators.Community.Archetype;
+
+public class ArchetypeMigrationConfigurerCollectionBuilder
+    : LazyCollectionBuilderBase<ArchetypeMigrationConfigurerCollectionBuilder, ArchetypeMigrationConfigurerCollection, IArchetypeMigrationConfigurer>
+{
+    protected override ArchetypeMigrationConfigurerCollectionBuilder This => this;
+}
+
+public class ArchetypeMigrationConfigurerCollection
+    : BuilderCollectionBase<IArchetypeMigrationConfigurer>
+{
+    public ArchetypeMigrationConfigurerCollection(Func<IEnumerable<IArchetypeMigrationConfigurer>> items) : base(items)
+    { }
+}

--- a/uSync.Migrations/Migrators/Community/Archetype/ArchetypeToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/ArchetypeToBlockListMigrator.cs
@@ -51,7 +51,7 @@ public class ArchetypeToBlockListMigrator : SyncPropertyMigratorBase
 
         foreach (var fieldset in archetypeConfiguration.Fieldsets)
         {
-            var alias = context.ArchetypeMigrationConfigurer.GetBlockElementAlias(fieldset.Alias, context);
+            var alias = context.ContentTypes.ArchetypeMigrationConfigurer.GetBlockElementAlias(fieldset.Alias, context);
             var newContentType = new NewContentTypeInfo
             {
                 Key = alias.ToGuid(),
@@ -123,7 +123,7 @@ public class ArchetypeToBlockListMigrator : SyncPropertyMigratorBase
 
         foreach (var item in items)
         {
-            var blockElementAlias = context.ArchetypeMigrationConfigurer.GetBlockElementAlias(item.Alias, context);
+            var blockElementAlias = context.ContentTypes.ArchetypeMigrationConfigurer.GetBlockElementAlias(item.Alias, context);
             var rawValues = new Dictionary<string, object?>();
             foreach (var property in item.Properties)
             {

--- a/uSync.Migrations/Migrators/Community/Archetype/ArchetypeToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/ArchetypeToBlockListMigrator.cs
@@ -1,0 +1,179 @@
+using Archetype.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
+using uSync.Migrations.Context;
+using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.Community.Archetype;
+
+[SyncMigrator("Imulus.Archetype")]
+[SyncMigratorVersion(7)]
+public class ArchetypeToBlockListMigrator : SyncPropertyMigratorBase
+{
+    public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => UmbConstants.PropertyEditors.Aliases.BlockList;
+
+    public override string GetDatabaseType(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => nameof(ValueStorageType.Ntext);
+
+    public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+    {
+        var config = new BlockListConfiguration();
+        var configPrevalue = dataTypeProperty.PreValues?.FirstOrDefault(p => p.Alias == "archetypeConfig")?.Value;
+        if (string.IsNullOrEmpty(configPrevalue))
+        {
+            return string.Empty;
+        }
+
+        var archetypeConfiguration = JsonConvert.DeserializeObject<ArchetypePreValue>(configPrevalue);
+
+        if (archetypeConfiguration == null)
+        {
+            return config;
+        }
+
+        config.ValidationLimit = new BlockListConfiguration.NumberRange()
+        {
+            Max = archetypeConfiguration.MaxFieldsets == default ? null : archetypeConfiguration.MaxFieldsets,
+            Min = archetypeConfiguration.MinFieldsets == default ? null : archetypeConfiguration.MinFieldsets,
+        };
+        config.UseSingleBlockMode = archetypeConfiguration.MaxFieldsets == 1 && archetypeConfiguration.MinFieldsets == 1 && archetypeConfiguration.Fieldsets.Count() == 1;
+        config.UseLiveEditing = true;
+        config.UseInlineEditingAsDefault = true;
+
+        var blocks = new List<BlockListConfiguration.BlockConfiguration>();
+
+        foreach (var fieldset in archetypeConfiguration.Fieldsets)
+        {
+            var alias = context.ArchetypeMigrationConfigurer.GetBlockElementAlias(fieldset.Alias, context);
+            var newContentType = new NewContentTypeInfo
+            {
+                Key = alias.ToGuid(),
+                Alias = alias,
+                Icon = string.IsNullOrWhiteSpace(fieldset.Icon) ? "icon-umb-content" : fieldset.Icon,
+                IsElement = true,
+                Name = fieldset.Label,
+                Folder = "Block List",
+                Properties = fieldset.Properties
+                    .Select(p =>
+                    {
+                        var dataType = context.DataTypes.GetByDefinition(p.DataTypeGuid);
+                        if (dataType == null)
+                        {
+                            return null;
+                        }
+
+                        return new NewContentTypeProperty
+                        {
+                            Alias = p.Alias,
+                            Name = p.Label,
+                            DataTypeAlias = dataType.DataTypeName,
+                            OriginalEditorAlias = dataType.EditorAlias,
+                        };
+                    })
+                    .WhereNotNull()
+                    .ToList(),
+            };
+
+            context.ContentTypes.AddNewContentType(newContentType);
+            context.ContentTypes.AddAliasAndKey(newContentType.Alias, newContentType.Key);
+            context.ContentTypes.AddElementType(newContentType.Key);
+
+            blocks.Add(new BlockListConfiguration.BlockConfiguration
+            {
+                ContentElementTypeKey = newContentType.Key,
+                Label = fieldset.LabelTemplate,
+            });
+        }
+
+        config.Blocks = blocks.ToArray();
+
+        return config;
+    }
+
+    public override string GetContentValue(SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
+    {
+        if (string.IsNullOrWhiteSpace(contentProperty?.Value))
+        {
+            return string.Empty;
+        }
+
+        var archetype = JsonConvert.DeserializeObject<ArchetypeModel>(contentProperty.Value);
+        if (archetype == null)
+        {
+            return string.Empty;
+        }
+
+        var items = archetype.Fieldsets?.Where(f => !f.Disabled);
+
+        if (items?.Any() != true)
+        {
+            return string.Empty;
+        }
+
+        var contentData = new List<BlockItemData>();
+
+        var layout = new List<BlockListLayoutItem>();
+
+        foreach (var item in items)
+        {
+            var blockElementAlias = context.ArchetypeMigrationConfigurer.GetBlockElementAlias(item.Alias, context);
+            var rawValues = new Dictionary<string, object?>();
+            foreach (var property in item.Properties)
+            {
+                var editorAlias = context.ContentTypes.GetEditorAliasByTypeAndProperty(blockElementAlias, property.Alias);
+
+                if (editorAlias == null)
+                {
+                    continue;
+                }
+
+                var migrator = context.Migrators.TryGetMigrator(editorAlias.OriginalEditorAlias);
+
+                if (migrator == null)
+                {
+                    continue;
+                }
+
+                var childProperty = new SyncMigrationContentProperty(editorAlias.OriginalEditorAlias,
+                    property.Value.ToString() ?? string.Empty);
+
+                rawValues[property.Alias] = migrator.GetContentValue(childProperty, context);
+            }
+
+            var key = context.ContentTypes.GetKeyByAlias(blockElementAlias);
+            var block = new BlockItemData
+            {
+                ContentTypeKey = key,
+                Udi = Udi.Create(UmbConstants.UdiEntityType.Element, item.Id),
+                RawPropertyValues = rawValues,
+            };
+
+            layout.Add(new BlockListLayoutItem { ContentUdi = block.Udi });
+
+            contentData.Add(block);
+        }
+
+        if (contentData.Any() == false)
+        {
+            return string.Empty;
+        }
+
+        var model = new BlockValue
+        {
+            ContentData = contentData,
+            Layout = new Dictionary<string, JToken>
+            {
+                { UmbConstants.PropertyEditors.Aliases.BlockList, JArray.FromObject(layout) },
+            },
+        };
+
+        return JsonConvert.SerializeObject(model, Formatting.Indented);
+    }
+}

--- a/uSync.Migrations/Migrators/Community/Archetype/DefaultArchetypeMigrationConfigurer.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/DefaultArchetypeMigrationConfigurer.cs
@@ -1,0 +1,11 @@
+﻿using uSync.Migrations.Context;
+
+namespace uSync.Migrations.Migrators.Community.Archetype;
+
+public class DefaultArchetypeMigrationConfigurer : IArchetypeMigrationConfigurer
+{
+    public string GetBlockElementAlias(string archetypeAlias, SyncMigrationContext context)
+    {
+        return archetypeAlias;
+    }
+}

--- a/uSync.Migrations/Migrators/Community/Archetype/IArchetypeMigrationConfigurer.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/IArchetypeMigrationConfigurer.cs
@@ -1,0 +1,8 @@
+﻿using uSync.Migrations.Context;
+
+namespace uSync.Migrations.Migrators.Community.Archetype;
+
+public interface IArchetypeMigrationConfigurer
+{
+    public string GetBlockElementAlias(string archetypeAlias, SyncMigrationContext context);
+}

--- a/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypeFieldsetModel.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypeFieldsetModel.cs
@@ -1,0 +1,39 @@
+using Newtonsoft.Json;
+
+namespace Archetype.Models
+{
+    /// <summary>
+    /// Model that represents a fieldset stored as content JSON.
+    /// </summary>
+    public class ArchetypeFieldsetModel
+    {
+        [JsonProperty("alias")]
+        public string Alias { get; set; }
+
+        [JsonProperty("disabled")]
+        public bool Disabled { get; set; }
+
+        [JsonProperty("properties")]
+        public IEnumerable<ArchetypePropertyModel> Properties;
+
+        [JsonProperty("id")]
+        public Guid Id { get; set; }
+
+        [JsonProperty("releaseDate")]
+        public DateTime? ReleaseDate { get; set; }
+
+        [JsonProperty("expireDate")]
+        public DateTime? ExpireDate { get; set; }
+
+        [JsonProperty("allowedMemberGroups")]
+        public string AllowedMemberGroups { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArchetypeFieldsetModel"/> class.
+        /// </summary>
+        public ArchetypeFieldsetModel()
+        {
+            Properties = new List<ArchetypePropertyModel>();
+        }
+    }
+}

--- a/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypeModel.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypeModel.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Archetype.Models
+{
+    /// <summary>
+    /// Model that represents an entire Archetype.
+    /// </summary>
+    [JsonObject]
+    public class ArchetypeModel : IEnumerable<ArchetypeFieldsetModel>
+    {
+        [JsonProperty("fieldsets")]
+        public IEnumerable<ArchetypeFieldsetModel> Fieldsets { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArchetypeModel"/> class.
+        /// </summary>
+        public ArchetypeModel()
+        {
+            Fieldsets = new List<ArchetypeFieldsetModel>();
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection of fieldsets.
+        /// </summary>
+        /// <returns>
+        /// An enumerator that can be used to iterate through the collection.
+        /// </returns>
+        public IEnumerator<ArchetypeFieldsetModel> GetEnumerator()
+        {
+            return this.Fieldsets.GetEnumerator();
+        }
+
+        //possibly obsolete?
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypePreValue.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypePreValue.cs
@@ -1,0 +1,86 @@
+using Newtonsoft.Json;
+
+namespace Archetype.Models
+{
+    /// <summary>
+    /// Model that represents the configured Archetype options.
+    /// </summary>
+    public class ArchetypePreValue
+    {
+        [JsonProperty("showAdvancedOptions")]
+        public bool ShowAdvancedOptions { get; set; }
+
+        [JsonProperty("startWithAddButton")]
+        public bool StartWithAddButton { get; set; }
+
+        [JsonProperty("hideFieldsetToolbar")]
+        [Obsolete("This value is no longer used but is kept to prevent breaking changes.")]
+        public bool HideFieldsetToolbar { get; set; }
+
+        [JsonProperty("enableMultipleFieldsets")]
+        public bool EnableMultipleFieldsets { get; set; }
+
+        [JsonProperty("enableCollapsing")]
+        public bool EnableCollapsing { get; set; }
+
+        [JsonProperty("enableMultipleOpen")]
+        public bool EnableMultipleOpen { get; set; }
+
+        [JsonProperty("enableCloning")]
+        public bool EnableCloning { get; set; }
+
+        [JsonProperty("enableDisabling")]
+        public bool EnableDisabling { get; set; }
+
+        [JsonProperty("enablePublishing")]
+        public bool EnablePublishing { get; set; }
+
+        [JsonProperty("enableCrossDragging")]
+        public bool EnableCrossDragging { get; set; }
+        
+        [JsonProperty("enableMemberGroups")]
+        public bool EnableMemberGroups { get; set; }
+
+        [JsonProperty("hideFieldsetControls")]
+        public bool HideFieldsetControls { get; set; }
+
+        [JsonProperty("hidePropertyLabel")]
+        public bool HidePropertyLabel { get; set; }
+
+        [JsonProperty("minFieldsets", NullValueHandling = NullValueHandling.Ignore)]
+        public int MinFieldsets { get; set; }
+
+        [JsonProperty("maxFieldsets", NullValueHandling = NullValueHandling.Ignore)]
+        public int MaxFieldsets { get; set; }
+
+        [JsonProperty("fieldsets")]
+        public IEnumerable<ArchetypePreValueFieldset> Fieldsets { get; set; }
+
+        [JsonProperty("fieldsetGroups")]
+        public IEnumerable<ArchetypePreValueFieldsetGroup> FieldsetGroups { get; set; }
+
+        [JsonProperty("hidePropertyLabels")]
+        public bool HidePropertyLabels { get; set; }
+
+        [JsonProperty("customCssClass")]
+        public string CustomCssClass { get; set; }
+
+        [JsonProperty("customCssPath")]
+        public string CustomCssPath { get; set; }
+
+        [JsonProperty("customJsPath")]
+        public string CustomJsPath { get; set; }
+
+        [JsonProperty("customViewPath")]
+        public string CustomViewPath { get; set; }
+
+        [JsonProperty("enableDeepDatatypeRequests")]
+        public bool EnableDeepDatatypeRequests { get; set; }
+        
+        [JsonProperty("developerMode")]
+        public bool DeveloperMode { get; set; }
+
+        [JsonProperty("overrideDefaultPropertyValueConverter")]
+        public bool OverrideDefaultPropertyValueConverter { get; set; }
+    }
+}

--- a/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypePreValueFieldset.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypePreValueFieldset.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Archetype.Models
+{
+    /// <summary>
+    /// Model that represents configured Archetype fieldsets.
+    /// </summary>
+    public class ArchetypePreValueFieldset
+    {
+        [JsonProperty("alias")]
+        public string Alias { get; set; }
+
+        [JsonProperty("remove")]
+        public bool Remove { get; set; }
+
+        [JsonProperty("collapse")]
+        public bool Collapse { get; set; }
+
+        [JsonProperty("labelTemplate")]
+        public string LabelTemplate { get; set; }
+
+        [JsonProperty("icon")]
+        public string Icon { get; set; }
+
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        [JsonProperty("previewImage")]
+        public string PreviewImage { get; set; }
+
+        [JsonProperty("properties")]
+        public IEnumerable<ArchetypePreValueProperty> Properties { get; set; }
+
+        [JsonProperty("group")]
+        public ArchetypePreValueFieldsetGroup Group { get; set; }
+    }
+}

--- a/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypePreValueFieldsetGroup.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypePreValueFieldsetGroup.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Archetype.Models
+{
+    /// <summary>
+    /// Model that represents configured groupings of Archetype fieldsets.
+    /// </summary>
+    public class ArchetypePreValueFieldsetGroup
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypePreValueProperty.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypePreValueProperty.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Archetype.Models
+{
+    /// <summary>
+    /// Model that represents a configured property on an Archetype fieldset.
+    /// </summary>
+    public class ArchetypePreValueProperty
+    {
+        [JsonProperty("alias")]
+        public string Alias { get; set; }
+
+        [JsonProperty("remove")]
+        public bool Remove { get; set; }
+
+        [JsonProperty("collapse")]
+        public bool Collapse { get; set; }
+
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        [JsonProperty("helpText")]
+        public string HelpText { get; set; }
+        
+        [JsonProperty("dataTypeGuid")]
+        public Guid DataTypeGuid { get; set; }
+
+        [JsonProperty("propertyEditorAlias")]
+        public string PropertyEditorAlias { get; set; }
+
+        [JsonProperty("value")]
+        public string Value { get; set; }
+
+        [JsonProperty("required")]
+        public bool Required { get; set; }
+
+        [JsonProperty("regEx")]
+        public string RegEx { get; set; }
+    }
+}

--- a/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypePropertyModel.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/Models/ArchetypePropertyModel.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+
+namespace Archetype.Models
+{
+    /// <summary>
+    /// Model that represents a stored property in Archetype.
+    /// </summary>
+    public class ArchetypePropertyModel
+    {
+        [JsonProperty("alias")]
+        public string Alias { get; set; }
+
+        [JsonProperty("value")]
+        public object Value { get; set; }
+
+        [JsonProperty("propertyEditorAlias")]
+        public string PropertyEditorAlias { get; internal set; }
+
+        [JsonProperty("dataTypeId")]
+        public int DataTypeId { get; internal set; }
+
+        [JsonProperty("dataTypeGuid")]
+        internal string DataTypeGuid { get; set; }
+    }
+}

--- a/uSync.Migrations/Models/DataTypeInfo.cs
+++ b/uSync.Migrations/Models/DataTypeInfo.cs
@@ -1,0 +1,14 @@
+﻿namespace uSync.Migrations.Models;
+
+public class DataTypeInfo
+{
+    public DataTypeInfo(string editorAlias, string dataTypeName)
+    {
+        EditorAlias = editorAlias;
+        DataTypeName = dataTypeName;
+    }
+
+    public string EditorAlias { get; }
+
+	public string DataTypeName { get; }
+}

--- a/uSync.Migrations/Models/NewContentTypeProperty.cs
+++ b/uSync.Migrations/Models/NewContentTypeProperty.cs
@@ -5,4 +5,5 @@ public class NewContentTypeProperty
 	public string Name { get; set; }
 	public string Alias { get; set; }
 	public string DataTypeAlias { get; set; }
+    public string OriginalEditorAlias { get; set; }
 }

--- a/uSync.Migrations/Services/SyncMigrationService.cs
+++ b/uSync.Migrations/Services/SyncMigrationService.cs
@@ -189,7 +189,7 @@ internal class SyncMigrationService : ISyncMigrationService
             .ForEach(x => x.PrepareMigrations(context));
 
         // add configurer for Archetype migrations
-        context.ArchetypeMigrationConfigurer = _archetypeConfigurers.FirstOrDefault(c => c.GetType().Name == options.ArchetypeMigrationConfigurer) 
+        context.ContentTypes.ArchetypeMigrationConfigurer = _archetypeConfigurers.FirstOrDefault(c => c.GetType().Name == options.ArchetypeMigrationConfigurer) 
             ?? new DefaultArchetypeMigrationConfigurer();
 
         return context;

--- a/uSync.Migrations/Services/SyncMigrationService.cs
+++ b/uSync.Migrations/Services/SyncMigrationService.cs
@@ -1,4 +1,4 @@
-﻿using NUglify.Helpers;
+using NUglify.Helpers;
 
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -10,6 +10,7 @@ using uSync.Migrations.Configuration.Models;
 using uSync.Migrations.Context;
 using uSync.Migrations.Handlers;
 using uSync.Migrations.Migrators;
+using uSync.Migrations.Migrators.Community.Archetype;
 using uSync.Migrations.Models;
 
 namespace uSync.Migrations.Services;
@@ -21,19 +22,22 @@ internal class SyncMigrationService : ISyncMigrationService
     private readonly SyncMigrationValidatorCollection _migrationValidators;
     private readonly uSyncConfigService _usyncConfig;
     private readonly SyncPropertyMigratorCollection _migrators;
+    private readonly ArchetypeMigrationConfigurerCollection _archetypeConfigurers;
 
     public SyncMigrationService(
         ISyncMigrationFileService migrationFileService,
         SyncMigrationHandlerCollection migrationHandlers,
         uSyncConfigService usyncConfig,
         SyncMigrationValidatorCollection migrationValidators,
-        SyncPropertyMigratorCollection migrators)
+        SyncPropertyMigratorCollection migrators,
+        ArchetypeMigrationConfigurerCollection archetypeConfigurers)
     {
         _migrationFileService = migrationFileService;
         _migrationHandlers = migrationHandlers;
         _usyncConfig = usyncConfig;
         _migrationValidators = migrationValidators;
         _migrators = migrators;
+        _archetypeConfigurers = archetypeConfigurers;
     }
 
     public IEnumerable<string> HandlerTypes(int version)
@@ -183,6 +187,10 @@ internal class SyncMigrationService : ISyncMigrationService
             .OrderBy(x => x.Priority)
             .ToList()
             .ForEach(x => x.PrepareMigrations(context));
+
+        // add configurer for Archetype migrations
+        context.ArchetypeMigrationConfigurer = _archetypeConfigurers.FirstOrDefault(c => c.GetType().Name == options.ArchetypeMigrationConfigurer) 
+            ?? new DefaultArchetypeMigrationConfigurer();
 
         return context;
     }


### PR DESCRIPTION
Adds a migrator for Archetype. This required some refactoring of the main uSync Migrations code - I've added some comments to the PR to explain further.