### PR TITLE
WIP - Merging property handlers.

### DIFF
--- a/MyMigrations/Mergers/SimpleMergePlan.cs
+++ b/MyMigrations/Mergers/SimpleMergePlan.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using uSync.Migrations.Configuration.Models;
+using uSync.Migrations.Models;
+
+namespace MyMigrations.Mergers;
+internal class SimpleMergePlan : ISyncMigrationPlan
+{
+    public int Order => 20;
+    public string Name => "Simple merger plan";
+    public string Icon => "icon-merge";
+    public string Description => "Will merge string values";
+
+    public MigrationOptions Options => new MigrationOptions
+    {
+        SourceVersion = 8, // only run on v8 to v10/11 migrations
+
+        MergingProperties = new()
+        {
+            {
+                // merge the footer on the home content type
+                "home", new MergingPropertiesConfig("mergedFooterProperties",
+                                nameof(SimpleStringMerger),
+                                new List<string>
+                                {
+                                    "footerDescription", "footerAddress", "footerHeader", "FooterCtalink", "footerCTACaption"
+                                })
+
+            }
+        }
+    };
+
+    // setting the values in the constructor might be simpler to read. 
+
+    //public SimpleMergePlan()
+    //{
+    //    var propertiesToMerge = new[] { "footerDescription", "footerAddress", "footerHeader", "FooterCtalink", "footerCTACaption" };
+    //    Options.MergingProperties.Add("Home", new MergingPropertiesConfig("mergedFooterProperties", nameof(SimpleStringMerger), propertiesToMerge));
+    //    Options.MergingProperties.Add("Person", new MergingPropertiesConfig("mergedPersonProperties", nameof(SimpleStringMerger), propertiesToMerge));
+    //}
+
+}

--- a/MyMigrations/Mergers/SimpleStringMerger.cs
+++ b/MyMigrations/Mergers/SimpleStringMerger.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using uSync.Migrations.Context;
+using uSync.Migrations.Migrators;
+using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Models;
+
+namespace MyMigrations.Mergers;
+
+/// <summary>
+///  example merging migrator. 
+/// </summary>
+/// <remarks>
+///  merging migrators will likey be very project specific, 
+///  if you want to merge to properties into one, you 
+///  need to configure that in a plan, and then 
+///  this migrator would get a list of properties, and 
+///  it can work out how to merge them into on single propery.
+/// </remarks>
+internal class SimpleStringMerger : ISyncPropertyMergingMigrator
+{
+    public string[] ContentTypes => throw new NotImplementedException();
+
+    /// <summary>
+    ///  Get the property info for the thing we are going to merge.
+    /// </summary>
+    /// <remarks>
+    ///  you don't have to implement this, if you already have the 
+    ///  property to want to merge into setup - but if for example
+    ///  you wanted to create a whole new property (or datatype or anything)
+    ///  as part of the migration you could do that here, and it will 
+    ///  become part of the migration.
+    /// </remarks>
+    public SplitPropertyInfo GetMergedProperty(string contentTypeAlias, string propertyAlias, string propertyName, SyncMigrationContext context)
+    {
+        // a simplistic example, we will create a new property on 
+        // the content type, called "Merged strings"
+        return new SplitPropertyInfo("Merged Strings",
+            "mergedStrings",
+            "Umbraco.TextArea",
+            context.DataTypes.GetFirstDefinition("Umbraco.TextArea") ?? Guid.Parse("0cc0eba1-9960-42c9-bf9b-60e150b429ae"));
+    }
+
+    public string GetMergedContentValues(IEnumerable<MergingPropertyValue> mergingPropertyValues, SyncMigrationContext context)
+    {
+        // this merger just merges everything into one single text field.
+        return string.Join("\r\n", mergingPropertyValues.Select(x => x.Value));
+    }
+
+}

--- a/uSync.Migrations/Composing/SyncMigrationsComposer.cs
+++ b/uSync.Migrations/Composing/SyncMigrationsComposer.cs
@@ -51,6 +51,9 @@ public static class SyncMigrationsBuilderExtensions
             .WithCollectionBuilder<SyncBlockMigratorCollectionBuilder>()
                 .Add(() => builder.TypeLoader.GetTypes<ISyncBlockMigrator>());
         
+        builder
+            .WithCollectionBuilder<SyncPropertyMergingCollectionBuilder>()
+                .Append(builder.TypeLoader.GetTypes<ISyncPropertyMergingMigrator>());
 
         builder.Services.AddTransient<ISyncMigrationFileService, SyncMigrationFileService>();
 

--- a/uSync.Migrations/Composing/SyncPropertyMergingCollectionBuilder.cs
+++ b/uSync.Migrations/Composing/SyncPropertyMergingCollectionBuilder.cs
@@ -1,0 +1,25 @@
+﻿using Umbraco.Cms.Core.Composing;
+
+using uSync.Migrations.Migrators;
+
+namespace uSync.Migrations.Composing;
+
+public class SyncPropertyMergingCollectionBuilder
+
+
+    : OrderedCollectionBuilderBase<SyncPropertyMergingCollectionBuilder,
+        SyncPropertyMergingCollection, ISyncPropertyMergingMigrator>
+{
+    protected override SyncPropertyMergingCollectionBuilder This => this;
+}
+
+public class SyncPropertyMergingCollection
+    : BuilderCollectionBase<ISyncPropertyMergingMigrator>
+{
+    public SyncPropertyMergingCollection(Func<IEnumerable<ISyncPropertyMergingMigrator>> items)
+        : base(items)
+    { }
+
+    public ISyncPropertyMergingMigrator? GetByName(string name)
+        => this.FirstOrDefault(x => x.GetType().Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+}

--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -1,6 +1,8 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
+using uSync.Migrations.Models;
+
 namespace uSync.Migrations.Configuration.Models;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
@@ -50,6 +52,12 @@ public class MigrationOptions
     public List<TabOptions>? ChangeTabs { get; set; }
 
     public string? ArchetypeMigrationConfigurer { get; set; }
+
+    /// <summary>
+    ///  things we might want to merge. 
+    /// </summary>
+    public Dictionary<string, MergingPropertiesConfig> MergingProperties { get; set; } = new(StringComparer.InvariantCultureIgnoreCase);
+
 }
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]

--- a/uSync.Migrations/Context/ContentMigrationContext.cs
+++ b/uSync.Migrations/Context/ContentMigrationContext.cs
@@ -1,15 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Text;
 using System.Threading.Tasks;
+
+using CSharpTest.Net.Collections;
+
+using uSync.Migrations.Migrators;
+using uSync.Migrations.Models;
 
 namespace uSync.Migrations.Context;
 public class ContentMigrationContext
 {
-
 	private Dictionary<Guid, string> _contentKeys { get; set; } = new();
 	private Dictionary<Guid, string> _contentPaths { get; set; } = new();
+
+	private Dictionary<string, MergingPropertiesConfig> _mergedProperties { get;set; } = new(StringComparer.InvariantCultureIgnoreCase);
 
 	/// <summary>
 	///  add the path for a content item to context. 
@@ -35,4 +42,12 @@ public class ContentMigrationContext
 	public string GetAliasByKey(Guid key)
 		=> _contentKeys?.TryGetValue(key, out var alias) == true ? alias : string.Empty;
 
+
+	public void AddMergedProperty(string contentType, MergingPropertiesConfig config)
+	{
+		_ = _mergedProperties.TryAdd(contentType, config);
+	}
+
+	public MergingPropertiesConfig? GetMergedProperties(string contentType)
+		=> _mergedProperties?.TryGetValue(contentType, out MergingPropertiesConfig? properties) == true ? properties : null;
 }

--- a/uSync.Migrations/Extensions/XElementExtensions.cs
+++ b/uSync.Migrations/Extensions/XElementExtensions.cs
@@ -5,6 +5,10 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
+using Umbraco.Extensions;
+
+using uSync.Core;
+
 namespace uSync.Migrations.Extensions;
 internal static class XElementExtensions
 {
@@ -19,5 +23,46 @@ internal static class XElementExtensions
             return XElement.Parse(element.ToString());
         }
         catch { return null; }
+    }
+
+    /// <summary>
+    ///  will extract the property values by culture from a content property element.
+    /// </summary>
+    public static Dictionary<string, string>? GetPropertyValueByCultures(this XElement property)
+    {
+        if (property == null) return null;
+        if (!property.HasElements) return null;
+
+        var propertiesByCulture = new Dictionary<string, string>();
+
+        foreach (var value in property.Elements())
+        {
+            var culture = value.Attribute("Culture").ValueOrDefault(string.Empty);
+            propertiesByCulture[culture] = value.ValueOrDefault(string.Empty);
+        }
+
+        return propertiesByCulture;
+    }
+
+    public static XElement CreateValueElement(this string value, string culture)
+    {
+        // create the value element for a cultuer. 
+        var valueElement = new XElement("Value");
+        if (!string.IsNullOrEmpty(culture))
+            valueElement.Add(new XAttribute("Culture", culture));
+        valueElement.Add(value);
+
+        return valueElement; 
+    }
+
+    public static void RemoveByName(this XElement parent, IEnumerable<string> names)
+    {
+        if (parent == null || names == null) return;
+
+        foreach(var element in parent.Elements().ToList())
+        {
+            if (names.InvariantContains(element.Name.LocalName))
+                element.Remove();
+        }
     }
 }

--- a/uSync.Migrations/Migrators/ISyncPropertyMigrator.cs
+++ b/uSync.Migrations/Migrators/ISyncPropertyMigrator.cs
@@ -2,6 +2,7 @@
 using Umbraco.Cms.Core.Composing;
 using uSync.Migrations.Context;
 using uSync.Migrations.Migrators.Models;
+using uSync.Migrations.Models;
 
 namespace uSync.Migrations.Migrators;
 
@@ -55,4 +56,25 @@ public interface ISyncPropertySplittingMigrator
 
 
     IEnumerable<SplitPropertyInfo> GetSplitProperties(string contentTypeAlias, string propertyAlias, string propertyName, SyncMigrationContext context);
+}
+
+/// <summary>
+///  interface to call when we are merging properties together. 
+/// </summary>
+public interface ISyncPropertyMergingMigrator
+{
+    /// <summary>
+    ///  list of content types this merger will work for. 
+    /// </summary>
+    string[] ContentTypes { get; }
+
+    /// <summary>
+    ///  Get what the merged property will be called - and create it.
+    /// </summary>
+    SplitPropertyInfo GetMergedProperty(string contentTypeAlias, string propertyAlias, string propertyName, SyncMigrationContext context);
+
+    /// <summary>
+    ///  get the merged values 
+    /// </summary>
+    string GetMergedContentValues(IEnumerable<MergingPropertyValue> mergingPropertyValues, SyncMigrationContext context);
 }

--- a/uSync.Migrations/Migrators/Models/SyncMigrationContentProperty.cs
+++ b/uSync.Migrations/Migrators/Models/SyncMigrationContentProperty.cs
@@ -35,3 +35,5 @@ public sealed class SyncMigrationContentProperty : SyncMigrationPropertyBase
     public string? Value { get; private set; }
 
 }
+
+

--- a/uSync.Migrations/Models/MergingPropertiesConfig.cs
+++ b/uSync.Migrations/Models/MergingPropertiesConfig.cs
@@ -1,0 +1,37 @@
+﻿using uSync.Migrations.Migrators;
+
+namespace uSync.Migrations.Models;
+public class MergingPropertiesConfig
+{
+    public MergingPropertiesConfig(string targetProperty, string mergingMigrator)
+    {
+        TargetPropertyAlias = targetProperty;
+        Merger = mergingMigrator;
+        RemoveMergedProperties = true;
+    }
+
+    public MergingPropertiesConfig(string targetProperty, string mergingMigrator, IEnumerable<string> properties)
+        : this(targetProperty, mergingMigrator)
+    {
+        MergedProperties.AddRange(properties);
+    }
+
+    public List<string> MergedProperties { get; set; } = new();
+    public string TargetPropertyAlias { get; set; }
+    public string Merger { get; set; }
+    public bool RemoveMergedProperties { get; set; }
+}
+
+public class MergingPropertyValue
+{
+    public MergingPropertyValue(string propertyAlias, string editorAlias, string value)
+    {
+        PropertyAlias = propertyAlias;
+        EditorAlias = editorAlias;
+        Value = value;
+    }
+
+    public string PropertyAlias { get; set; }
+    public string EditorAlias { get; set; }
+    public string Value { get; set; }   
+}

--- a/uSync.Migrations/Services/SyncMigrationService.cs
+++ b/uSync.Migrations/Services/SyncMigrationService.cs
@@ -28,6 +28,7 @@ internal class SyncMigrationService : ISyncMigrationService
     private readonly uSyncConfigService _usyncConfig;
     private readonly SyncPropertyMigratorCollection _migrators;
     private readonly ArchetypeMigrationConfigurerCollection _archetypeConfigurers;
+    private readonly SyncPropertyMergingCollection _mergingCollection;
 
     public SyncMigrationService(
         ILogger<SyncMigrationService> logger,
@@ -36,7 +37,8 @@ internal class SyncMigrationService : ISyncMigrationService
         uSyncConfigService usyncConfig,
         SyncMigrationValidatorCollection migrationValidators,
         SyncPropertyMigratorCollection migrators,
-        ArchetypeMigrationConfigurerCollection archetypeConfigurers)
+        ArchetypeMigrationConfigurerCollection archetypeConfigures,
+        SyncPropertyMergingCollection mergingCollection)
     {
         _logger = logger;
 
@@ -45,7 +47,8 @@ internal class SyncMigrationService : ISyncMigrationService
         _usyncConfig = usyncConfig;
         _migrationValidators = migrationValidators;
         _migrators = migrators;
-        _archetypeConfigurers = archetypeConfigurers;
+        _archetypeConfigurers = archetypeConfigures;
+        _mergingCollection = mergingCollection;
     }
 
     public IEnumerable<string> HandlerTypes(int version)
@@ -220,6 +223,8 @@ internal class SyncMigrationService : ISyncMigrationService
 
         AddMigrators(context, options.PreferredMigrators);
 
+        AddMergers(context, options.MergingProperties);
+
         // let the handlers run through their prep (populate all the lookups)
         GetHandlers(options.SourceVersion)?
             .OrderBy(x => x.Priority)
@@ -244,6 +249,25 @@ internal class SyncMigrationService : ISyncMigrationService
             {
                 context.Migrators.AddPropertyMigration(item.EditorAlias, item.Migrator);
             }
+        }
+    }
+
+    private void AddMergers(SyncMigrationContext context, Dictionary<string, MergingPropertiesConfig> mergingProperties)
+    {
+        _logger.LogInformation("Adding property mergers");
+
+        foreach (var mergingProperty in mergingProperties)
+        {
+            // find the merger. 
+            var merger = _mergingCollection.GetByName(mergingProperty.Value.Merger);
+            if (merger == null) continue;
+
+            // add the merger to the context. 
+            _logger.LogInformation("Loading Merger {merger} for {contentType}", merger.GetType().Name, mergingProperty.Key);
+            context.Migrators.AddMergingMigrator(mergingProperty.Key, merger);
+
+            // the merging properties. 
+            context.Content.AddMergedProperty(mergingProperty.Key, mergingProperty.Value);
         }
     }
 }

--- a/uSync.Migrations/Services/SyncMigrationStatusService.cs
+++ b/uSync.Migrations/Services/SyncMigrationStatusService.cs
@@ -199,6 +199,7 @@ internal class SyncMigrationStatusService : ISyncMigrationStatusService
             MigrationType = defaultOptions.MigrationType,
             PreferredMigrators = defaultOptions.PreferredMigrators,
             PropertyMigrators = defaultOptions.PropertyMigrators,
+            MergingProperties = defaultOptions.MergingProperties,           
         };
     }
 

--- a/uSyncMigrationSite/uSyncMigrationSite.csproj
+++ b/uSyncMigrationSite/uSyncMigrationSite.csproj
@@ -22,6 +22,7 @@
 	<ItemGroup>
 		<!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
 		<PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
+		<ProjectReference Include="..\MyMigrations\MyMigrations.csproj" />
 		<ProjectReference Include="..\uSync.Migrations\uSync.Migrations.csproj" />
 		<RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" Condition="$(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx')))" />
 	</ItemGroup>


### PR DESCRIPTION
*WIP - still a little bit to do around - datatype generation* 

## Property merging 

This PR adds the ability to write property merging code, (via a `ISyncPropertyMergingMigrator`)

Merging will likely be very project specific, as you need to know the content type and the property names you want to merge , so it's something that you will configure on a project by project basis, but in theory this lets you do things like merge a load of properties into a single property (e.g a blockgrid). 

there are two parts to using a Merger. 

## 1. you need a Merger (implimenting `ISyncPropertyMergingMigrator` 

At a simple level this class will then get a list of property values, and is expected to return a string representing the merged properties,  for a complex property this will likely be a JSON string. 

e.g the SimpleStringMerger in this PR does this. 

```cs
public string GetMergedContentValues(IEnumerable<MergingPropertyValue> mergingPropertyValues, SyncMigrationContext context)
{
    // this merger just merges everything into one single text field.
    return string.Join("\r\n", mergingPropertyValues.Select(x => x.Value));
}
```
So it takes all the values and merges them into one single value. 

**_A usefull merger will be more complicated at this point, but this is where the magic happens._** 

## 2. You need a custom MigrationPlan

The MigrationPlan will define how the merge will work for your content types. 

In the same code for this PR we have a SimpleMergePlan - with the following options 

```cs
 public MigrationOptions Options => new MigrationOptions
{
    SourceVersion = 8, // only run on v8 to v10/11 migrations

    MergingProperties = new()
    {
        {
            // merge the footer on the home content type
            "home", new MergingPropertiesConfig("mergedFooterProperties",
                            nameof(SimpleStringMerger),
                            new List<string>
                            {
                                "footerDescription", "footerAddress", "footerHeader", "FooterCtalink", "footerCTACaption"
                            })
         }
    }
};
```

This says via code config, for the "Home" content type, merge all the "footer..." properties. using the `SimpleStringMerger`

it can also be done in the constructor of the plan, as that might read nicer. 

```cs
public SimpleMergePlan()
{
    var propertiesToMerge = new[] { "footerDescription", "footerAddress", "footerHeader", "FooterCtalink", "footerCTACaption" };
    Options.MergingProperties.Add("Home", new MergingPropertiesConfig("mergedFooterProperties", nameof(SimpleStringMerger), propertiesToMerge));
}
```

Merges run after migrations, so if you are merging anything it will first be migrated, and then merged, so you should expect everything to be in the 'v8' version of a property by the time it gets to the merger. 

### ToDo 
- [ ] For completness we also should allow mergers to define the properties they are going to merge into. this is the `GetMergedProperty` method of `ISyncPropertyMergingMigrator` 

it will be called when the migration is prepped, and in theory will allow the migrator to say, this is the name of type of property i am going to create for the merge, 

> at the moment this doesn't do anything - and even when it does, it won't be required, If you have already setup your doctypes for the merge, then you won't need to do this.




