### PR TITLE
Add migration from Epiphany.SeoMetadata to separate properties

### DIFF
--- a/uSync.Migrations/Context/ContentTypeMigrationContext.cs
+++ b/uSync.Migrations/Context/ContentTypeMigrationContext.cs
@@ -95,14 +95,14 @@ public class ContentTypeMigrationContext
 	///  allows you to track when the editor alias of a property changes from original to a new value
 	/// </remarks>
 
-	public void AddProperty(string? contentTypeAlias, string? propertyAlias, string? originalAlias, string? newAlias)
+	public void AddProperty(string? contentTypeAlias, string? propertyAlias, string? originalAlias, string? newAlias, Guid? dataTypeDefinition = default)
 	{
 		_ = string.IsNullOrWhiteSpace(contentTypeAlias) == false &&
 			string.IsNullOrWhiteSpace(propertyAlias) == false &&
 			string.IsNullOrWhiteSpace(originalAlias) == false &&
 			string.IsNullOrWhiteSpace(newAlias) == false &&
 			_propertyTypes.TryAdd($"{contentTypeAlias}_{propertyAlias}",
-			new EditorAliasInfo(originalAlias, newAlias));
+			new EditorAliasInfo(originalAlias, newAlias, dataTypeDefinition));
 	}
 
 	/// <summary>

--- a/uSync.Migrations/Context/DataTypeMigrationContext.cs
+++ b/uSync.Migrations/Context/DataTypeMigrationContext.cs
@@ -90,4 +90,7 @@ public class DataTypeMigrationContext
 		=> _dataTypeVariations?.TryGetValue(guid, out var variation) == true
 			? variation : "Nothing";
 
+    public Guid? GetFirstDefinition(string alias)
+		=> _dataTypeDefinitions?.FirstOrDefault(x => x.Value == alias).Key;
+
 }

--- a/uSync.Migrations/Context/MigratorsContext.cs
+++ b/uSync.Migrations/Context/MigratorsContext.cs
@@ -36,13 +36,27 @@ public class MigratorsContext
 		}
 
 		return null;
-	}
+    }
 
 	/// <summary>
-	/// A cache of dictionary items that can be used if you need to store/retrieve custom data between 
-	/// config and content mappings
+	/// gets the property splitting version of a migrator (if there is one)
 	/// </summary>
-	private Dictionary<string, Dictionary<string, object>> _migratorCache = new(StringComparer.OrdinalIgnoreCase);
+    public ISyncPropertySplittingMigrator TryGetPropertySplittingMigrator(string editorAlias)
+    {
+        if (_migrators.TryGetValue(editorAlias, out var migrator)
+            && migrator is ISyncPropertySplittingMigrator propertySplittingMigrator)
+        {
+            return propertySplittingMigrator;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// A cache of dictionary items that can be used if you need to store/retrieve custom data between 
+    /// config and content mappings
+    /// </summary>
+    private Dictionary<string, Dictionary<string, object>> _migratorCache = new(StringComparer.OrdinalIgnoreCase);
 
 	/// <summary>
 	///  add a dictionary of custom values for this datatype alias.
@@ -62,5 +76,4 @@ public class MigratorsContext
 	public Dictionary<string, object> GetCustomValues(string alias)
 		=> _migratorCache.TryGetValue(alias, out Dictionary<string, object>? values)
 			? values : new Dictionary<string, object>();
-
 }

--- a/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -46,12 +46,32 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
             var editorAlias = property.Element("Type").ValueOrDefault(string.Empty);
             var definition = property.Element("Definition").ValueOrDefault(Guid.Empty);
             var alias = property.Element("Alias")?.ValueOrDefault(string.Empty) ?? string.Empty;
+            var propertyName = property.Element("Name")?.ValueOrDefault(string.Empty) ?? string.Empty;
 
-            context.ContentTypes.AddProperty(contentTypeAlias, alias,
+            // if this is a property splitting editor, we need to add the split properties
+            var propertySplittingMigrator = context.Migrators.TryGetPropertySplittingMigrator(editorAlias);
+            if (propertySplittingMigrator != null)
+            {
+                context.ContentTypes.AddProperty(contentTypeAlias, alias, editorAlias, "none"); // add the original property so we can reference the original EditorAlias later
+
+                var splitProperties = propertySplittingMigrator.GetSplitProperties(contentTypeAlias, alias, propertyName, context);
+                foreach (var splitProperty in splitProperties)
+                {
+                    context.ContentTypes.AddProperty(contentTypeAlias, splitProperty.Alias,
+                                               editorAlias, splitProperty.DataTypeAlias, splitProperty.DataTypeDefinition);
+
+                    context.ContentTypes.AddDataTypeAlias(contentTypeAlias, alias, splitProperty.DataTypeAlias);
+                }
+            }
+            else
+            {
+                context.ContentTypes.AddProperty(contentTypeAlias, alias,
                     editorAlias, context.DataTypes.GetByDefinition(definition));
 
-            context.ContentTypes.AddDataTypeAlias(contentTypeAlias, alias,
-                context.DataTypes.GetAlias(definition));
+                context.ContentTypes.AddDataTypeAlias(contentTypeAlias, alias,
+                    context.DataTypes.GetAlias(definition));
+            }
+
 
             //
             // for now we are doing this just for media folders, but it might be
@@ -128,18 +148,61 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
                     continue;
                 }
 
-                var newProperty = property.Clone();
-                if (newProperty != null)
-                {
-                    // update the datatype we are using (this might be new). 
-                    UpdatePropertyEditor(alias, newProperty, context);
-                    UpdatePropertyXml(source, newProperty, context);
-                    newProperties.Add(newProperty);
-                }
+                var updatedProperties = GetUpdatedProperties(source, alias, property, context);
+                newProperties.Add(updatedProperties);
             }
         }
 
         target.Add(newProperties);
+    }
+
+    protected virtual IEnumerable<XElement> GetUpdatedProperties(XElement source, string contentTypeAlias, XElement property, SyncMigrationContext context)
+    {
+        var editorAlias = property.Element("Type").ValueOrDefault(string.Empty);
+
+        var propertySplittingMigrator = context.Migrators.TryGetPropertySplittingMigrator(editorAlias);
+        if (propertySplittingMigrator == null)
+        {
+            var updatedProperty = GetUpdatedProperty(source, contentTypeAlias, property, context);
+            if (updatedProperty != null)
+            {
+                yield return updatedProperty;
+            }
+
+            yield break;
+        }
+        
+        // if we have a property splitting migrator, we need to get the split properties
+        var propertyAlias = property.Element("Alias")?.ValueOrDefault(string.Empty) ?? string.Empty;
+        var propertyName = property.Element("Name")?.ValueOrDefault(string.Empty) ?? string.Empty;
+        var splitProperties = propertySplittingMigrator.GetSplitProperties(contentTypeAlias, propertyAlias, propertyName, context);
+        
+        foreach (var splitProperty in splitProperties)
+        {
+            var updatedProperty = GetUpdatedProperty(source, contentTypeAlias, property, context);
+            if (updatedProperty != null)
+            {
+                updatedProperty.CreateOrSetElement("Alias", splitProperty.Alias);
+                updatedProperty.CreateOrSetElement("Name", splitProperty.Name);
+                updatedProperty.CreateOrSetElement("Type", splitProperty.DataTypeAlias);
+                updatedProperty.CreateOrSetElement("Definition", splitProperty.DataTypeDefinition);
+                yield return updatedProperty;
+            }
+        }
+    }
+
+    protected virtual XElement? GetUpdatedProperty(XElement source, string alias, XElement property, SyncMigrationContext context)
+    {
+        var newProperty = property.Clone();
+        if (newProperty != null)
+        {
+            // update the datatype we are using (this might be new). 
+            UpdatePropertyEditor(alias, newProperty, context);
+            UpdatePropertyXml(source, newProperty, context);
+            return newProperty;
+        }
+
+        return null;
     }
 
     protected virtual void UpdatePropertyEditor(string alias, XElement newProperty, SyncMigrationContext context)

--- a/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
@@ -52,6 +52,19 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
     protected abstract ReplacementDataTypeInfo? GetReplacementInfo(
         string dataTypeAlias, string editorAlias, string databaseType, XElement source, SyncMigrationContext context);
 
+    /// <summary>
+    /// Whether properties using this property editor should be split into multiple properties
+    /// </summary>
+    protected bool IsSplitPropertyEditor(string editorAlias, SyncMigrationContext context)
+    {
+        //
+        // replacements
+        //
+        var migrator = context.Migrators.TryGetPropertySplittingMigrator(editorAlias);
+
+        return migrator != null;
+    }
+
     protected override void PrepareFile(XElement source, SyncMigrationContext context)
     {
         var (alias, dtd) = GetAliasAndKey(source);
@@ -72,6 +85,13 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
             {
                 context.DataTypes.AddVariation(dtd, replacementInfo.Variation);
             }
+        }
+
+        var isSplitPropertyEditor = IsSplitPropertyEditor(editorAlias, context);
+        if (isSplitPropertyEditor)
+        {
+            // if this editor is to be split, then by default we won't migrate the data type
+            return;
         }
 
         // add alias, (won't update if replacement was added)

--- a/uSync.Migrations/Migrators/Community/EpiphanySeoMetadataToSeparateFields.cs
+++ b/uSync.Migrations/Migrators/Community/EpiphanySeoMetadataToSeparateFields.cs
@@ -1,0 +1,58 @@
+using Newtonsoft.Json;
+using Umbraco.Extensions;
+using uSync.Migrations.Context;
+using uSync.Migrations.Migrators.Models;
+
+namespace uSync.Migrations.Migrators.Community;
+
+[SyncMigrator("Epiphany.SeoMetadata")]
+[SyncDefaultMigrator]
+public class EpiphanySeoMetadataToSeparateFields : SyncPropertyMigratorBase, ISyncPropertySplittingMigrator
+{
+    private readonly Dictionary<string, (string Name, string Alias, string EditorAlias, string OriginalEditorAlias, Guid DefaultDefinition)> Properties = new()
+    {
+        { 
+            nameof(SeoMetadata.Title), 
+            ("Meta title", "metaTitle", "Umbraco.TextBox", "Umbraco.Textbox", Guid.Parse("0cc0eba1-9960-42c9-bf9b-60e150b429ae")) 
+        },
+        { 
+            nameof(SeoMetadata.Description), 
+            ("Meta description", "metaDescription", "Umbraco.TextArea", "Umbraco.TextboxMultiple", Guid.Parse("c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3")) 
+        },
+        { 
+            nameof(SeoMetadata.NoIndex),
+            ("Robots NoIndex", "robotsNoIndex", "Umbraco.TrueFalse", "Umbraco.TrueFalse", Guid.Parse("92897bc6-a5f3-4ffe-ae27-f2e7e33dda49"))
+        },
+        { 
+            nameof(SeoMetadata.UrlName),
+            ("URL name", "umbracoUrlName", "Umbraco.TextBox", "Umbraco.Textbox", Guid.Parse("0cc0eba1-9960-42c9-bf9b-60e150b429ae"))
+        },
+    };
+
+    public IEnumerable<SplitPropertyContent> GetContentValues(SyncMigrationContentProperty migrationProperty, SyncMigrationContext context)
+    {
+        if (string.IsNullOrWhiteSpace(migrationProperty.Value))
+        {
+            yield break;
+        }
+
+        var content = JsonConvert.DeserializeObject<SeoMetadata>(migrationProperty.Value);
+        yield return new SplitPropertyContent(Properties[nameof(SeoMetadata.Title)].Alias, content.Title);
+        yield return new SplitPropertyContent(Properties[nameof(SeoMetadata.Description)].Alias, content.Description);
+        yield return new SplitPropertyContent(Properties[nameof(SeoMetadata.NoIndex)].Alias, (content.NoIndex ? 1 : 0).ToString());
+        yield return new SplitPropertyContent(Properties[nameof(SeoMetadata.UrlName)].Alias, content.UrlName);
+    }
+
+    public IEnumerable<SplitPropertyInfo> GetSplitProperties(string contentTypeAlias, string propertyAlias, string propertyName, SyncMigrationContext context)
+    {
+        return Properties.Values.Select(x => new SplitPropertyInfo(x.Name, x.Alias, x.EditorAlias, context.DataTypes.GetFirstDefinition(x.OriginalEditorAlias) ?? x.DefaultDefinition));
+    }
+}
+
+public class SeoMetadata
+{
+    public string Title { get; set; }
+    public string Description { get; set; }
+    public bool NoIndex { get; set; }
+    public string UrlName { get; set; }
+}

--- a/uSync.Migrations/Migrators/ISyncPropertyMigrator.cs
+++ b/uSync.Migrations/Migrators/ISyncPropertyMigrator.cs
@@ -42,3 +42,17 @@ public interface ISyncVariationPropertyMigrator
 {
     public Attempt<CulturedPropertyValue> GetVariedElements(SyncMigrationContentProperty contentProperty, SyncMigrationContext context);
 }
+
+/// <summary>
+/// interface to implemenet if your property splits up a value into separate properties
+/// </summary>
+public interface ISyncPropertySplittingMigrator
+{
+    /// <summary>
+    /// gets a dictionary of alias/value pairs of new properties to map to
+    /// </summary>
+    IEnumerable<SplitPropertyContent> GetContentValues(SyncMigrationContentProperty migrationProperty, SyncMigrationContext context);
+
+
+    IEnumerable<SplitPropertyInfo> GetSplitProperties(string contentTypeAlias, string propertyAlias, string propertyName, SyncMigrationContext context);
+}

--- a/uSync.Migrations/Migrators/Models/SplitPropertyContent.cs
+++ b/uSync.Migrations/Migrators/Models/SplitPropertyContent.cs
@@ -1,0 +1,14 @@
+﻿namespace uSync.Migrations.Migrators.Models;
+
+public class SplitPropertyContent
+{
+    public SplitPropertyContent(string alias, string value)
+    {
+        Alias = alias;
+        Value = value;
+    }
+
+    public string Alias { get; }
+
+    public string Value { get; }
+}

--- a/uSync.Migrations/Migrators/Models/SplitPropertyInfo.cs
+++ b/uSync.Migrations/Migrators/Models/SplitPropertyInfo.cs
@@ -1,0 +1,17 @@
+﻿namespace uSync.Migrations.Migrators.Models;
+
+public class SplitPropertyInfo
+{
+    public SplitPropertyInfo(string name, string alias, string dataTypeAlias, Guid dataTypeDefinition)
+    {
+        Name = name;
+        Alias = alias;
+        DataTypeAlias = dataTypeAlias;
+        DataTypeDefinition = dataTypeDefinition;
+    }
+
+    public string Name { get; }
+    public string Alias { get; }
+    public string DataTypeAlias { get; }
+    public Guid DataTypeDefinition { get; }
+}

--- a/uSync.Migrations/Models/EditorAliasInfo.cs
+++ b/uSync.Migrations/Models/EditorAliasInfo.cs
@@ -2,13 +2,16 @@
 
 public class EditorAliasInfo
 {
-	public EditorAliasInfo(string orginalEditorAlias, string updatedEditorAlias)
-	{
-		OriginalEditorAlias = orginalEditorAlias;
-		UpdatedEditorAlias = updatedEditorAlias;
-	}
+    public EditorAliasInfo(string orginalEditorAlias, string updatedEditorAlias, Guid? dataTypeDefinition = default)
+    {
+        OriginalEditorAlias = orginalEditorAlias;
+        UpdatedEditorAlias = updatedEditorAlias;
+        DataTypeDefinition = dataTypeDefinition;
+    }
 
-	public string OriginalEditorAlias { get; }
+    public string OriginalEditorAlias { get; }
 
 	public string UpdatedEditorAlias { get; }
+
+    public Guid? DataTypeDefinition { get; set; }
 }


### PR DESCRIPTION
This adds a new migrator interface (`ISyncPropertySplittingMigrator`) for migrators that split a single property into multiple. The Epiphany.SeoMetadata package stored meta Title, Description, UrlName and NoIndex in a blob of JSON. This migrator splits this JSON into separate properties.