### PR TITLE
Some times DTGEs has no view specified

### DIFF
--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -115,7 +116,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 				{
 					foreach (var control in area.Controls)
 					{
-						if (control.Editor.View == null && control.Value?["dtgeContentTypeAlias"] != null)
+						if (control.Editor.View == null && control.Value is JObject value && value["dtgeContentTypeAlias"] != null)
 						{
 							control.Editor.View = "/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html";
 							_logger.LogDebug("Control {alias} looks like a DTGE, but has no view, {view} has been added as view", control.Editor.Alias, control.Editor.View);

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -106,6 +106,25 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 			return string.Empty;
 		}
 
+		// For some reason, DTGEs can sometimes end up without a view specified. This should fix it.
+		foreach (var section in source.Sections)
+		{
+			foreach (var row in section.Rows)
+			{
+				foreach (var area in row.Areas)
+				{
+					foreach (var control in area.Controls)
+					{
+						if (control.Editor.View == null && control.Value?["dtgeContentTypeAlias"] != null)
+						{
+							control.Editor.View = "/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html";
+							_logger.LogDebug("Control {alias} looks like a DTGE, but has no view, {view} has been added as view", control.Editor.Alias, control.Editor.View);
+						}
+					}
+				}
+			}
+		}
+
 		var helper = new GridToBlockContentHelper(_conventions, _blockMigrators,
 			_loggerFactory.CreateLogger<GridToBlockContentHelper>());
 		


### PR DESCRIPTION
I found out (at least in my migration), that I had a bunch of DTGEs in my content, where the view property was just null. This caused the Migration to fall back to the default grid editor migrator, and then it failed, because it couldn't find the contenttype (as it was looking for eg. BlockElement_spot).

The grid editor could look like this:
```json
{
  "value": {
    "id": "4467644c-b930-e6be-61b7-9867f8baf26c",
    "dtgeContentTypeAlias": "spot",
    "value": {
      "name": "Spot",
      "image": "",
      "title": "Skal du fakturere et af selskaberne?",
      "description": null,
      "link": [],
      "hideImage": "0"
    }
  },
  "editor": {
    "alias": "spot",
    "view": null
  },
  "styles": null,
  "config": null
},
```

So I added some code, to run through the deserialized grid value, and find controls with null in view, and a dtgeContentTypeAlias property in value, to force a view path back in there.

I'm not sure why this happens, but this specific project, has once been migrated from 7 to 8 too. Maybe some of the data got corrupted back then. We've never had any problems with it though.