### PR TITLE
Allow setting compositions and tabs for new content types

### DIFF
--- a/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -1,13 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
 using System.Xml.Linq;
-
-using Microsoft.Extensions.Logging;
-
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
-
 using uSync.Core;
 using uSync.Migrations.Composing;
 using uSync.Migrations.Context;
@@ -275,7 +272,7 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
             // if this has been blocked don't add it. 
 			if (context.IsBlocked(this.ItemType, contentType.Alias)) continue;
 
-            var source = contentType.MakeXMLFromNewDocType(_dataTypeService);
+            var source = contentType.MakeXMLFromNewDocType(_dataTypeService, context);
 
 			var migratingNotification = new SyncMigratingNotification<TEntity>(source, context);
 			if (_eventAggregator.PublishCancelable(migratingNotification) == true)

--- a/uSync.Migrations/Models/NewContentTypeInfo.cs
+++ b/uSync.Migrations/Models/NewContentTypeInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace uSync.Migrations.Models;
+﻿using System.Collections;
+
+namespace uSync.Migrations.Models;
 
 public class NewContentTypeInfo
 {
@@ -12,4 +14,14 @@ public class NewContentTypeInfo
 
     public string? Folder { get; set; }
     public IList<NewContentTypeProperty> Properties { get; set; } = new List<NewContentTypeProperty>();
+    public IList<string> CompositionAliases { get; set; } = new List<string>();
+    public IEnumerable<NewContentTypeTab> Tabs { get; set; } = new List<NewContentTypeTab> { new() };
+}
+
+public class NewContentTypeTab
+{
+    public string Name { get; set; } = "Block";
+    public string Alias { get; set; } = "block";
+    public string Type { get; set; } = "Group";
+    public int SortOrder { get; set; } = 0;
 }

--- a/uSync.Migrations/Models/NewContentTypeProperty.cs
+++ b/uSync.Migrations/Models/NewContentTypeProperty.cs
@@ -6,4 +6,6 @@ public class NewContentTypeProperty
     public string Alias { get; set; }
     public string DataTypeAlias { get; set; }
     public string OriginalEditorAlias { get; set; }
+
+    public string TabAlias { get; set; } = "block";
 }


### PR DESCRIPTION
When adding new content types to the context, this changeset allows specifying compositions and tabs to be added to the new content types. Previously no compositions were used and there was a single hard-coded "Block" tab group.

This is a feature that I'd like to use in [this BlockListSettings addon](https://github.com/EtchUK/Etch.uSyncMigrations.BlockListSettings) I've been working on.