### PR TITLE
Fix for Nested Content to Block List in Grid

### DIFF
--- a/uSync.Migrations/Migrators/Optional/NestedToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Optional/NestedToBlockListMigrator.cs
@@ -111,6 +111,13 @@ public class NestedToBlockListMigrator : SyncPropertyMigratorBase
     public override string? GetContentValue(SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
     {
         if (string.IsNullOrWhiteSpace(contentProperty.Value)) return string.Empty;
+
+        if (contentProperty.Value.InvariantStartsWith("{\r\n  \"layout\": {\r\n    \"Umbraco.BlockList\":"))
+        {
+            _logger.LogDebug("Property [{name}] is already BlockList", contentProperty.EditorAlias);
+            return contentProperty.Value;
+        }
+
         var rowValues = JsonConvert.DeserializeObject<IList<NestedContentRowValue>>(contentProperty.Value, new JsonSerializerSettings() { DateParseHandling = DateParseHandling.None });
         if (rowValues == null) return string.Empty;
 


### PR DESCRIPTION
When converting grid with DTGE with Nested Content inside, for some reason it runs the migration of Nested Content properties twice. Should probably be fixed in another way, but I got around it, by checking the value, as in this PR.

You could do the check like in Grid to BlockGrid, but I am unsure how it would cope with Nested Content inside of Nested Content.