### PR TITLE
Allow content import without content types

### DIFF
--- a/uSync.Migrations/Handlers/Eight/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentBaseMigrationHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
@@ -21,8 +22,10 @@ internal class ContentBaseMigrationHandler<TEntity> : SharedContentBaseHandler<T
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         IShortStringHelper shortStringHelper,
+        IContentTypeService contentTypeService,
+        IDataTypeService dataTypeService,
         ILogger<ContentBaseMigrationHandler<TEntity>> logger) 
-        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
+        : base(eventAggregator, migrationFileService, shortStringHelper, contentTypeService, dataTypeService, logger)
     { }
 
     protected override string GetContentType(XElement source)

--- a/uSync.Migrations/Handlers/Eight/ContentMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentMigrationHandler.cs
@@ -2,6 +2,7 @@
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 
 using uSync.Migrations.Services;
@@ -18,7 +19,9 @@ internal class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, I
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         IShortStringHelper shortStringHelper,
+        IContentTypeService contentTypeService,
+        IDataTypeService dataTypeService,
         ILogger<ContentMigrationHandler> logger)
-        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
+        : base(eventAggregator, migrationFileService, shortStringHelper, contentTypeService, dataTypeService, logger)
     { }
 }

--- a/uSync.Migrations/Handlers/Eight/MediaMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/MediaMigrationHandler.cs
@@ -2,6 +2,7 @@
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 
 using uSync.Migrations.Services;
@@ -18,7 +19,9 @@ internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISync
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         IShortStringHelper shortStringHelper,
+        IContentTypeService contentTypeService,
+        IDataTypeService dataTypeService,
         ILogger<MediaMigrationHandler> logger) 
-        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
+        : base(eventAggregator, migrationFileService, shortStringHelper, contentTypeService, dataTypeService, logger)
     { }
 }

--- a/uSync.Migrations/Handlers/Seven/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentBaseMigrationHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
@@ -21,8 +22,10 @@ internal abstract class ContentBaseMigrationHandler<TEntity> : SharedContentBase
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         IShortStringHelper shortStringHelper,
+        IContentTypeService contentTypeService,
+        IDataTypeService dataTypeService,
         ILogger<ContentBaseMigrationHandler<TEntity>> logger)
-        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
+        : base(eventAggregator, migrationFileService, shortStringHelper, contentTypeService, dataTypeService, logger)
     { }
 
     protected override int GetId(XElement source)

--- a/uSync.Migrations/Handlers/Seven/ContentMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentMigrationHandler.cs
@@ -2,6 +2,7 @@
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 
 using uSync.Migrations.Services;
@@ -18,7 +19,9 @@ internal class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, I
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         IShortStringHelper shortStringHelper,
+        IContentTypeService contentTypeService,
+        IDataTypeService dataTypeService,
         ILogger<ContentMigrationHandler> logger)
-        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
+        : base(eventAggregator, migrationFileService, shortStringHelper, contentTypeService, dataTypeService, logger)
     { }
 }

--- a/uSync.Migrations/Handlers/Seven/MediaMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/MediaMigrationHandler.cs
@@ -2,6 +2,7 @@
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 
 using uSync.Migrations.Services;
@@ -18,8 +19,10 @@ internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISync
         IEventAggregator eventAggregator,
         ISyncMigrationFileService migrationFileService,
         IShortStringHelper shortStringHelper,
+        IContentTypeService contentTypeService,
+        IDataTypeService dataTypeService,
         ILogger<MediaMigrationHandler> logger)
-        : base(eventAggregator, migrationFileService, shortStringHelper, logger)
+        : base(eventAggregator, migrationFileService, shortStringHelper, contentTypeService, dataTypeService, logger)
     {
         _ignoredProperties.UnionWith(new[]
         {

--- a/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -31,7 +31,7 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
 		_dataTypeService = dataTypeService;
 	}
 
-	protected override void PrepareFile(XElement source, SyncMigrationContext context)
+    protected override void PrepareFile(XElement source, SyncMigrationContext context)
     {
         var (contentTypeAlias, key) = GetAliasAndKey(source);
         context.ContentTypes.AddAliasAndKey(contentTypeAlias, key);


### PR DESCRIPTION
Many of the migrators rely on ContentTypes on the context when performing a Content migration. Previously this meant that the Content migration couldn't be run without the ContentTypes migration. With this change, all of the existing database content types are added to the context before a content import.

This means that a content import can be run even after content type changes have been made (such as new properties added) to the target database.