### PR TITLE
Migrator for robotsMetaEditor to Contentment Data List

### DIFF
--- a/uSync.Migrations/Migrators/Community/RobotsMetaEditorToContentmentDataList.cs
+++ b/uSync.Migrations/Migrators/Community/RobotsMetaEditorToContentmentDataList.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using uSync.Migrations.Context;
+using uSync.Migrations.Migrators.Models;
+
+namespace uSync.Migrations.Migrators.Community;
+
+[SyncMigrator("robotsMetaEditor")]
+[SyncMigratorVersion(7, 8)]
+public class RobotsMetaEditorToContentmentDataList : SyncPropertyMigratorBase
+{
+    public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => "Umbraco.Community.Contentment.DataList";
+
+    public override object? GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty,
+        SyncMigrationContext context)
+    {
+        var config = JsonConvert.DeserializeObject("{\r\n  \"dataSource\": [\r\n    {\r\n      \"key\": \"Umbraco.Community.Contentment.DataEditors.UserDefinedDataListSource, Umbraco.Community.Contentment\",\r\n      \"value\": {\r\n        \"items\": [\r\n          {\r\n            \"icon\": \"icon-stop color-black\",\r\n            \"name\": \"Index this, and follow links\",\r\n            \"value\": \"index,follow,noodp\",\r\n            \"description\": \"Will allow indexing of this page, and allow the search engine to follow links\"\r\n          },\r\n          {\r\n            \"icon\": \"icon-stop\",\r\n            \"name\": \"Dont index this, but follow links\",\r\n            \"value\": \"noindex,follow,noodp\",\r\n            \"description\": \"Will disallow indexing of this page, but will allow the search engine to follow links\"\r\n          },\r\n          {\r\n            \"icon\": \"icon-stop\",\r\n            \"name\": \"Index none\",\r\n            \"value\": \"noindex,nofollow,noodp\",\r\n            \"description\": \"Will disallow indexing of this page, and disallow it to follow links\"\r\n          }\r\n        ]\r\n      }\r\n    }\r\n  ],\r\n  \"listEditor\": [\r\n    {\r\n      \"key\": \"Umbraco.Community.Contentment.DataEditors.RadioButtonListDataListEditor, Umbraco.Community.Contentment\",\r\n      \"value\": {\r\n        \"showDescriptions\": \"1\",\r\n        \"showIcons\": \"0\",\r\n        \"allowClear\": \"0\"\r\n      }\r\n    }\r\n  ]\r\n}");
+        return config;
+    }
+}


### PR DESCRIPTION
This adds a migrator for [robotsMetaEditor](https://github.com/mikkelhm/Umbraco-robots-meta-tag-property-editor) to Contentment Data List with a user defined source, and a radio button list as the display.

![image](https://github.com/Jumoo/uSyncMigrations/assets/3726467/25355651-51e1-4d0c-b4dd-b7eab678fd84)

I've added the `[SyncMigratorVersion(7, 8)]` because it wont run on my machine without it. Don't know if its necessary, or just me :)