### PR TITLE
Make NuPickers models public

### DIFF
--- a/uSync.Migrations/Migrators/Models/NuPickers/NuPickersEnumConfig.cs
+++ b/uSync.Migrations/Migrators/Models/NuPickers/NuPickersEnumConfig.cs
@@ -1,6 +1,6 @@
 ﻿namespace uSync.Migrations.Migrators.Models.NuPickers
 {
-    internal class NuPickersEnumConfig
+    public class NuPickersEnumConfig
     {
         public string AssemblyName { get; set; }
         public string ApiController { get; set; }

--- a/uSync.Migrations/Migrators/Models/NuPickers/NuPickersSqlConfig.cs
+++ b/uSync.Migrations/Migrators/Models/NuPickers/NuPickersSqlConfig.cs
@@ -1,6 +1,6 @@
 ﻿namespace uSync.Migrations.Migrators.Models.NuPickers
 {
-    internal class NuPickersSqlConfig
+    public class NuPickersSqlConfig
     {
         public string Query { get; set; }
         public string ConnectionString { get; set; }

--- a/uSync.Migrations/Migrators/Models/NuPickers/NuPickersXmlConfig.cs
+++ b/uSync.Migrations/Migrators/Models/NuPickers/NuPickersXmlConfig.cs
@@ -1,6 +1,6 @@
 ﻿namespace uSync.Migrations.Migrators.Models.NuPickers
 {
-    internal class NuPickersXmlConfig
+    public class NuPickersXmlConfig
     {
         public string ApiController { get; set; }
         public string XmlData { get; set; }


### PR DESCRIPTION
To facilitate creating custom migrators without the need to duplicate these models