### PR TITLE
Fix SEO metadata migrator outputting empty GUID for definition node

### DIFF
--- a/uSync.Migrations/Context/DataTypeMigrationContext.cs
+++ b/uSync.Migrations/Context/DataTypeMigrationContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -92,6 +92,9 @@ public class DataTypeMigrationContext
 			? variation : "Nothing";
 
     public Guid? GetFirstDefinition(string alias)
-		=> _dataTypeDefinitions?.FirstOrDefault(x => x.Value.EditorAlias == alias).Key;
+    {
+        var dataTypeDefinition = _dataTypeDefinitions?.FirstOrDefault(x => x.Value.EditorAlias == alias);
+        return dataTypeDefinition.Value.Value != null ? dataTypeDefinition.Value.Key : null;
+    }
 
 }


### PR DESCRIPTION
Issue was occurring due to the data type not being present causing the `FirstOrDefault` to return an empty item with an empty GUID. Solution was to add a check to see if the value returned from `FirstOrDefault` isn't null.