### PR TITLE
fix: ensure Umbraco.Date editors are migrated to Umbraco.DateTime

### DIFF
--- a/uSync.Migrations/Migrators/Core/DatePickerMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/DatePickerMigrator.cs
@@ -1,8 +1,13 @@
 ﻿using Umbraco.Cms.Core.PropertyEditors;
+using uSync.Migrations.Context;
+using uSync.Migrations.Migrators.Models;
 
 namespace uSync.Migrations.Migrators;
 
 [SyncMigrator(UmbConstants.PropertyEditors.Aliases.DateTime, typeof(DateTimeConfiguration), IsDefaultAlias = true)]
 [SyncMigrator("Umbraco.Date")]
 public class DatePickerMigrator : SyncPropertyMigratorBase
-{ }
+{ 
+    public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        => UmbConstants.PropertyEditors.Aliases.DateTime;
+}


### PR DESCRIPTION
Umbraco.Date no longer exists in Umbraco, so Umbraco.Date editors can be migrated to Umbraco.DateTime. Without this change, Umbraco.Date editors remain as Umbraco.Date which doesn't exist and causes issues when trying to use such editors in Umbraco 9+. 