### PR TITLE
DTGE fixes

### DIFF
--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigContext.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigContext.cs
@@ -68,6 +68,24 @@ internal class GridToBlockGridConfigContext
         AllowedLayouts[RootArea] = rootAllowed;
     }
 
+    public IEnumerable<string> GetAllowedEditors(BlockGridConfiguration.BlockGridAreaConfiguration area)
+    {
+        if (AllowedEditors.TryGetValue(area, out var allowed))
+            return allowed;
+
+        return Enumerable.Empty<string>();
+    }
+
+    public IEnumerable<string> GetRootAllowedEditors()
+        => GetAllowedEditors(RootArea);
+
+    public void AppendToRootEditors(IEnumerable<string> allowed)
+    {
+        var rootAllowed = GetRootAllowedEditors().ToList();
+        rootAllowed.AddRange(allowed);
+        AllowedEditors[RootArea] = rootAllowed;
+    }
+
     public IEnumerable<string> AllEditors()
         => AllowedEditors.SelectMany(x => x.Value).Distinct();
 

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutBlockHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutBlockHelper.cs
@@ -165,6 +165,7 @@ internal class GridToBlockGridConfigLayoutBlockHelper
 
                 if (gridArea.Grid == gridBlockContext.GridColumns)
                 {
+                    gridBlockContext.AppendToRootEditors(allowed);
                     gridBlockContext.AppendToRootLayouts(allowed);
                     continue;
                 }

--- a/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -56,19 +56,24 @@ internal class GridToBlockContentHelper
 
         var blockLayouts = new List<BlockGridLayoutItem>();
 
-        var rootSection = new BlockItemData
+        BlockGridLayoutItem? rootLayoutItem = null;
+
+        if (sectionKey != Guid.Empty)
         {
-          Udi = Udi.Create(UmbConstants.UdiEntityType.Element, Guid.NewGuid()),
-          ContentTypeKey = sectionKey,
-          ContentTypeAlias = sectionContentTypeAlias
-        };
-        block.ContentData.Add(rootSection);
-        var rootLayoutItem = new BlockGridLayoutItem
-        {
-          ContentUdi = rootSection.Udi,
-          ColumnSpan = gridColumns,
-          RowSpan = 1
-        };
+            var rootSection = new BlockItemData
+            {
+                Udi = Udi.Create(UmbConstants.UdiEntityType.Element, Guid.NewGuid()),
+                ContentTypeKey = sectionKey,
+                ContentTypeAlias = sectionContentTypeAlias
+            };
+            block.ContentData.Add(rootSection);
+            rootLayoutItem = new BlockGridLayoutItem
+            {
+                ContentUdi = rootSection.Udi,
+                ColumnSpan = gridColumns,
+                RowSpan = 1
+            };
+        }
         var rootLayoutAreas = new List<BlockGridLayoutAreaItem>();
 
         foreach (var item in sections.Select((value, sectionIndex) => new {sectionIndex, value}))
@@ -144,10 +149,10 @@ internal class GridToBlockContentHelper
                 blockLayouts.Clear();
             }
         }
-        if (rootLayoutAreas.Count > 1)
+        if (rootLayoutItem != null && rootLayoutAreas.Count > 1)
         {
-          rootLayoutItem.Areas = rootLayoutAreas.ToArray();
-          blockLayouts.Add(rootLayoutItem);
+            rootLayoutItem.Areas = rootLayoutAreas.ToArray();
+            blockLayouts.Add(rootLayoutItem);
         }
 
         // end - process layouts into block format. 


### PR DESCRIPTION
This fixes a couple of issues I encountered while migrating a DTGE based site.

e615325 If you have an editor, using a regex to define allowed content types, it will now migrate into a new block type per content type matched.

c23ae99 If your root section only has one area, as wide as the complete grid, the layout block type is not created, but the migrator will still try to create the layout block. This fails, as the layout block gets a content type of Guid.Empty - as the block type and content type isn't created.

2ab119d If I understand correctly, layouts with full width are counted as root sections, and not converted into layout blocks. If you have editors only allowed in these full width columns, they are not being created correctly.