### PR TITLE
Ability to rename content types

### DIFF
--- a/uSync.Migrations/Configuration/Models/MigrationOptions.cs
+++ b/uSync.Migrations/Configuration/Models/MigrationOptions.cs
@@ -62,6 +62,11 @@ public class MigrationOptions
     ///  things we might want to merge.
     /// </summary>
     public Dictionary<string, MergingPropertiesConfig> MergingProperties { get; set; } = new(StringComparer.InvariantCultureIgnoreCase);
+    
+    /// <summary>
+    /// Mapping of old to new content type aliases
+    /// </summary>
+    public IDictionary<string, string>? ReplacementAliases { get; set; }
 }
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]

--- a/uSync.Migrations/Context/ContentTypeMigrationContext.cs
+++ b/uSync.Migrations/Context/ContentTypeMigrationContext.cs
@@ -34,6 +34,10 @@ public class ContentTypeMigrationContext
     ///  list of content types that need to be set as element types. 
     /// </summary>
     private HashSet<Guid> _elementContentTypes = new HashSet<Guid>();
+    
+    private Dictionary<string, string> _replacementAliases =
+	    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
     public IArchetypeMigrationConfigurer ArchetypeMigrationConfigurer { get; set; } 
 
     /// <summary>
@@ -236,5 +240,13 @@ public class ContentTypeMigrationContext
 		=> _dataTypeAliases.TryGetValue($"{contentTypeAlias}_{propertyAlias}", out var alias) == true
 			? alias : string.Empty;
 
+	/// <summary>
+	/// Add a replacement alias for a content type alias
+	/// </summary>
+	public void AddReplacementAlias(string original, string replacement)
+		=> _replacementAliases.TryAdd(original, replacement);
 
+	public string GetReplacementAlias(string alias)
+		=> _replacementAliases.TryGetValue(alias, out var replacement) 
+			? replacement : alias;
 }

--- a/uSync.Migrations/Handlers/Eight/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentBaseMigrationHandler.cs
@@ -25,8 +25,8 @@ internal class ContentBaseMigrationHandler<TEntity> : SharedContentBaseHandler<T
         : base(eventAggregator, migrationFileService, shortStringHelper, logger)
     { }
 
-    protected override string GetContentType(XElement source)
-        => source.Element("Info")?.Element("ContentType").ValueOrDefault(string.Empty) ?? string.Empty;
+    protected override string GetContentType(XElement source, SyncMigrationContext context)
+        => context.ContentTypes.GetReplacementAlias(source.Element("Info")?.Element("ContentType").ValueOrDefault(string.Empty) ?? string.Empty);
 
     protected override int GetId(XElement source) => -1;
 

--- a/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
@@ -25,10 +25,10 @@ internal class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseH
         : base(eventAggregator, migrationFileService, logger, dataTypeService, migrationHandlers)
     { }
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext? context)
     {
-        var (a, k) = base.GetAliasAndKey(source, context);
-        return (alias: context.ContentTypes.GetReplacementAlias(a), key: k);
+        var (alias, key) = base.GetAliasAndKey(source, context);
+        return (alias: context?.ContentTypes.GetReplacementAlias(alias) ?? alias, key: key);
     }
 
     protected override void UpdatePropertyXml(XElement source, XElement newProperty, SyncMigrationContext context)

--- a/uSync.Migrations/Handlers/MigrationHandlerBase.cs
+++ b/uSync.Migrations/Handlers/MigrationHandlerBase.cs
@@ -161,7 +161,7 @@ internal abstract class MigrationHandlerBase<TObject>
                 // if the file is a delete/rename/etc skip over it. 
                 if (source.IsEmptyItem()) continue;
 
-                var (alias, key) = GetAliasAndKey(source);
+                var (alias, key) = GetAliasAndKey(source, context);
                 if (context.IsBlocked(ItemType, alias)) continue;
 
                 var migratingNotification = new SyncMigratingNotification<TObject>(source, context);
@@ -217,6 +217,7 @@ internal abstract class MigrationHandlerBase<TObject>
     ///  method to get the source and alias of a value.
     /// </summary>
     /// <param name="source"></param>
+    /// <param name="context"></param>
     /// <returns></returns>
-    protected abstract (string alias, Guid key) GetAliasAndKey(XElement source);
+    protected abstract (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context);
 }

--- a/uSync.Migrations/Handlers/MigrationHandlerBase.cs
+++ b/uSync.Migrations/Handlers/MigrationHandlerBase.cs
@@ -216,8 +216,22 @@ internal abstract class MigrationHandlerBase<TObject>
     /// <summary>
     ///  method to get the source and alias of a value.
     /// </summary>
-    /// <param name="source"></param>
-    /// <param name="context"></param>
+    /// <param name="source">XMLElement for item</param>
+    /// <param name="context">Migration context</param>
     /// <returns></returns>
-    protected abstract (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context);
+    protected abstract (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext? context);
+
+    /// <summary>
+    ///  Get the Alias and Key values for an item.
+    /// </summary>
+    /// <remarks>
+    ///  this method is obsolete, you should pass the context.
+    ///  this then allows for renames, and maniupulation based on config.
+    /// </remarks>
+    /// <param name="source">XML Source for item</param>
+    /// <returns></returns>
+    [Obsolete("Call GetAliasAndKey with MigrationContext")]
+    protected virtual (string alias, Guid key) GetAliasAndKey(XElement source)
+    => GetAliasAndKey(source, null);
+
 }

--- a/uSync.Migrations/Handlers/Seven/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentBaseMigrationHandler.cs
@@ -28,7 +28,7 @@ internal abstract class ContentBaseMigrationHandler<TEntity> : SharedContentBase
     protected override int GetId(XElement source)
         => source.Attribute("id").ValueOrDefault(0);
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext? context)
        => (
             alias: source.Attribute("nodeName").ValueOrDefault(string.Empty),
             key: source.Attribute("guid").ValueOrDefault(Guid.Empty)

--- a/uSync.Migrations/Handlers/Seven/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentBaseMigrationHandler.cs
@@ -28,7 +28,7 @@ internal abstract class ContentBaseMigrationHandler<TEntity> : SharedContentBase
     protected override int GetId(XElement source)
         => source.Attribute("id").ValueOrDefault(0);
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
        => (
             alias: source.Attribute("nodeName").ValueOrDefault(string.Empty),
             key: source.Attribute("guid").ValueOrDefault(Guid.Empty)
@@ -37,8 +37,8 @@ internal abstract class ContentBaseMigrationHandler<TEntity> : SharedContentBase
     protected override Guid GetParent(XElement source)
         => source.Attribute("parentGUID").ValueOrDefault(Guid.Empty);
 
-    protected override string GetContentType(XElement source)
-        => source.Attribute("nodeTypeAlias").ValueOrDefault(string.Empty);
+    protected override string GetContentType(XElement source, SyncMigrationContext context)
+        => context.ContentTypes.GetReplacementAlias(source.Attribute("nodeTypeAlias").ValueOrDefault(string.Empty));
 
     protected override string GetPath(string alias, Guid parent, SyncMigrationContext context)
         => context.Content.GetContentPath(parent) + "/" + alias.ToSafeAlias(_shortStringHelper);
@@ -63,7 +63,7 @@ internal abstract class ContentBaseMigrationHandler<TEntity> : SharedContentBase
 
     protected override XElement GetBaseXml(XElement source, Guid parent, string contentType, int level, SyncMigrationContext context)
     {
-        var (alias, key) = GetAliasAndKey(source);
+        var (alias, key) = GetAliasAndKey(source, context);
 
         var template = source.Attribute("templateAlias").ValueOrDefault(string.Empty);
         var published = source.Attribute("published").ValueOrDefault(false);

--- a/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Linq;
+﻿using System.Diagnostics.Tracing;
+using System.Xml.Linq;
 
 using Microsoft.Extensions.Logging;
 
@@ -37,11 +38,14 @@ internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContent
         _shortStringHelper = shortStringHelper;
     }
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
-        => (
-            alias: context.ContentTypes.GetReplacementAlias(source.Element("Info")?.Element("Alias")?.ValueOrDefault(string.Empty) ?? string.Empty),
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext? context)
+    {
+        var sourceAlias = source.Element("Info")?.Element("Alias").ValueOrDefault(string.Empty) ?? string.Empty;
+        return (
+            alias: context?.ContentTypes.GetReplacementAlias(sourceAlias) ?? sourceAlias,
             key: source.Element("Info")?.Element("Key")?.ValueOrDefault(Guid.Empty) ?? Guid.Empty
         );
+    }
 
     protected override void UpdateTabs(XElement source, XElement target, SyncMigrationContext context)
     {

--- a/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/DataTypeMigrationHandler.cs
@@ -39,7 +39,7 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
         _migrators = migrators;
     }
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext? context)
         => (
             alias: source.Attribute("Name").ValueOrDefault(string.Empty),
             key: source.Attribute("Key").ValueOrDefault(Guid.Empty)

--- a/uSync.Migrations/Handlers/Seven/DictionaryMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/DictionaryMigrationHandler.cs
@@ -35,7 +35,7 @@ internal class DictionaryMigrationHandler : SharedHandlerBase<DictionaryItem>, I
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
          => null;
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
         => (
             alias: source.Attribute("Key").ValueOrDefault(string.Empty),
             key: source.Attribute("guid").ValueOrDefault(Guid.Empty)

--- a/uSync.Migrations/Handlers/Seven/DictionaryMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/DictionaryMigrationHandler.cs
@@ -35,7 +35,7 @@ internal class DictionaryMigrationHandler : SharedHandlerBase<DictionaryItem>, I
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
          => null;
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext? context)
         => (
             alias: source.Attribute("Key").ValueOrDefault(string.Empty),
             key: source.Attribute("guid").ValueOrDefault(Guid.Empty)

--- a/uSync.Migrations/Handlers/Seven/LanguageMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/LanguageMigrationHandler.cs
@@ -31,7 +31,7 @@ internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigr
         _localizationService = localizationService;
     }
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext? context)
     {
         var alias = source.Attribute("CultureAlias").ValueOrDefault(string.Empty);
         var key = alias.ToGuid();

--- a/uSync.Migrations/Handlers/Seven/LanguageMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/LanguageMigrationHandler.cs
@@ -31,7 +31,7 @@ internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigr
         _localizationService = localizationService;
     }
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
     {
         var alias = source.Attribute("CultureAlias").ValueOrDefault(string.Empty);
         var key = alias.ToGuid();
@@ -39,7 +39,7 @@ internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigr
     }
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
     {
-        var (alias, key) = GetAliasAndKey(source);
+        var (alias, key) = GetAliasAndKey(source, context);
 
         var existing = _localizationService.GetLanguageByIsoCode(alias);
 

--- a/uSync.Migrations/Handlers/Seven/MacroMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/MacroMigrationHandler.cs
@@ -25,7 +25,7 @@ internal class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationH
         : base(eventAggregator, migrationFileService, logger)
     { }
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
         => (
             alias: source.Element("alias").ValueOrDefault(string.Empty),
             key: source.Element("Key").ValueOrDefault(Guid.Empty)
@@ -33,7 +33,7 @@ internal class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationH
 
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
     {
-        var (alias, key) = GetAliasAndKey(source);
+        var (alias, key) = GetAliasAndKey(source, context);
 
         var target = new XElement("Macro",
             new XAttribute(uSyncConstants.Xml.Key, key),

--- a/uSync.Migrations/Handlers/Seven/MacroMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/MacroMigrationHandler.cs
@@ -25,7 +25,7 @@ internal class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationH
         : base(eventAggregator, migrationFileService, logger)
     { }
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext? context)
         => (
             alias: source.Element("alias").ValueOrDefault(string.Empty),
             key: source.Element("Key").ValueOrDefault(Guid.Empty)

--- a/uSync.Migrations/Handlers/Seven/TemplateMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/TemplateMigrationHandler.cs
@@ -43,7 +43,7 @@ internal class TemplateMigrationHandler : SharedTemplateHandler,  ISyncMigration
         return target;
     }
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
         => (
             alias: source.Element("Alias").ValueOrDefault(string.Empty),
             key: source.Element("Key").ValueOrDefault(Guid.Empty)

--- a/uSync.Migrations/Handlers/Seven/TemplateMigrationHandler.cs
+++ b/uSync.Migrations/Handlers/Seven/TemplateMigrationHandler.cs
@@ -43,7 +43,7 @@ internal class TemplateMigrationHandler : SharedTemplateHandler,  ISyncMigration
         return target;
     }
 
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext? context)
         => (
             alias: source.Element("Alias").ValueOrDefault(string.Empty),
             key: source.Element("Key").ValueOrDefault(Guid.Empty)

--- a/uSync.Migrations/Handlers/Shared/SharedContentBaseHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedContentBaseHandler.cs
@@ -38,7 +38,7 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
 
     protected override void PrepareFile(XElement source, SyncMigrationContext context)
     {
-        var (alias, key) = GetAliasAndKey(source);
+        var (alias, key) = GetAliasAndKey(source, context);
 
         if (key != Guid.Empty)
         {
@@ -59,7 +59,7 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
 
     protected abstract Guid GetParent(XElement source);
 
-    protected abstract string GetContentType(XElement source);
+    protected abstract string GetContentType(XElement source, SyncMigrationContext context);
 
     protected abstract string GetPath(string alias, Guid parent, SyncMigrationContext context);
 
@@ -69,10 +69,10 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
 
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
     {
-        var (alias, key) = GetAliasAndKey(source);
+        var (alias, key) = GetAliasAndKey(source, context);
 
         var parent = GetParent(source);
-        var contentType = GetContentType(source);
+        var contentType = GetContentType(source, context);
 
         var path = GetPath(alias, parent, context);
         context.Content.AddContentPath(key, path);

--- a/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedDataTypeHandler.cs
@@ -67,7 +67,7 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
 
     protected override void PrepareFile(XElement source, SyncMigrationContext context)
     {
-        var (alias, dtd) = GetAliasAndKey(source);
+        var (alias, dtd) = GetAliasAndKey(source, context);
         var editorAlias = GetEditorAlias(source);
 
         if (dtd == Guid.Empty || string.IsNullOrEmpty(editorAlias)) return;
@@ -98,7 +98,7 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
     public void PrePrepareFiles(XElement source, SyncMigrationContext context)
     {
         var editorAlias = GetEditorAlias(source);
-        var (alias, dtd) = GetAliasAndKey(source);
+        var (alias, dtd) = GetAliasAndKey(source, context);
 
         if (dtd == Guid.Empty || string.IsNullOrEmpty(editorAlias)) return;
 
@@ -140,8 +140,8 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
 
     protected override XElement? MigrateFile(XElement source, int level, SyncMigrationContext context)
     {
-        var (alias, key) = GetAliasAndKey(source);
-        var editorAlias = GetEditorAlias(source);   
+        var (alias, key) = GetAliasAndKey(source, context);
+        var editorAlias = GetEditorAlias(source);
 
         if (context.DataTypes.GetReplacement(key) != key)
         {

--- a/uSync.Migrations/Handlers/Shared/SharedHandlerBase.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedHandlerBase.cs
@@ -44,9 +44,9 @@ internal abstract class SharedHandlerBase<TObject> :MigrationHandlerBase<TObject
     { }
 
     /// <summary>
-    ///  alias and key - v8 we have methods that get these values consitantly. 
+    ///  alias and key - v8 we have methods that get these values consistently. 
     /// </summary>
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext? context)
         => (alias: source.GetAlias(), key: source.GetKey());
 
     /// <summary>

--- a/uSync.Migrations/Handlers/Shared/SharedHandlerBase.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedHandlerBase.cs
@@ -46,7 +46,7 @@ internal abstract class SharedHandlerBase<TObject> :MigrationHandlerBase<TObject
     /// <summary>
     ///  alias and key - v8 we have methods that get these values consitantly. 
     /// </summary>
-    protected override (string alias, Guid key) GetAliasAndKey(XElement source)
+    protected override (string alias, Guid key) GetAliasAndKey(XElement source, SyncMigrationContext context)
         => (alias: source.GetAlias(), key: source.GetKey());
 
     /// <summary>

--- a/uSync.Migrations/Handlers/Shared/SharedTemplateHandler.cs
+++ b/uSync.Migrations/Handlers/Shared/SharedTemplateHandler.cs
@@ -35,7 +35,7 @@ internal abstract class SharedTemplateHandler : SharedHandlerBase<Template>
 
     protected override void PrepareFile(XElement source, SyncMigrationContext context)
     {
-        var (alias, key) = GetAliasAndKey(source);
+        var (alias, key) = GetAliasAndKey(source, context);
         context.Templates.AddAliasKeyLookup(alias, key);
     }
 }

--- a/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/DocTypeGridEditorBlockMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/BlockMigrators/DocTypeGridEditorBlockMigrator.cs
@@ -82,7 +82,7 @@ internal class DocTypeGridEditorBlockMigrator : ISyncBlockMigrator
 	{
 		var propertyValues = new Dictionary<string, object>();
 
-		var contentTypeAlias = GetContentTypeAlias(control);
+		var contentTypeAlias = context.ContentTypes.GetReplacementAlias(GetContentTypeAlias(control));
 		if (string.IsNullOrWhiteSpace(contentTypeAlias)) return propertyValues;
 
 		var elementValue = control.Value?.Value<JObject>("value")?

--- a/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Extensions;
 
 using uSync.Migrations.Context;
-using uSync.Migrations.Logging;
 using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
 using uSync.Migrations.Migrators.BlockGrid.Extensions;
 using uSync.Migrations.Migrators.BlockGrid.Models;

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 
 using Newtonsoft.Json;
-
+using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Strings;
@@ -23,6 +23,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 	private readonly ILegacyGridConfig _gridConfig;
 	private readonly SyncBlockMigratorCollection _blockMigrators;
 	private readonly ILoggerFactory _loggerFactory;
+	private readonly IProfilingLogger _profilingLogger;
 	private readonly ILogger<GridToBlockGridMigrator> _logger;
 
 	private readonly GridConventions _conventions;
@@ -31,13 +32,15 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
         ILegacyGridConfig gridConfig,
         SyncBlockMigratorCollection blockMigrators,
         IShortStringHelper shortStringHelper,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IProfilingLogger profilingLogger)
     {
         _gridConfig = gridConfig;
         _blockMigrators = blockMigrators;
         _conventions = new GridConventions(shortStringHelper);
         _loggerFactory = loggerFactory;
-		_logger = loggerFactory.CreateLogger<GridToBlockGridMigrator>();	
+        _profilingLogger = profilingLogger;
+        _logger = loggerFactory.CreateLogger<GridToBlockGridMigrator>();	
     }
 
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
@@ -121,8 +124,11 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 			return string.Empty;
 		}
 
-		var helper = new GridToBlockContentHelper(_conventions, _blockMigrators,
-			_loggerFactory.CreateLogger<GridToBlockContentHelper>());
+		var helper = new GridToBlockContentHelper(
+			_conventions, 
+			_blockMigrators,
+			_loggerFactory.CreateLogger<GridToBlockContentHelper>(), 
+			_profilingLogger);
 		
 		var blockValue = helper.ConvertToBlockValue(source, context);
 		if (blockValue == null)

--- a/uSync.Migrations/Migrators/Core/MultiNodeTreePickerMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/MultiNodeTreePickerMigrator.cs
@@ -19,6 +19,12 @@ public class MultiNodeTreePickerMigrator : SyncPropertyMigratorBase
     {
         var config = new MultiNodePickerConfiguration();
 
+        var filter = dataTypeProperty.PreValues?.FirstOrDefault(pv => pv.Alias == "filter");
+        if (filter != null)
+        {
+            filter.Value = string.Join(",", filter.Value?.Split(",").Select(x => context.ContentTypes.GetReplacementAlias(x)) ?? Enumerable.Empty<string>());
+        }
+
         var mappings = new Dictionary<string, string>
         {
             { "filter", nameof(config.Filter) },

--- a/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
+++ b/uSync.Migrations/Migrators/Core/NestedContentMigrator.cs
@@ -29,6 +29,7 @@ public class NestedContentMigrator : SyncPropertyMigratorBase
 
         var contentTypeKeys = config.ContentTypes.Select(x => x.Alias)
             .WhereNotNull() // satisfy nullability requirement
+            .Select(context.ContentTypes.GetReplacementAlias)
             .Where(a => !string.IsNullOrWhiteSpace(a))
             .Select(context.ContentTypes.GetKeyByAlias);
 
@@ -54,7 +55,8 @@ public class NestedContentMigrator : SyncPropertyMigratorBase
 
             foreach (var property in row.RawPropertyValues)
             {
-                var editorAlias = context.ContentTypes.GetEditorAliasByTypeAndProperty(row.ContentTypeAlias, property.Key);
+                var contentTypeAlias = context.ContentTypes.GetReplacementAlias(row.ContentTypeAlias);
+                var editorAlias = context.ContentTypes.GetEditorAliasByTypeAndProperty(contentTypeAlias, property.Key);
                 if (editorAlias == null) continue;
 
                 try
@@ -65,7 +67,7 @@ public class NestedContentMigrator : SyncPropertyMigratorBase
                     {
                         row.RawPropertyValues[property.Key] = migrator.GetContentValue(
                             new SyncMigrationContentProperty(
-                                row.ContentTypeAlias, property.Key, row.ContentTypeAlias, property.Value?.ToString()),
+                                contentTypeAlias, property.Key, contentTypeAlias, property.Value?.ToString()),
                                 context);
                     }
                 }

--- a/uSync.Migrations/Services/SyncMigrationService.cs
+++ b/uSync.Migrations/Services/SyncMigrationService.cs
@@ -236,14 +236,18 @@ internal class SyncMigrationService : ISyncMigrationService
 
         AddMergers(context, options.MergingProperties);
 
+        
+        // add configurer for Archetype migrations
+        context.ContentTypes.ArchetypeMigrationConfigurer = _archetypeConfigures.FirstOrDefault(c => c.GetType() == options.ArchetypeMigrationConfigurer) ?? _archetypeConfigures.FirstOrDefault(c => c.GetType()== typeof(DefaultArchetypeMigrationConfigurer));
+
+        options.ReplacementAliases?
+            .ForEach(kvp => context.ContentTypes.AddReplacementAlias(kvp.Key, kvp.Value));
+
         // let the handlers run through their prep (populate all the lookups)
         GetHandlers(options.SourceVersion)?
             .OrderBy(x => x.Priority)
             .ToList()
             .ForEach(x => x.PrepareMigrations(context));
-
-        // add configurer for Archetype migrations
-        context.ContentTypes.ArchetypeMigrationConfigurer = _archetypeConfigures.FirstOrDefault(c => c.GetType() == options.ArchetypeMigrationConfigurer) ?? _archetypeConfigures.FirstOrDefault(c => c.GetType()== typeof(DefaultArchetypeMigrationConfigurer));
 
         return context;
     }

--- a/uSync.Migrations/Services/SyncMigrationStatusService.cs
+++ b/uSync.Migrations/Services/SyncMigrationStatusService.cs
@@ -198,6 +198,7 @@ internal class SyncMigrationStatusService : ISyncMigrationStatusService
             PreferredMigrators = defaultOptions.PreferredMigrators,
             PropertyMigrators = defaultOptions.PropertyMigrators,
             MergingProperties = defaultOptions.MergingProperties,
+            ReplacementAliases = defaultOptions.ReplacementAliases,
         };
     }
 }


### PR DESCRIPTION
Based on comments from #200.

I've taken over the work that @bielu started. We found some issues with his implementation - where the replacement aliases weren't being used in all places. This PR fixes those issues and addresses the feedback from #200.

I tried to cover any other places that content type aliases are referenced such as in MNTP config, but it's possible there are others I've missed. Hopefully this is a good enough starting point.