### PR TITLE
Feat/migrate block grid config

### DIFF
--- a/uSync.Migrations/Composing/SyncMigrationsComposer.cs
+++ b/uSync.Migrations/Composing/SyncMigrationsComposer.cs
@@ -14,6 +14,7 @@ using uSync.Migrations.Handlers;
 using uSync.Migrations.Legacy.Grid;
 using uSync.Migrations.Migrators;
 using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+using uSync.Migrations.Migrators.BlockGrid.Config;
 using uSync.Migrations.Migrators.BlockGrid.Extensions;
 using uSync.Migrations.Migrators.Community;
 using uSync.Migrations.Migrators.Community.Archetype;
@@ -58,6 +59,10 @@ public static class SyncMigrationsBuilderExtensions
         builder
             .WithCollectionBuilder<SyncBlockMigratorCollectionBuilder>()
                 .Add(() => builder.TypeLoader.GetTypes<ISyncBlockMigrator>());
+
+        builder
+            .WithCollectionBuilder<GridSettingsViewMigratorCollectionBuilder>()
+                .Add(() => builder.TypeLoader.GetTypes<IGridSettingsViewMigrator>());
 
         builder
             .WithCollectionBuilder<SyncPropertyMergingCollectionBuilder>()

--- a/uSync.Migrations/Composing/UmbracoBuilderExtensions.cs
+++ b/uSync.Migrations/Composing/UmbracoBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Umbraco.Cms.Core.DependencyInjection;
 
 using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
+using uSync.Migrations.Migrators.BlockGrid.Config;
 
 namespace uSync.Migrations.Composing;
 
@@ -14,4 +15,7 @@ public static class UmbracoBuilderExtensions
 
     public static SyncBlockMigratorCollectionBuilder SyncBlockMigrators(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<SyncBlockMigratorCollectionBuilder>();
+
+    public static GridSettingsViewMigratorCollectionBuilder GridSettingsMigrators(this IUmbracoBuilder builder)
+        => builder.WithCollectionBuilder<GridSettingsViewMigratorCollectionBuilder>();
 }

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigContext.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigContext.cs
@@ -16,7 +16,6 @@ namespace uSync.Migrations.Migrators.BlockGrid.Config;
 /// </remarks>
 internal class GridToBlockGridConfigContext
 {
-    public string GridDocTypeAlias { get; }
     public GridConfiguration GridConfiguration { get; }
     public ILegacyGridEditorsConfig GridEditorsConfig { get; }
     public int? GridColumns { get; }

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigContext.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigContext.cs
@@ -16,6 +16,7 @@ namespace uSync.Migrations.Migrators.BlockGrid.Config;
 /// </remarks>
 internal class GridToBlockGridConfigContext
 {
+    public string GridDocTypeAlias { get; }
     public GridConfiguration GridConfiguration { get; }
     public ILegacyGridEditorsConfig GridEditorsConfig { get; }
     public int? GridColumns { get; }

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutBlockHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutBlockHelper.cs
@@ -10,6 +10,7 @@ using uSync.Migrations.Context;
 using uSync.Migrations.Migrators.BlockGrid.Extensions;
 using uSync.Migrations.Migrators.BlockGrid.Models;
 using uSync.Migrations.Models;
+using static Umbraco.Cms.Core.PropertyEditors.ListViewConfiguration;
 
 namespace uSync.Migrations.Migrators.BlockGrid.Config;
 
@@ -27,13 +28,13 @@ internal class GridToBlockGridConfigLayoutBlockHelper
         _logger = logger;
     }
 
-    public void AddLayoutBlocks(GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context)
+    public void AddLayoutBlocks(GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context, string dataTypeAlias)
     {
         // gather all the layout blocks we can from the templates 
         // and layouts sections of the config. 
         GetTemplateLayouts(gridBlockContext.GridConfiguration.GetItemBlock("templates"), gridBlockContext, context);
 
-        GetLayoutLayouts(gridBlockContext.GridConfiguration.GetItemBlock("layouts"), gridBlockContext, context);
+        GetLayoutLayouts(gridBlockContext.GridConfiguration.GetItemBlock("layouts"), gridBlockContext, context, dataTypeAlias);
 
         AddContentTypesForLayoutBlocks(gridBlockContext, context);
     }
@@ -137,7 +138,7 @@ internal class GridToBlockGridConfigLayoutBlockHelper
         }
     }
 
-    private void GetLayoutLayouts(JToken? layouts, GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context)
+    private void GetLayoutLayouts(JToken? layouts, GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context, string dataTypeAlias)
     {
         if (layouts == null) return;
 
@@ -189,12 +190,14 @@ internal class GridToBlockGridConfigLayoutBlockHelper
             if (rowAreas.Count == 0) continue;
 
             var contentTypeAlias = _conventions.LayoutContentTypeAlias(layout.Name);
+            var settingsContentTypeAlias = _conventions.LayoutSettingsContentTypeAlias(dataTypeAlias);
 
             var layoutBlock = new BlockGridConfiguration.BlockGridBlockConfiguration
             {
                 Label = layout?.Name,
                 Areas = rowAreas.ToArray(),
                 ContentElementTypeKey = context.GetContentTypeKeyOrDefault(contentTypeAlias, contentTypeAlias.ToGuid()),
+                SettingsElementTypeKey = context.GetContentTypeKeyOrDefault(settingsContentTypeAlias, settingsContentTypeAlias.ToGuid()),
                 GroupKey = gridBlockContext.LayoutsGroup.Key.ToString(),
 				BackgroundColor = Grid.LayoutBlocks.Background,
 				IconColor = Grid.LayoutBlocks.Icon,
@@ -262,8 +265,4 @@ internal class GridToBlockGridConfigLayoutBlockHelper
             context.ContentTypes.AddElementType(block.ContentElementTypeKey);
         }
     }
-
-
-
-
 }

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutBlockHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutBlockHelper.cs
@@ -10,7 +10,6 @@ using uSync.Migrations.Context;
 using uSync.Migrations.Migrators.BlockGrid.Extensions;
 using uSync.Migrations.Migrators.BlockGrid.Models;
 using uSync.Migrations.Models;
-using static Umbraco.Cms.Core.PropertyEditors.ListViewConfiguration;
 
 namespace uSync.Migrations.Migrators.BlockGrid.Config;
 

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutSettingsHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutSettingsHelper.cs
@@ -32,7 +32,7 @@ namespace uSync.Migrations.Migrators.BlockGrid.Config
             var gridStyles = GetGridSettingsFromConfig(gridBlockContext.GridConfiguration?.GetItemBlock("styles"));
 
             // Take only the settings that have applyTo = row. Other value here could be cell.
-            var gridSettings = gridConfig.Concat(gridStyles).Where(s => s.ApplyTo == "row");
+            var gridSettings = gridConfig.Concat(gridStyles).Where(s => s.ApplyTo != "cell");
 
             AddGridLayoutSettings(gridSettings, gridBlockContext, context, gridAlias);
         }
@@ -58,14 +58,6 @@ namespace uSync.Migrations.Migrators.BlockGrid.Config
                 var dataTypeAlias = gridSettingPropertyMigrator is not null
                                     ? gridSettingPropertyMigrator.NewDataTypeAlias
                                     : configItem.View;
-/*
-                var dataTypeName
-
-                context.DataTypes.AddDefinition(dataTypeAlias.ToGuid(), new DataTypeInfo(
-                    editorAlias: dataTypeAlias,
-                    originalEditorAlias: dataTypeAlias,
-                    dataTypeName))*/
-
 
                 return new NewContentTypeProperty()
                 {

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutSettingsHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutSettingsHelper.cs
@@ -11,11 +11,18 @@ namespace uSync.Migrations.Migrators.BlockGrid.Config
     internal class GridToBlockGridConfigLayoutSettingsHelper
     {
         private readonly GridConventions _conventions;
+        private readonly GridSettingsViewMigratorCollection _gridSettingsViewMigrators;
+        private readonly ILogger<GridToBlockGridConfigLayoutSettingsHelper> _logger;
 
-        public GridToBlockGridConfigLayoutSettingsHelper(GridConventions conventions,
-            ILogger<GridToBlockGridConfigLayoutBlockHelper> logger)
+
+        public GridToBlockGridConfigLayoutSettingsHelper(
+            GridConventions conventions,
+            GridSettingsViewMigratorCollection gridSettingsViewMigrators,
+            ILogger<GridToBlockGridConfigLayoutSettingsHelper> logger)
         {
             _conventions = conventions;
+            _gridSettingsViewMigrators = gridSettingsViewMigrators;
+            _logger = logger;
         }
 
         public void AddGridSettings(GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context, string gridAlias)
@@ -46,11 +53,25 @@ namespace uSync.Migrations.Migrators.BlockGrid.Config
             {
                 var contentTypeAlias = configItem.Key!;
 
+                var gridSettingPropertyMigrator = _gridSettingsViewMigrators.GetMigrator(configItem.View);
+                
+                var dataTypeAlias = gridSettingPropertyMigrator is not null
+                                    ? gridSettingPropertyMigrator.NewDataTypeAlias
+                                    : configItem.View;
+/*
+                var dataTypeName
+
+                context.DataTypes.AddDefinition(dataTypeAlias.ToGuid(), new DataTypeInfo(
+                    editorAlias: dataTypeAlias,
+                    originalEditorAlias: dataTypeAlias,
+                    dataTypeName))*/
+
+
                 return new NewContentTypeProperty()
                 {
                     Name = configItem.Label ?? contentTypeAlias,
                     Alias = contentTypeAlias,
-                    DataTypeAlias = configItem?.View,
+                    DataTypeAlias = dataTypeAlias,
                 };
             });
 

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutSettingsHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutSettingsHelper.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using Umbraco.Extensions;
+using uSync.Migrations.Context;
+using uSync.Migrations.Migrators.BlockGrid.Extensions;
+using uSync.Migrations.Migrators.BlockGrid.Models;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Config
+{
+    internal class GridToBlockGridConfigLayoutSettingsHelper
+    {
+        private readonly GridConventions _conventions;
+
+        public GridToBlockGridConfigLayoutSettingsHelper(GridConventions conventions,
+            ILogger<GridToBlockGridConfigLayoutBlockHelper> logger)
+        {
+            _conventions = conventions;
+        }
+
+        public void AddGridSettings(GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context, string gridAlias)
+        {
+            AddGridConfig(gridBlockContext.GridConfiguration.GetItemBlock("config"), gridBlockContext, context, gridAlias);
+        }
+
+        private void AddGridConfig(JToken? config, GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context, string gridAlias)
+        {
+            if (config == null) return;
+
+            var gridLayoutConfigurations = config
+                .ToObject<IEnumerable<GridConfigConfigurationItem>>() ?? Enumerable.Empty<GridConfigConfigurationItem>();
+
+            var contentTypeProperties = gridLayoutConfigurations.Select(configItem =>
+            {
+                var contentType = configItem.Key;
+
+                return new NewContentTypeProperty()
+                {
+                    Name = configItem.Label,
+                    Alias = configItem.Key,
+                    DataTypeAlias = configItem.View,
+                };
+            });
+
+            var alias = _conventions.LayoutSettingsContentTypeAlias(gridAlias);
+
+            context.ContentTypes.AddNewContentType(new NewContentTypeInfo
+            {
+                Name = alias,
+                Alias = alias,
+                Key = alias.ToGuid(),
+                Description = alias,
+                Icon = "icon-book color-red",
+                IsElement = true,
+                Folder = "BlockGrid/Settings",
+                Properties = contentTypeProperties.ToList()
+            });
+
+            
+
+/*            context.
+*/            /*            context.ContentTypes.AddNewContentType(new NewContentTypeInfo
+                        {
+                            Key = contentTypeAlias.ToGuid(),
+                            Alias = contentTypeAlias,
+                            Name = configItem.Label ?? contentTypeAlias,
+                            Description = "Grid Settings",
+                            Folder = "BlockGrid/Settings",
+                            Icon = "icon-cog color-purple",
+                            IsElement = true
+                        });*/
+        }
+
+        private void AddGridStyles(JToken? config, GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/uSync.Migrations/Migrators/BlockGrid/Config/IGridSettingsViewMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/IGridSettingsViewMigrator.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Extensions;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Config
+{
+    public interface IGridSettingsViewMigrator : IDiscoverable
+    {
+        string ViewKey { get; }
+        string NewDataTypeAlias { get; }
+    }
+
+    public class GridSettingsViewMigratorCollectionBuilder
+        : LazyCollectionBuilderBase<GridSettingsViewMigratorCollectionBuilder, GridSettingsViewMigratorCollection, IGridSettingsViewMigrator>
+    {
+        protected override GridSettingsViewMigratorCollectionBuilder This => this;
+    }
+
+    public class GridSettingsViewMigratorCollection
+        : BuilderCollectionBase<IGridSettingsViewMigrator>
+    {
+        public GridSettingsViewMigratorCollection(Func<IEnumerable<IGridSettingsViewMigrator>> items) : base(items)
+        {}
+
+        public IGridSettingsViewMigrator? GetMigrator(string? viewKey)
+        {
+            if (viewKey == null) return null;
+            return this.FirstOrDefault(x => x.ViewKey.InvariantEquals(viewKey));
+        }
+    }
+}

--- a/uSync.Migrations/Migrators/BlockGrid/Config/IGridSettingsViewMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/IGridSettingsViewMigrator.cs
@@ -13,6 +13,7 @@ namespace uSync.Migrations.Migrators.BlockGrid.Config
     {
         string ViewKey { get; }
         string NewDataTypeAlias { get; }
+        public object ConvertContentString(string value);
     }
 
     public class GridSettingsViewMigratorCollectionBuilder

--- a/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -317,6 +317,11 @@ internal class GridToBlockContentHelper
 
     private BlockItemData? GetSettingsBlockItemDataFromRow(GridValue.GridRow row, SyncMigrationContext context, string dataTypeAlias)
     {
+        if (dataTypeAlias.IsNullOrWhiteSpace())
+        {
+            return null;
+        }
+
         var settingsValues = new Dictionary<string, object?>();
 
         var rowLayoutSettingsContentTypeAlias = _conventions.LayoutSettingsContentTypeAlias(dataTypeAlias);
@@ -326,7 +331,6 @@ internal class GridToBlockContentHelper
         {
             foreach (JProperty config in row.Config)
             {
-                var test = _conventions.FormatGridSettingKey(config.Name);
                 settingsValues.Add(_conventions.FormatGridSettingKey(config.Name), config.Value);
             }
         }

--- a/uSync.Migrations/Migrators/BlockGrid/Extensions/GridConventions.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Extensions/GridConventions.cs
@@ -45,6 +45,9 @@ internal class GridConventions
             return splitString[0];
         }
 
-        return string.Join("", splitString.First().ToLower(), string.Join("", splitString.Skip(1).Select(s => s.ToFirstUpper()))).ToString();
+        return string.Join("", 
+            splitString.First().ToLower(), 
+            string.Join("", splitString.Skip(1).Select(s => s.ToFirstUpper())))
+            .ToString();
     }
 }

--- a/uSync.Migrations/Migrators/BlockGrid/Extensions/GridConventions.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Extensions/GridConventions.cs
@@ -31,4 +31,7 @@ internal class GridConventions
 
     public string LayoutContentTypeAlias(string layout)
         => layout.GetBlockGridLayoutContentTypeAlias(ShortStringHelper);
+
+    public string LayoutSettingsContentTypeAlias(string layout)
+        => layout.GetBlockGridLayoutSettingsContentTypeAlias(ShortStringHelper);
 }

--- a/uSync.Migrations/Migrators/BlockGrid/Extensions/GridConventions.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Extensions/GridConventions.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Strings;
+﻿using System.Text.Json;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
 
 namespace uSync.Migrations.Migrators.BlockGrid.Extensions;
 
@@ -34,4 +36,15 @@ internal class GridConventions
 
     public string LayoutSettingsContentTypeAlias(string layout)
         => layout.GetBlockGridLayoutSettingsContentTypeAlias(ShortStringHelper);
+
+    public string FormatGridSettingKey(string setting)
+    {
+        var splitString = setting.Split("-");
+        if (splitString.Length == 1)
+        {
+            return splitString[0];
+        }
+
+        return string.Join("", splitString.First().ToLower(), string.Join("", splitString.Skip(1).Select(s => s.ToFirstUpper()))).ToString();
+    }
 }

--- a/uSync.Migrations/Migrators/BlockGrid/Extensions/GridToBlockGridNameExtensions.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Extensions/GridToBlockGridNameExtensions.cs
@@ -21,6 +21,9 @@ internal static class GridToBlockGridNameExtensions
     public static string GetBlockGridLayoutContentTypeAlias(this string name, IShortStringHelper shortStringHelper)
         => name.GetContentTypeAlias("BlockGridLayout_", shortStringHelper);
 
+    public static string GetBlockGridLayoutSettingsContentTypeAlias(this string name, IShortStringHelper shortStringHelper)
+        => name.GetContentTypeAlias("BlockGridLayoutSettings_", shortStringHelper);
+
     public static string GetBlockGridAreaConfigurationAlias(this string name, IShortStringHelper shortStringHelper)
         => name.GetContentTypeAlias("BlockGridArea_", shortStringHelper);
 
@@ -37,6 +40,4 @@ internal static class GridToBlockGridNameExtensions
         context.Content.AddKey(defaultKey, alias);
         return defaultKey;
     }
-
-
 }

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -84,10 +84,10 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
         var layoutSettingsBlockHelper = new GridToBlockGridConfigLayoutSettingsHelper(_conventions, _loggerFactory.CreateLogger<GridToBlockGridConfigLayoutBlockHelper>());
 
         // adds content types for the core elements (headline, rte, etc)
-        contentBlockHelper.AddConfigDataTypes(gridToBlockContext, context);
+		contentBlockHelper.AddConfigDataTypes(gridToBlockContext, context);
 		
 		// Add settings
-        layoutSettingsBlockHelper.AddGridSettings(gridToBlockContext, context, dataTypeProperty.DataTypeAlias);
+		layoutSettingsBlockHelper.AddGridSettings(gridToBlockContext, context, dataTypeProperty.DataTypeAlias);
 
 		// prep the layouts 
 		layoutBlockHelper.AddLayoutBlocks(gridToBlockContext, context, dataTypeProperty.DataTypeAlias);

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -41,8 +41,13 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
         _blockMigrators = blockMigrators;
         _conventions = new GridConventions(shortStringHelper);
         _loggerFactory = loggerFactory;
+<<<<<<< HEAD
         _profilingLogger = profilingLogger;
         _logger = loggerFactory.CreateLogger<GridToBlockGridMigrator>();	
+=======
+        _logger = loggerFactory.CreateLogger<GridToBlockGridMigrator>();
+        _profilingLogger = profilingLogger;
+>>>>>>> 8b68bbf (Namespace fixes.)
     }
 
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
@@ -151,11 +156,16 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 			}
 		}
 
+<<<<<<< HEAD
 		var helper = new GridToBlockContentHelper(
 			_conventions, 
 			_blockMigrators,
 			_loggerFactory.CreateLogger<GridToBlockContentHelper>(), 
 			_profilingLogger);
+=======
+		var helper = new GridToBlockContentHelper(_conventions, _blockMigrators,
+			_loggerFactory.CreateLogger<GridToBlockContentHelper>(), _profilingLogger);
+>>>>>>> 9a47735 (Namespace fixes.)
 		
 		var blockValue = helper.ConvertToBlockValue(source, context);
 		if (blockValue == null)

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -2,11 +2,11 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Strings;
+
 using uSync.Migrations.Context;
 using uSync.Migrations.Legacy.Grid;
 using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
@@ -24,8 +24,8 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 	private readonly ILegacyGridConfig _gridConfig;
 	private readonly SyncBlockMigratorCollection _blockMigrators;
 	private readonly ILoggerFactory _loggerFactory;
-	private readonly IProfilingLogger _profilingLogger;
-	private readonly ILogger<GridToBlockGridMigrator> _logger;
+    private readonly ILogger<GridToBlockGridMigrator> _logger;
+    private readonly IProfilingLogger _profilingLogger;
 	private readonly GridConventions _conventions;
 
     public GridToBlockGridMigrator(

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -83,7 +83,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 		var layoutBlockHelper = new GridToBlockGridConfigLayoutBlockHelper(_conventions, _loggerFactory.CreateLogger<GridToBlockGridConfigLayoutBlockHelper>());
         var layoutSettingsBlockHelper = new GridToBlockGridConfigLayoutSettingsHelper(_conventions, _loggerFactory.CreateLogger<GridToBlockGridConfigLayoutBlockHelper>());
 
-        // adds content types for the core elements (headline, rte, etc)
+		// adds content types for the core elements (headline, rte, etc)
 		contentBlockHelper.AddConfigDataTypes(gridToBlockContext, context);
 		
 		// Add settings

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -23,6 +23,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 {
 	private readonly ILegacyGridConfig _gridConfig;
 	private readonly SyncBlockMigratorCollection _blockMigrators;
+	private readonly GridSettingsViewMigratorCollection _gridSettingsMigrators;
 	private readonly ILoggerFactory _loggerFactory;
 	private readonly ILogger<GridToBlockGridMigrator> _logger;
 	private readonly IProfilingLogger _profilingLogger;
@@ -31,12 +32,14 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
     public GridToBlockGridMigrator(
         ILegacyGridConfig gridConfig,
         SyncBlockMigratorCollection blockMigrators,
+		GridSettingsViewMigratorCollection gridSettingsMigrators,
         IShortStringHelper shortStringHelper,
         ILoggerFactory loggerFactory,
         IProfilingLogger profilingLogger)
     {
         _gridConfig = gridConfig;
         _blockMigrators = blockMigrators;
+		_gridSettingsMigrators = gridSettingsMigrators;
         _conventions = new GridConventions(shortStringHelper);
         _loggerFactory = loggerFactory;
         _profilingLogger = profilingLogger;
@@ -74,7 +77,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 
 		var contentBlockHelper = new GridToBlockGridConfigBlockHelper(_blockMigrators, _loggerFactory.CreateLogger<GridToBlockGridConfigBlockHelper>());
 		var layoutBlockHelper = new GridToBlockGridConfigLayoutBlockHelper(_conventions, _loggerFactory.CreateLogger<GridToBlockGridConfigLayoutBlockHelper>());
-        var layoutSettingsBlockHelper = new GridToBlockGridConfigLayoutSettingsHelper(_conventions, _loggerFactory.CreateLogger<GridToBlockGridConfigLayoutBlockHelper>());
+        var layoutSettingsBlockHelper = new GridToBlockGridConfigLayoutSettingsHelper(_conventions, _gridSettingsMigrators, _loggerFactory.CreateLogger<GridToBlockGridConfigLayoutSettingsHelper>());
 
 		// adds content types for the core elements (headline, rte, etc)
 		contentBlockHelper.AddConfigDataTypes(gridToBlockContext, context);

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -95,8 +95,6 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 		// Add the content blocks
 		contentBlockHelper.AddContentBlocks(gridToBlockContext, context);
 
-		// Add the grid config and styles
-
 		// Get resultant configuration
 		var result = gridToBlockContext.ConvertToBlockGridConfiguration();
 

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -1,12 +1,10 @@
 ﻿using Microsoft.Extensions.Logging;
-
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Strings;
-
 using uSync.Migrations.Context;
 using uSync.Migrations.Legacy.Grid;
 using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
@@ -75,15 +73,21 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 
 		var contentBlockHelper = new GridToBlockGridConfigBlockHelper(_blockMigrators, _loggerFactory.CreateLogger<GridToBlockGridConfigBlockHelper>());
 		var layoutBlockHelper = new GridToBlockGridConfigLayoutBlockHelper(_conventions, _loggerFactory.CreateLogger<GridToBlockGridConfigLayoutBlockHelper>());
+        var layoutSettingsBlockHelper = new GridToBlockGridConfigLayoutSettingsHelper(_conventions, _loggerFactory.CreateLogger<GridToBlockGridConfigLayoutBlockHelper>());
 
-		// adds content types for the core elements (headline, rte, etc)
-		contentBlockHelper.AddConfigDataTypes(gridToBlockContext, context);
+        // adds content types for the core elements (headline, rte, etc)
+        contentBlockHelper.AddConfigDataTypes(gridToBlockContext, context);
+		
+		// Add settings
+        layoutSettingsBlockHelper.AddGridSettings(gridToBlockContext, context, dataTypeProperty.DataTypeAlias);
 
 		// prep the layouts 
-		layoutBlockHelper.AddLayoutBlocks(gridToBlockContext, context);
+		layoutBlockHelper.AddLayoutBlocks(gridToBlockContext, context, dataTypeProperty.DataTypeAlias);
 
 		// Add the content blocks
 		contentBlockHelper.AddContentBlocks(gridToBlockContext, context);
+
+		// Add the grid config and styles
 
 		// Get resultant configuration
 		var result = gridToBlockContext.ConvertToBlockGridConfiguration();

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -26,8 +26,6 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 	private readonly ILoggerFactory _loggerFactory;
 	private readonly IProfilingLogger _profilingLogger;
 	private readonly ILogger<GridToBlockGridMigrator> _logger;
-	private readonly IProfilingLogger _profilingLogger;
-
 	private readonly GridConventions _conventions;
 
     public GridToBlockGridMigrator(
@@ -41,13 +39,8 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
         _blockMigrators = blockMigrators;
         _conventions = new GridConventions(shortStringHelper);
         _loggerFactory = loggerFactory;
-<<<<<<< HEAD
         _profilingLogger = profilingLogger;
         _logger = loggerFactory.CreateLogger<GridToBlockGridMigrator>();	
-=======
-        _logger = loggerFactory.CreateLogger<GridToBlockGridMigrator>();
-        _profilingLogger = profilingLogger;
->>>>>>> 8b68bbf (Namespace fixes.)
     }
 
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
@@ -154,16 +147,11 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 			}
 		}
 
-<<<<<<< HEAD
 		var helper = new GridToBlockContentHelper(
 			_conventions, 
 			_blockMigrators,
 			_loggerFactory.CreateLogger<GridToBlockContentHelper>(), 
 			_profilingLogger);
-=======
-		var helper = new GridToBlockContentHelper(_conventions, _blockMigrators,
-			_loggerFactory.CreateLogger<GridToBlockContentHelper>(), _profilingLogger);
->>>>>>> 9a47735 (Namespace fixes.)
 		
 		var blockValue = helper.ConvertToBlockValue(source, context);
 		if (blockValue == null)

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -125,17 +125,15 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 			.Select(propertyType => propertyType.DataTypeId)
 			.FirstOrDefault();
 
-		/*		var test2 = _dataTypeService.GetDataType();
-		*/
-		//var test3 = _contentTypeService.Get		
-
-		/*		var all_grids = _dataTypeService.GetByEditorAlias(contentProperty.EditorAlias).Where(dataType => test?.Contains(dataType.Key) == true);
-		*/
 		var dataTypeAlias = "";
 		if (gridDataTypeId is not null)
 		{
 			dataTypeAlias = _dataTypeService.GetDataType((int)gridDataTypeId)?.Name;
         }
+		else
+		{
+			_logger.LogWarning("  Data type for grid could not be found when converting {alias}. Migration will run, but layout setting will not be migrated.", contentProperty.EditorAlias);
+		}
 
         if (string.IsNullOrWhiteSpace(contentProperty.Value))
 		{

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -24,8 +24,8 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 	private readonly ILegacyGridConfig _gridConfig;
 	private readonly SyncBlockMigratorCollection _blockMigrators;
 	private readonly ILoggerFactory _loggerFactory;
-    private readonly ILogger<GridToBlockGridMigrator> _logger;
-    private readonly IProfilingLogger _profilingLogger;
+	private readonly ILogger<GridToBlockGridMigrator> _logger;
+	private readonly IProfilingLogger _profilingLogger;
 	private readonly GridConventions _conventions;
 
     public GridToBlockGridMigrator(

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.Logging;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -22,6 +24,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 	private readonly ILegacyGridConfig _gridConfig;
 	private readonly SyncBlockMigratorCollection _blockMigrators;
 	private readonly ILoggerFactory _loggerFactory;
+	private readonly IProfilingLogger _profilingLogger;
 	private readonly ILogger<GridToBlockGridMigrator> _logger;
 	private readonly IProfilingLogger _profilingLogger;
 

--- a/uSync.Migrations/Migrators/BlockGrid/Models/GridModels.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Models/GridModels.cs
@@ -66,12 +66,12 @@ internal class GridAreaConfiguration
     public string[]? Allowed { get; set; }
 }
 
-internal class GridConfigConfiguration
+internal class GridSettingsConfiguration
 {
-    GridConfigConfigurationItem[]? ConfigItems { get; set; }
+    GridSettingsConfigurationItem[]? ConfigItems { get; set; }
 }
 
-internal class GridConfigConfigurationItem
+internal class GridSettingsConfigurationItem
 {
     [JsonProperty("label")]
     public string? Label { get; set; }
@@ -84,6 +84,12 @@ internal class GridConfigConfigurationItem
 
     [JsonProperty("view")]
     public string? View { get; set; }
+
+    [JsonProperty("modifier")]
+    public string? Modifier { get; set; }
+
+    [JsonProperty("applyTo")]
+    public string? ApplyTo { get; set; }
 }
 
 /// <summary>

--- a/uSync.Migrations/Migrators/BlockGrid/Models/GridModels.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Models/GridModels.cs
@@ -66,6 +66,26 @@ internal class GridAreaConfiguration
     public string[]? Allowed { get; set; }
 }
 
+internal class GridConfigConfiguration
+{
+    GridConfigConfigurationItem[]? ConfigItems { get; set; }
+}
+
+internal class GridConfigConfigurationItem
+{
+    [JsonProperty("label")]
+    public string? Label { get; set; }
+
+    [JsonProperty("description")]
+    public string? Description { get; set; }
+
+    [JsonProperty("key")]
+    public string? Key { get; set; }
+
+    [JsonProperty("view")]
+    public string? View { get; set; }
+}
+
 /// <summary>
 ///  contains the data for a block (content and settings)
 /// </summary>

--- a/uSync.Migrations/Migrators/BlockGrid/ViewPropertyMigrators/GridViewPropertyBooleanMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/ViewPropertyMigrators/GridViewPropertyBooleanMigrator.cs
@@ -14,20 +14,9 @@ namespace uSync.Migrations.Migrators.BlockGrid.ViewPropertyMigrators
 
         public string NewDataTypeAlias => "True/false";
 
-
-        /*        public NewContentTypeProperty GetContentTypeProperty()
-                {
-                    return new NewContentTypeProperty
-                    {
-                        Name = "",
-                        Alias = "GridSettingProperty_Boolean",
-                        DataTypeAlias = "True/false"
-                    };
-                }
-
-                public object GetPropertyValue(string value)
-                {
-
-                }*/
+        public object ConvertContentString(string value)
+        {
+            return value;
+        }
     }
 }

--- a/uSync.Migrations/Migrators/BlockGrid/ViewPropertyMigrators/GridViewPropertyBooleanMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/ViewPropertyMigrators/GridViewPropertyBooleanMigrator.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using uSync.Migrations.Migrators.BlockGrid.Config;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.ViewPropertyMigrators
+{
+    public class GridViewPropertyBooleanMigrator : IGridSettingsViewMigrator
+    {
+        public string ViewKey => "Boolean";
+
+        public string NewDataTypeAlias => "True/false";
+
+
+        /*        public NewContentTypeProperty GetContentTypeProperty()
+                {
+                    return new NewContentTypeProperty
+                    {
+                        Name = "",
+                        Alias = "GridSettingProperty_Boolean",
+                        DataTypeAlias = "True/false"
+                    };
+                }
+
+                public object GetPropertyValue(string value)
+                {
+
+                }*/
+    }
+}


### PR DESCRIPTION
Adds in some rough functionality to convert config and styles from the legacy grid to the BlockGrid & acts as a start for settings conversion. This implementation only handles the config/styles in the Layout layer (row) but perhaps similar implementations can be adopted for other layers.

It does this by:

Content Types

1. Reading config/styles & merging them (they have the same JSON data structure, afaik these are split up in the legacy grid for permissions based settings).
2. Create datatypes called BlockGridSettings_<NameOfGrid> for each grid.
3. Add the above block grid settings to each of the layouts for that grid. (It is safe to assume that all the layouts can have these as that is the behaviour of the legacy grid).

**Nothing is done with modifier & prevalues as this is out of scope for me personally, but should definitely be included in a future update**

Content
Converts content by simply porting the string over or using a process defined by anything that implements `IGridSettingsMigrator`. This is tied to each "datatype" (view) using the ViewKey property. The process for the conversion is defined in `ConvertContentString`. I would have liked to make this more customisable, but this seems to do the job for now. The `NewDataTypeAlias` should already be created in Umbraco but perhaps a way to do this automatically based off of a description in the `IGridSettingsMigrator` could be done to make this more programmatic?
The setting "content" migrator does hook into `IContentTypeService` & `IDataTypeService` which isn't great as that means it relies on the old data being present to work and goes against the idea of being able to go from old usync config -> new , on a fresh umbraco site/database.


Note:
One thing I would have liked to not do is pass the dataTypeProperty.DataTypeAlias around (specifically to layoutSettingsBlockHelper.AddGridSettings() & layoutBlockHelper.AddLayoutBlocks() ). I was considering putting in into a context but then realised that probbaly wouldnt work and/or be messier as that would involve just passing it to there and storing it there, which is probably an equally as bad solution. I'm more than happy for alternatives to this.

Some more default GridViewPropertyMigrators will be needed (they may need more customisable interfaces?) for the following:

radiobuttonlist
mediapicker
imagepicker
booleantreepicker
treesource
multivalues