### PR TITLE
Fix issue where nested DateTime format gets messed up

### DIFF
--- a/uSync.Migrations/Migrators/Community/Archetype/ArchetypeToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/ArchetypeToBlockListMigrator.cs
@@ -104,7 +104,7 @@ public class ArchetypeToBlockListMigrator : SyncPropertyMigratorBase
             return string.Empty;
         }
 
-        var archetype = JsonConvert.DeserializeObject<ArchetypeModel>(contentProperty.Value);
+        var archetype = JsonConvert.DeserializeObject<ArchetypeModel>(contentProperty.Value, new JsonSerializerSettings() { DateParseHandling = DateParseHandling.None });
         if (archetype == null)
         {
             return string.Empty;

--- a/uSync.Migrations/Migrators/Community/StackedContentToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/StackedContentToBlockListMigrator.cs
@@ -65,7 +65,7 @@ public class StackedContentToBlockListMigrator : SyncPropertyMigratorBase
             return string.Empty;
         }
 
-        var items = JsonConvert.DeserializeObject<IList<StackedContentItem>>(contentProperty.Value);
+        var items = JsonConvert.DeserializeObject<IList<StackedContentItem>>(contentProperty.Value, new JsonSerializerSettings() { DateParseHandling = DateParseHandling.None });
         if (items?.Any() != true)
         {
             return string.Empty;

--- a/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 using Umbraco.Cms.Core.PropertyEditors;
 
@@ -27,7 +27,7 @@ public class NestedContentMigrator : SyncPropertyMigratorBase
         var config = (NestedContentConfiguration?)new NestedContentConfiguration().MapPreValues(dataTypeProperty.PreValues);
         if (config?.ContentTypes == null) return new NestedContentConfiguration();
 
-        foreach(var contentTypeAlias in config.ContentTypes.Select(x => x.Alias))
+        foreach (var contentTypeAlias in config.ContentTypes.Select(x => x.Alias))
         {
             if (string.IsNullOrWhiteSpace(contentTypeAlias)) continue;
 
@@ -43,7 +43,7 @@ public class NestedContentMigrator : SyncPropertyMigratorBase
     {
         if (string.IsNullOrWhiteSpace(contentProperty.Value)) return string.Empty;
 
-        var rowValues = JsonConvert.DeserializeObject<IList<NestedContentRowValue>>(contentProperty.Value);
+        var rowValues = JsonConvert.DeserializeObject<IList<NestedContentRowValue>>(contentProperty.Value, new JsonSerializerSettings() { DateParseHandling = DateParseHandling.None });
         if (rowValues == null) return string.Empty;
 
         foreach (var row in rowValues)
@@ -69,7 +69,7 @@ public class NestedContentMigrator : SyncPropertyMigratorBase
                                 context);
                     }
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     throw new Exception($"Nested Error: [{editorAlias.OriginalEditorAlias} -{property.Key}] : {ex.Message}", ex);
                 }

--- a/uSync.Migrations/Migrators/Optional/NestedToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Optional/NestedToBlockListMigrator.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -110,7 +110,7 @@ public class NestedToBlockListMigrator : SyncPropertyMigratorBase
     public override string? GetContentValue(SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
     {
         if (string.IsNullOrWhiteSpace(contentProperty.Value)) return string.Empty;
-        var rowValues = JsonConvert.DeserializeObject<IList<NestedContentRowValue>>(contentProperty.Value);
+        var rowValues = JsonConvert.DeserializeObject<IList<NestedContentRowValue>>(contentProperty.Value, new JsonSerializerSettings() { DateParseHandling = DateParseHandling.None });
         if (rowValues == null) return string.Empty;
 
         var blockValue = new BlockValue();


### PR DESCRIPTION
Nested DateTime values (like this 2022-12-31T00:00:00) were getting parsed by the DeserializeObject call, and later converted back to string using simply `.ToString()` which used the default string formatting for the current culture (e.g. 12/31/2021 12:00:00 AM). This format later resulted in errors after import when trying to build the Examine index. This changeset prevents DateTimes from being parsed, so the date/time values stay as a string, which is how the Umbraco.DateTime migrator expects the value.