### PR TITLE
Language handler - LCID was unreliable, changed to culture code

### DIFF
--- a/uSync.Migrations/Handlers/Seven/LanguageMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/LanguageMigrationHandler.cs
@@ -1,21 +1,20 @@
-﻿using System.Globalization;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 
 using Microsoft.Extensions.Logging;
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 using uSync.Core;
 using uSync.Migrations.Context;
-using uSync.Migrations.Extensions;
 using uSync.Migrations.Handlers.Shared;
 using uSync.Migrations.Services;
 
 namespace uSync.Migrations.Handlers.Seven;
 
-[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Languages, 
+[SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Languages,
     SourceVersion = 7,
     SourceFolderName = "Languages", TargetFolderName = "Languages")]
 internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigrationHandler
@@ -35,7 +34,7 @@ internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigr
     protected override (string alias, Guid key) GetAliasAndKey(XElement source)
     {
         var alias = source.Attribute("CultureAlias").ValueOrDefault(string.Empty);
-        var key = CultureInfo.GetCultureInfo(alias)?.LCID.Int2Guid() ?? Guid.Empty;
+        var key = alias.ToGuid();
         return (alias: alias, key: key);
     }
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)


### PR DESCRIPTION
I'd noticed a couple of cultures having the same LCID, 4096, 19465. Which meant that when generating a Guid, there'd be a key clash. I've switched the code to use the alias (ISO culture code) to generate the Guid from.