### PR TITLE
Migrators by property name.

### DIFF
--- a/MyMigrations/MyMigrationProfile.cs
+++ b/MyMigrations/MyMigrationProfile.cs
@@ -53,6 +53,16 @@ public class MyMigrationProfile : ISyncMigrationPlan
 
         // eveything beneath is optional... 
 
+        //PropertyMigrators = new Dictionary<string, string>()
+        //{
+        //    // use the NestedToBlockListMigrator For myProperty in the 'MyContentType' contentType
+        //    { "myContentType_myProperty", nameof(NestedToBlockListMigrator) }, 
+
+        //    // Convert all properties called myGridProperty to blocklist 
+        //    { "myGridProperty", nameof(GridToBlockListMigrator) }
+        //},
+
+
         // add a list of things we don't want to import 
         BlockedItems = new Dictionary<string, List<string>>
         {

--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -18,6 +18,16 @@ public class MigrationOptions
 
     public IDictionary<string, string>? PreferredMigrators { get; set; }
 
+    /// <summary>
+    ///  migrators by property name. 
+    /// </summary>
+    /// <remarks>
+    ///  property migrators will be searched by property alias
+    ///  and contentType_propertyAlias, so you can define both 
+    ///  for all properties with a name, or restrict to the content/media type
+    /// </remarks>
+    public IDictionary<string, string>? PropertyMigrators { get; set; }
+
     public bool BlockListViews { get; set; } = true;
 
     public bool BlockCommonTypes { get; set; } = true;

--- a/uSync.Migrations/Handlers/MigrationHandlerBase.cs
+++ b/uSync.Migrations/Handlers/MigrationHandlerBase.cs
@@ -179,7 +179,16 @@ internal abstract class MigrationHandlerBase<TObject>
             catch(Exception ex)
             {
                 _logger.LogError(ex, "Error while processing {file}", file);
-                throw new Exception($"Error processing {file}", ex);
+
+                var name = Path.Combine(
+                    Path.GetFileNameWithoutExtension(Path.GetDirectoryName(file)) ?? "",
+                    Path.GetFileNameWithoutExtension(file));
+
+                // throw new Exception($"Error processing {file}", ex);
+                messages.Add(new MigrationMessage(ItemType, name, MigrationMessageType.Error)
+                {
+                    Message = ex.Message
+                });
             }
         }
 

--- a/uSync.Migrations/Services/SyncMigrationStatusService.cs
+++ b/uSync.Migrations/Services/SyncMigrationStatusService.cs
@@ -198,6 +198,7 @@ internal class SyncMigrationStatusService : ISyncMigrationStatusService
             IgnoredPropertiesByContentType = defaultOptions.IgnoredPropertiesByContentType,
             MigrationType = defaultOptions.MigrationType,
             PreferredMigrators = defaultOptions.PreferredMigrators,
+            PropertyMigrators = defaultOptions.PropertyMigrators,
         };
     }
 


### PR DESCRIPTION
Adds the ability to set migrators by property name,. (either globally or at a contentType level).

In your own plan - code. add the following: 

```
        PropertyMigrators = new Dictionary<string, string>()
        {
            // use the NestedToBlockListMigrator For myProperty in the 'MyContentType' contentType
            { "myContentType_myProperty", nameof(NestedToBlockListMigrator) }, 

            // Convert all properties called myGridProperty to blocklist 
            { "myGridProperty", nameof(GridToBlockListMigrator) }
        },
```