### PR TITLE
Fix to ensure element type compositions are marked as element types

### DIFF
--- a/uSync.Migrations/Migrators/Community/StackedContentToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/StackedContentToBlockListMigrator.cs
@@ -41,10 +41,7 @@ public class StackedContentToBlockListMigrator : SyncPropertyMigratorBase
 
         if (blocks?.Any() == true)
         {
-            foreach (var elementTypeKey in blocks.Select(x => x.ContentElementTypeKey))
-            {
-                context.ContentTypes.AddElementType(elementTypeKey);
-            }
+            context.ContentTypes.AddElementTypes(blocks.Select(x => x.ContentElementTypeKey), true);
         }
 
         var validationLimit = singleItemMode == 1

--- a/uSync.Migrations/Migrators/Optional/NestedToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Optional/NestedToBlockListMigrator.cs
@@ -10,6 +10,7 @@ using Umbraco.Extensions;
 
 using uSync.Migrations.Context;
 using uSync.Migrations.Extensions;
+using uSync.Migrations.Migrators.Core;
 using uSync.Migrations.Migrators.Models;
 
 using static Umbraco.Cms.Core.Constants;
@@ -91,7 +92,7 @@ public class NestedToBlockListMigrator : SyncPropertyMigratorBase
                 var contentTypeKey = context.ContentTypes.GetKeyByAlias(item.Alias);
 
                 // tell the process we need this to be an element type
-                context.ContentTypes.AddElementType(contentTypeKey);
+                context.ContentTypes.AddElementTypes(new[] { contentTypeKey }, true);
 
                 blocks.Add(new BlockListConfiguration.BlockConfiguration
                 {


### PR DESCRIPTION
When an element type has a composition type, this composition type does not getting imported as an element type. This causes an error later, when generating models.