### PR TITLE
Fix stacked content migrator to respect preferred migrators

### DIFF
--- a/uSync.Migrations/Migrators/Community/StackedContentToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/StackedContentToBlockListMigrator.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.Blocks;
@@ -88,8 +88,7 @@ public class StackedContentToBlockListMigrator : SyncPropertyMigratorBase
                     continue;
                 }
 
-                var migrator = _migrators.Value
-                    .FirstOrDefault(x => x.Editors.InvariantContains(editorAlias.OriginalEditorAlias));
+                var migrator = context.Migrators.TryGetMigrator(editorAlias.OriginalEditorAlias);
 
                 if (migrator == null)
                 {


### PR DESCRIPTION
When the stacked content migrator was migrating any values nested inside, it wasn't respecting the preferred migrator settings (it was just taking the first applicable migrator). This changeset fixes this issue so that preferred migrators are respected.