### PR TITLE
fix: ensured that we can rerun migrations after having db up and running first migration

### DIFF
--- a/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
@@ -44,7 +44,7 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
     {
         foreach (var datatype in _dataTypeService.GetAll())
         {
-            context.DataTypes.AddDefinition(datatype.Key, new Models.DataTypeInfo(datatype.EditorAlias, datatype.Name ?? datatype.EditorAlias));
+            context.DataTypes.AddDefinition(datatype.Key, new Models.DataTypeInfo(datatype.EditorAlias, datatype.EditorAlias,datatype.Name ?? datatype.EditorAlias));
         }
     }
 
@@ -80,12 +80,18 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
         if (replacementInfo != null)
         {
             context.DataTypes.AddReplacement(dtd, replacementInfo.Key);
-            context.DataTypes.AddDefinition(dtd, new Models.DataTypeInfo(replacementInfo.EditorAlias, dataTypeName));
+
+            context.DataTypes.AddDefinition(dtd, new Models.DataTypeInfo(replacementInfo.EditorAlias, editorAlias,dataTypeName));
 
             if (string.IsNullOrWhiteSpace(replacementInfo.Variation) == false)
             {
                 context.DataTypes.AddVariation(dtd, replacementInfo.Variation);
             }
+        }
+
+        if (context.DataTypes.GetByDefinition(dtd) != null)
+        {
+            context.DataTypes.GetByDefinition(dtd).OriginalEditorAlias = editorAlias;
         }
     }
 
@@ -105,8 +111,15 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
 
         var dataTypeName = GetDataTypeName(source);
 
+   
         // add alias, (won't update if replacement was added)
-        context.DataTypes.AddDefinition(dtd, new Models.DataTypeInfo(editorAlias, dataTypeName));
+        context.DataTypes.AddDefinition(dtd, new Models.DataTypeInfo(editorAlias, editorAlias, dataTypeName));
+        if (context.DataTypes.GetByDefinition(dtd) != null)
+        {
+            // ensured that we always populated old alias, so we can use it in archetype
+
+            context.DataTypes.GetByDefinition(dtd).OriginalEditorAlias = editorAlias;
+         }
         context.DataTypes.AddAlias(dtd, alias);
     }
 

--- a/uSync.Migrations/Migrators/Community/Archetype/ArchetypeToBlockListMigrator.cs
+++ b/uSync.Migrations/Migrators/Community/Archetype/ArchetypeToBlockListMigrator.cs
@@ -76,7 +76,7 @@ public class ArchetypeToBlockListMigrator : SyncPropertyMigratorBase
                             Alias = p.Alias,
                             Name = p.Label,
                             DataTypeAlias = dataType.DataTypeName,
-                            OriginalEditorAlias = dataType.EditorAlias,
+                            OriginalEditorAlias =  string.IsNullOrWhiteSpace(p.PropertyEditorAlias) ? dataType.OriginalEditorAlias:p.PropertyEditorAlias,
                         };
                     })
                     .WhereNotNull()

--- a/uSync.Migrations/Migrators/Community/VortoMapper.cs
+++ b/uSync.Migrations/Migrators/Community/VortoMapper.cs
@@ -85,7 +85,7 @@ public class VortoMapper : SyncPropertyMigratorBase,
                 if (dataType is not null)
                 {
                     var migrator = context.Migrators.TryGetMigrator(
-                        $"{contentProperty.ContentTypeAlias}_{contentProperty.PropertyAlias}", dataType.EditorAlias);
+                        $"{contentProperty.ContentTypeAlias}_{contentProperty.PropertyAlias}", dataType.OriginalEditorAlias);
 
                     if (migrator != null)
                     {

--- a/uSync.Migrations/Models/DataTypeInfo.cs
+++ b/uSync.Migrations/Models/DataTypeInfo.cs
@@ -2,13 +2,15 @@
 
 public class DataTypeInfo
 {
-    public DataTypeInfo(string editorAlias, string dataTypeName)
+    public DataTypeInfo(string editorAlias, string originalEditorAlias, string dataTypeName)
     {
         EditorAlias = editorAlias;
+        OriginalEditorAlias = originalEditorAlias;
         DataTypeName = dataTypeName;
     }
 
     public string EditorAlias { get; }
 
+    public string OriginalEditorAlias { get; set; }
     public string DataTypeName { get; }
 }


### PR DESCRIPTION
Hi @KevinJump,
found interesting issue with that we rely on datatype service in context, datatypes getting migrated, but content is not as we cannot fnd migrator for editor alias :)