### PR TITLE
RichText/TinyMCE - config migrator

### DIFF
--- a/uSync.Migrations/Migrators/Core/RichTextBoxMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/RichTextBoxMigrator.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.PropertyEditors;
+﻿using Newtonsoft.Json.Linq;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
 using uSync.Migrations.Context;
 using uSync.Migrations.Extensions;
 using uSync.Migrations.Migrators.Models;
@@ -9,6 +11,63 @@ namespace uSync.Migrations.Migrators;
 [SyncMigrator("Umbraco.TinyMCEv3")]
 public class RichTextBoxMigrator : SyncPropertyMigratorBase
 {
+    public override object? GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+    {
+        if (dataTypeProperty.PreValues?.Count > 0)
+        {
+            var config = new RichTextConfiguration().MapPreValues(dataTypeProperty.PreValues) as RichTextConfiguration;
+
+            if (config is not null)
+            {
+                if (config.Editor is JObject editor)
+                {
+                    var toolbar = editor["toolbar"] as JArray;
+                    if (toolbar?.Count > 0)
+                    {
+                        var replacements = new Dictionary<string, string>
+                        {
+                            { "code", "ace" },
+                            { "styleselect", "styles" },
+                        };
+
+                        foreach (var replacement in replacements)
+                        {
+                            var idx = toolbar.FindIndex(x => replacement.Key.Equals(x.ToString()) == true);
+                            if (idx >= 0)
+                            {
+                                toolbar.RemoveAt(idx);
+                                toolbar.Insert(idx, replacement.Value);
+                            }
+                        }
+                    }
+
+                    var stylesheets = editor["stylesheets"] as JArray;
+                    if (stylesheets?.Count > 0)
+                    {
+                        for (int i = 0; i < stylesheets.Count; i++)
+                        {
+                            stylesheets[i].Replace($"/css/{stylesheets[i]}.css");
+                        }
+                    }
+
+                    if (editor["mode"] is null)
+                    {
+                        editor["mode"] = "classic";
+                    }
+                }
+
+                if (config.OverlaySize is null)
+                {
+                    config.OverlaySize = "small";
+                }
+            }
+
+            return config;
+        }
+
+        return base.GetConfigValues(dataTypeProperty, context);
+    }
+
     public override string? GetContentValue(SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
     {
         var richTextValue = string.Empty;


### PR DESCRIPTION
There are subtle differences in the config options from v7, e.g. `"ace"` instead of `"code"`. This patch aligns them.