### PR TITLE
Packer v7 min version guidance

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -15,6 +15,7 @@ uSync Packers are simple packages for Umbraco 7 and Umbraco 8, that use gather u
 | Umbraco 7 | Umbraco 8
 | - | -
 | [uSync.Migrations.Packer v7](https://clients.jumoo.co.uk/migrations/uSync.Migrations.Packer_7.0.1.zip) | [uSync.Migrations.Packer v8](https://clients.jumoo.co.uk/migrations/uSync.Migrations.Packer_8.0.0.zip)
+| Minimum v7.15.10 | Minimum ?
 
 > All Packers packages are available at https://clients.jumoo.co.uk/migrations/
 


### PR DESCRIPTION
I just tried to install the v7 packer on a v7.13.2 site to discover that it won't install as requires a minimum Umbraco version of 7.15.10

Assuming that this _has_ to be the minimum version supported, I have added a note to the Getting Started docs.

What's the minimum version for the v8 packer, as I could get that added too?

I assume that if you are on a site lower than the minimum you need to go to Our and download the appropriate 'Content Edition' package? I could add those words too.