### PR TITLE
Support nuPickers JSON format

### DIFF
--- a/uSync.Migrations/Migrators/Community/NuPickersEnumCheckBoxPickerToContentmentDataList.cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersEnumCheckBoxPickerToContentmentDataList.cs
@@ -3,17 +3,14 @@ using Newtonsoft.Json;
 using uSync.Migrations.Context;
 using uSync.Migrations.Extensions;
 using uSync.Migrations.Migrators.Models;
-using uSync.Migrations.Models;
 using uSync.Migrations.Migrators.Models.NuPickers;
 using Umbraco.Extensions;
 
 namespace uSync.Migrations.Migrators.Community
 {
     [SyncMigrator("nuPickers.EnumCheckBoxPicker")]
-    public class NuPickersEnumCheckBoxPickerToContentmentDataList : SyncPropertyMigratorBase
+    public class NuPickersEnumCheckBoxPickerToContentmentDataList : NuPickersToContentmentDataListBase
     {
-        public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-      => "Umbraco.Community.Contentment.DataList";
         public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         {
             var nuPickersConfig = JsonConvert.DeserializeObject<NuPickersEnumConfig>(dataTypeProperty.PreValues?.GetPreValueOrDefault("dataSource", string.Empty));

--- a/uSync.Migrations/Migrators/Community/NuPickersEnumDropDownPickerToContentmentDataList.cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersEnumDropDownPickerToContentmentDataList.cs
@@ -3,17 +3,14 @@ using Newtonsoft.Json.Linq;
 using Umbraco.Extensions;
 using uSync.Migrations.Context;
 using uSync.Migrations.Extensions;
-using uSync.Migrations.Migrators;
 using uSync.Migrations.Migrators.Models;
 using uSync.Migrations.Migrators.Models.NuPickers;
 
 namespace uSync.Migrations.Migrators.Community;
 
 [SyncMigrator("nuPickers.EnumDropDownPicker")]
-public class NuPickersEnumDropDownPickerToContentmentDataList : SyncPropertyMigratorBase
+public class NuPickersEnumDropDownPickerToContentmentDataList : NuPickersToContentmentDataListBase
 {
-    public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-        => "Umbraco.Community.Contentment.DataList";
     public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
     {
         var nuPickersConfig = JsonConvert.DeserializeObject<NuPickersEnumConfig>(dataTypeProperty.PreValues?.GetPreValueOrDefault("dataSource", string.Empty));

--- a/uSync.Migrations/Migrators/Community/NuPickersSqlDropdownPickerToContentmentDataList.cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersSqlDropdownPickerToContentmentDataList.cs
@@ -8,10 +8,8 @@ using uSync.Migrations.Migrators.Models.NuPickers;
 namespace uSync.Migrations.Migrators.Community
 {
     [SyncMigrator("nuPickers.SqlDropdownPicker")]
-    public class NuPickersSqlDropdownPickerToContentmentDataList : SyncPropertyMigratorBase
+    public class NuPickersSqlDropdownPickerToContentmentDataList : NuPickersToContentmentDataListBase
     {
-        public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-      => "Umbraco.Community.Contentment.DataList";
         public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         {
             var nuPickersConfig = JsonConvert.DeserializeObject<NuPickersSqlConfig>(dataTypeProperty.PreValues?.GetPreValueOrDefault("dataSource", string.Empty));

--- a/uSync.Migrations/Migrators/Community/NuPickersToContentmentDataListBase.cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersToContentmentDataListBase.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Extensions;
+using uSync.Migrations.Context;
+using uSync.Migrations.Migrators.Models;
+
+namespace uSync.Migrations.Migrators.Community;
+
+[SyncMigrator("nuPickers - base migrator, not used directly")]
+public class NuPickersToContentmentDataListBase : SyncPropertyMigratorBase
+{
+    public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => "Umbraco.Community.Contentment.DataList";
+
+    public override string GetContentValue(SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
+    {
+        if (string.IsNullOrWhiteSpace(contentProperty.Value))
+        {
+            return string.Empty;
+        }
+
+        if (!contentProperty.Value.DetectIsJson())
+        {
+            return contentProperty.Value;
+        }
+
+        var jtoken = JToken.Parse(contentProperty.Value);
+        var values = jtoken.Select(t => t.Value<string>("key")).ToArray();
+        return JsonConvert.SerializeObject(values, Formatting.Indented);
+    }
+}

--- a/uSync.Migrations/Migrators/Community/NuPickersXPathCheckboxPickerToContentmentDataList .cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersXPathCheckboxPickerToContentmentDataList .cs
@@ -9,10 +9,8 @@ using uSync.Migrations.Migrators.Models.NuPickers;
 namespace uSync.Migrations.Migrators.Community
 {
     [SyncMigrator("nuPickers.XmlCheckBoxPicker")]
-    public class NuPickersXPathCheckboxPickerToContentmentDataList : SyncPropertyMigratorBase
+    public class NuPickersXPathCheckboxPickerToContentmentDataList : NuPickersToContentmentDataListBase
     {
-        public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-      => "Umbraco.Community.Contentment.DataList";
         public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         {
             var nuPickersConfig = JsonConvert.DeserializeObject<NuPickersXmlConfig>(dataTypeProperty.PreValues?.GetPreValueOrDefault("dataSource", string.Empty));

--- a/uSync.Migrations/Migrators/Community/NuPickersXPathDropdownPickerToContentmentDataList.cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersXPathDropdownPickerToContentmentDataList.cs
@@ -9,10 +9,8 @@ using uSync.Migrations.Migrators.Models;
 namespace uSync.Migrations.Migrators.Community
 {
     [SyncMigrator("nuPickers.XmlDropdownPicker")]
-    public class NuPickersXPathDropdownPickerToContentmentDataList : SyncPropertyMigratorBase
+    public class NuPickersXPathDropdownPickerToContentmentDataList : NuPickersToContentmentDataListBase
     {
-        public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-      => "Umbraco.Community.Contentment.DataList";
         public override object GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         {
             var nuPickersConfig = JsonConvert.DeserializeObject<NuPickersConfig>(dataTypeProperty.PreValues?.GetPreValueOrDefault("dataSource", string.Empty));


### PR DESCRIPTION
In addition to the default CSV format, this adds support for migrating nupickers that used JSON format