### PR TITLE
Migrator for skttl.HtmlEditor to Contentment Code Editor

### DIFF
--- a/uSync.Migrations/Migrators/Community/SkttlHtmlEditorToContentmentCodeEditor.cs
+++ b/uSync.Migrations/Migrators/Community/SkttlHtmlEditorToContentmentCodeEditor.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using uSync.Migrations.Context;
+using uSync.Migrations.Migrators.Models;
+
+namespace uSync.Migrations.Migrators.Community;
+
+[SyncMigrator("skttl.HtmlEditor")]
+[SyncMigratorVersion(7, 8)]
+public class SkttlHtmlEditorToContentmentCodeEditorMigrator : SyncPropertyMigratorBase
+{
+    public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+  => "Umbraco.Community.Contentment.CodeEditor";
+    public override object? GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+    {
+        var config = JsonConvert.DeserializeObject("{\r\n  \"mode\": \"razor\",\r\n  \"theme\": \"chrome\",\r\n  \"fontSize\": \"small\",\r\n  \"useWrapMode\": \"0\",\r\n  \"minLines\": 12,\r\n  \"maxLines\": 30\r\n}");
+        return config;
+
+    }
+}


### PR DESCRIPTION
This adds a migrator for [skttl.HtmlEditor](https://github.com/skttl/skttl.HtmlEditor) to Contentment Code Editor.

I've added the [SyncMigratorVersion(7, 8)] because it wont run on my machine without it. Don't know if its necessary, or just me :)