### PR TITLE
Fixed XPath string manipulation for NuPickers

### DIFF
--- a/uSync.Migrations/Migrators/Community/NuPickersToContentmentDataListBase.cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersToContentmentDataListBase.cs
@@ -7,7 +7,7 @@ using uSync.Migrations.Migrators.Models;
 namespace uSync.Migrations.Migrators.Community;
 
 [SyncMigrator("nuPickers - base migrator, not used directly")]
-public class NuPickersToContentmentDataListBase : SyncPropertyMigratorBase
+public abstract class NuPickersToContentmentDataListBase : SyncPropertyMigratorBase
 {
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         => "Umbraco.Community.Contentment.DataList";

--- a/uSync.Migrations/Migrators/Community/NuPickersXPathCheckboxPickerToContentmentDataList .cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersXPathCheckboxPickerToContentmentDataList .cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Umbraco.Extensions;
 using uSync.Migrations.Context;
 using uSync.Migrations.Extensions;
 using uSync.Migrations.Migrators.Models;

--- a/uSync.Migrations/Migrators/Community/NuPickersXPathCheckboxPickerToContentmentDataList .cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersXPathCheckboxPickerToContentmentDataList .cs
@@ -16,6 +16,9 @@ namespace uSync.Migrations.Migrators.Community
 
             if (nuPickersConfig == null) return null;
 
+            // replace non-standard token '$ancestorOrSelf' parsed by nuPickers, into a Contentment '$current' placeholder token
+            nuPickersConfig.XPath = nuPickersConfig.XPath.Replace("$ancestorOrSelf", "$current");
+
             //Using an anonymous object for now, but ideally this should be replaced with Contentment objects (when they're created).
             var dataSource = new[]
             {

--- a/uSync.Migrations/Migrators/Community/NuPickersXPathCheckboxPickerToContentmentDataList .cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersXPathCheckboxPickerToContentmentDataList .cs
@@ -17,9 +17,6 @@ namespace uSync.Migrations.Migrators.Community
 
             if (nuPickersConfig == null) return null;
 
-            //XPath datasource is now erroring out if the XPath starts with a // so replacing with $root as a catch all.
-            if (nuPickersConfig.XPath.StartsWith("//")) nuPickersConfig.XPath = nuPickersConfig.XPath.ReplaceFirst("//", "$root/");
-
             //Using an anonymous object for now, but ideally this should be replaced with Contentment objects (when they're created).
             var dataSource = new[]
             {

--- a/uSync.Migrations/Migrators/Community/NuPickersXPathDropdownPickerToContentmentDataList.cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersXPathDropdownPickerToContentmentDataList.cs
@@ -18,9 +18,6 @@ namespace uSync.Migrations.Migrators.Community
 
             if (nuPickersConfig == null) return null;
 
-            //XPath datasource is now erroring out if the XPath starts with a // so replacing with $root as a catch all.
-            if (nuPickersConfig.XPath.StartsWith("//")) nuPickersConfig.XPath = nuPickersConfig.XPath.ReplaceFirst("//", "$root/");
-
             //Using an anonymous object for now, but ideally this should be replaced with Contentment objects (when they're created).
             var dataSource = new[]
             {

--- a/uSync.Migrations/Migrators/Community/NuPickersXPathDropdownPickerToContentmentDataList.cs
+++ b/uSync.Migrations/Migrators/Community/NuPickersXPathDropdownPickerToContentmentDataList.cs
@@ -18,6 +18,9 @@ namespace uSync.Migrations.Migrators.Community
 
             if (nuPickersConfig == null) return null;
 
+            // replace non-standard token '$ancestorOrSelf' parsed by nuPickers, into a Contentment '$current' placeholder token
+            nuPickersConfig.XPath = nuPickersConfig.XPath.Replace("$ancestorOrSelf", "$current");
+
             //Using an anonymous object for now, but ideally this should be replaced with Contentment objects (when they're created).
             var dataSource = new[]
             {


### PR DESCRIPTION
Changing an XPath string expression from '//' to '$root/' changes its behaviour from select descendants to select children.

Using '$root//' works as does the original '//' as both are valid XPath expressions, but chose to remove the string replacement and keep the original expression as had no problems with it in the destination Contentment dataTypes - although perhaps I've missed where it errors ? (if so, could add the '$root' prefix)

Also added handling of non-standard token '$ancestorOrSelf' which gets converted into a Contentment '$current' token.
