### PR TITLE
Make v7 node ID accessible in SyncMigrationContext._idKeyMap

### DIFF
--- a/uSync.Migrations/Context/SyncMigrationContext.cs
+++ b/uSync.Migrations/Context/SyncMigrationContext.cs
@@ -76,6 +76,14 @@ public class SyncMigrationContext : IDisposable
     /// </summary>
     public Guid GetKey(int id)
         => _idKeyMap?.TryGetValue(id, out var key) == true ? key : Guid.Empty;
+
+		/// <summary>
+		/// Retrieves the `int` ID reference (from the v7 CMS) from the `Guid` key.
+		/// </summary>
+		/// <param name="key"></param>
+		/// <returns></returns>
+		public int GetId(Guid key)
+				=> _idKeyMap?.FirstOrDefault(x => x.Value == key).Key ?? 0;
    
     public void Dispose()
     { }


### PR DESCRIPTION
While doing our migration we wanted to be able to assign the v7 Umbraco numeric node ID to a property on some documents, but I couldn't figure out an easy way to do that. This change allows the ID to be obtained from the _idKeyMap by passing in the node Key.