### PR TITLE
Updated "Installed Package" name

### DIFF
--- a/uSync.Migrations/uSyncMigrations.cs
+++ b/uSync.Migrations/uSyncMigrations.cs
@@ -1,13 +1,11 @@
 ﻿global using UmbConstants = Umbraco.Cms.Core.Constants;
 global using BackOfficeConstants = uSync.BackOffice.uSyncConstants;
 
-using Org.BouncyCastle.Bcpg.Sig;
-
 namespace uSync.Migrations;
 
 public static class uSyncMigrations
 {
-    public const string AppName = "Migrations";
+    public const string AppName = "uSync Migrations";
 
     public const string TreeName = "uSyncMigrations";
 


### PR DESCRIPTION
In the backoffice, when you view Installed Packages, this package was listed as "Migrations".
I've updated this to be "uSync Migrations", as I couldn't see it being used elsewhere in the codebase.

Also removed the odd "BouncyCastle" using namespace.