### PR TITLE
feat: block grid settings

### DIFF
--- a/uSync.Migrations/Migrators/BlockGrid/Composition/BlockGridMigratorComposer.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Composition/BlockGridMigratorComposer.cs
@@ -1,0 +1,16 @@
+﻿using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using uSync.Migrations.Composing;
+using uSync.Migrations.Migrators.BlockGrid.SettingsMigrator;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Composition;
+[ComposeAfter(typeof(SyncMigrationsComposer))]
+public class BlockGridMigratorComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder
+            .WithCollectionBuilder<GridSettingsViewMigratorCollectionBuilder>()
+            .Add(() => builder.TypeLoader.GetTypes<IGridSettingsViewMigrator>());
+    }
+}

--- a/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutSettingsHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutSettingsHelper.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using Umbraco.Extensions;
+using uSync.Migrations.Context;
+using uSync.Migrations.Migrators.BlockGrid.Extensions;
+using uSync.Migrations.Migrators.BlockGrid.Models;
+using uSync.Migrations.Migrators.BlockGrid.SettingsMigrator;
+using uSync.Migrations.Models;
+
+namespace uSync.Migrations.Migrators.BlockGrid.Config;
+
+ internal class GridToBlockGridConfigLayoutSettingsHelper
+    {
+        private readonly GridConventions _conventions;
+        private readonly GridSettingsViewMigratorCollection _gridSettingsViewMigrators;
+        private readonly ILogger<GridToBlockGridConfigLayoutSettingsHelper> _logger;
+
+
+        public GridToBlockGridConfigLayoutSettingsHelper(
+            GridConventions conventions,
+            GridSettingsViewMigratorCollection gridSettingsViewMigrators,
+            ILogger<GridToBlockGridConfigLayoutSettingsHelper> logger)
+        {
+            _conventions = conventions;
+            _gridSettingsViewMigrators = gridSettingsViewMigrators;
+            _logger = logger;
+        }
+
+        public void AddGridSettings(GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context, string gridAlias)
+        {
+            var gridConfig = GetGridSettingsFromConfig(gridBlockContext.GridConfiguration?.GetItemBlock("config"));
+
+            var gridStyles = GetGridSettingsFromConfig(gridBlockContext.GridConfiguration?.GetItemBlock("styles"));
+
+            // Take only the settings that have applyTo = row. Other value here could be cell.
+            // TODO: Implement cell settings converter.
+            var gridSettings = gridConfig.Concat(gridStyles).Where(s => s.ApplyTo != "cell");
+
+            AddGridLayoutSettings(gridSettings, gridBlockContext, context, gridAlias);
+        }
+
+        private IEnumerable<GridSettingsConfigurationItem> GetGridSettingsFromConfig(JToken? config)
+        {
+            if (config == null)
+            {
+                return Enumerable.Empty<GridSettingsConfigurationItem>();
+            }
+
+            return config.ToObject<IEnumerable<GridSettingsConfigurationItem>>() ?? Enumerable.Empty<GridSettingsConfigurationItem>();
+        }
+
+        private void AddGridLayoutSettings(IEnumerable<GridSettingsConfigurationItem> gridLayoutConfigurations, GridToBlockGridConfigContext gridBlockContext, SyncMigrationContext context, string gridAlias)
+        {
+            var contentTypeProperties = gridLayoutConfigurations.Where(configItem => configItem.Key is not null).Select(configItem =>
+            {
+                var contentTypeAlias = configItem.Key;
+                if (contentTypeAlias.IsNullOrWhiteSpace() == true)
+                {
+                    _logger.LogError("No key defined for grid layout configuration in {alias}", gridAlias);
+                    return null;
+                }
+                var gridSettingPropertyMigrator = _gridSettingsViewMigrators.GetMigrator(configItem.View);
+                var dataTypeAlias = gridSettingPropertyMigrator is not null && !gridSettingPropertyMigrator.NewDataTypeAlias.IsNullOrWhiteSpace()
+                                    ? gridSettingPropertyMigrator.NewDataTypeAlias
+                                    : configItem.View;
+                if (dataTypeAlias.IsNullOrWhiteSpace() == true)
+                {
+                    _logger.LogError("No view defined for grid layout configuration in {alias}", gridAlias);
+                    return null;
+                }
+                return new NewContentTypeProperty(configItem.Label ?? contentTypeAlias,contentTypeAlias, dataTypeAlias);
+            }).WhereNotNull();
+
+            var alias = _conventions.LayoutSettingsContentTypeAlias(gridAlias);
+
+            context.ContentTypes.AddNewContentType(new NewContentTypeInfo(alias.ToGuid(),alias,alias,"icon-book color-red", "BlockGrid/settings")
+            {
+                Description = alias,
+                IsElement = true,
+                Properties = contentTypeProperties.ToList()
+            });
+        }
+    }

--- a/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -151,7 +151,7 @@ internal class GridToBlockContentHelper
                 {
                     block.SettingsData.Add(rowContentAndSettings.Settings);
                 }
-                blockLayouts.Add(GetGridRowBlockLayout(rowContentAndSettings.Content, rowLayoutAreas, rowColumns));
+                blockLayouts.Add(GetGridRowBlockLayout(rowContentAndSettings, rowLayoutAreas, rowColumns));
             }
 
             // section 
@@ -225,11 +225,11 @@ internal class GridToBlockContentHelper
             ContentTypeAlias = rowLayoutContentTypeAlias
         };
 
-        var settingsData = GetSettingsBlockItemDataFromRow(row, context, dataTypeAlias);
+        var settingsData = GetSettingsBlockItemDataFromRow(row, context, dataTypeAlias, contentData.Udi);
 
         return new BlockContentPair(content: contentData, settings: settingsData);
     }
-    private BlockItemData? GetSettingsBlockItemDataFromRow(GridValue.GridRow row, SyncMigrationContext context, string dataTypeAlias)
+    private BlockItemData? GetSettingsBlockItemDataFromRow(GridValue.GridRow row, SyncMigrationContext context, string dataTypeAlias, Udi contentUdi)
     {
         if (dataTypeAlias.IsNullOrWhiteSpace())
         {
@@ -265,17 +265,18 @@ internal class GridToBlockContentHelper
 
         return new BlockItemData
         {
-            Udi = Udi.Create(UmbConstants.UdiEntityType.Element, Guid.NewGuid()),
+            Udi = contentUdi,
             ContentTypeKey = rowSettingsContentTypeKey,
             ContentTypeAlias = rowLayoutSettingsContentTypeAlias,
             RawPropertyValues = settingsValues
         };
     }
-    private BlockGridLayoutItem GetGridRowBlockLayout(BlockItemData rowContent, List<BlockGridLayoutAreaItem> rowLayoutAreas, int? rowColumns)
+    private BlockGridLayoutItem GetGridRowBlockLayout(BlockContentPair rowContentAndSettings, List<BlockGridLayoutAreaItem> rowLayoutAreas, int? rowColumns)
     {
         return new BlockGridLayoutItem
         {
-            ContentUdi = rowContent.Udi,
+            ContentUdi = rowContentAndSettings.Content.Udi,
+            SettingsUdi = rowContentAndSettings.Settings?.Udi,
             Areas = rowLayoutAreas.ToArray(),
             ColumnSpan = rowColumns,
             RowSpan = 1,

--- a/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -103,7 +103,7 @@ internal class GridToBlockContentHelper
 
                 foreach (var area in row.Areas.Select((value, index) => (value, index)))
                 {
-                    var areaIsFullWidth = rowIsFullWidth && area.value.Grid.GetIntOrDefault(0) == gridColumns;
+                    var areaIsFullWidth = false;
 
                     // get the content
                     var contentAndSettings = GetGridAreaBlockContent(area.value, context).ToList();

--- a/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -103,7 +103,7 @@ internal class GridToBlockContentHelper
 
                 foreach (var area in row.Areas.Select((value, index) => (value, index)))
                 {
-                    var areaIsFullWidth = false;
+                    var areaIsFullWidth = rowIsFullWidth && area.value.Grid.GetIntOrDefault(0) == gridColumns;
 
                     // get the content
                     var contentAndSettings = GetGridAreaBlockContent(area.value, context).ToList();

--- a/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -42,7 +42,7 @@ internal class GridToBlockContentHelper
     /// <summary>
     ///  convert a grid value (so with sections, rows, areas and controls) into a block value for a grid.
     /// </summary>
-    public BlockValue? ConvertToBlockValue(GridValue source, SyncMigrationContext context)
+    public BlockValue? ConvertToBlockValue(GridValue source, SyncMigrationContext context, string dataTypeAlias)
     {
         _logger.LogDebug(">> {method}", nameof(ConvertToBlockValue));
 
@@ -142,10 +142,16 @@ internal class GridToBlockContentHelper
                 // row 
                 if (!rowLayoutAreas.Any()) continue;
 
-                var rowContent = GetGridRowBlockContent(row, context);
 
-                block.ContentData.Add(rowContent);
-                blockLayouts.Add(GetGridRowBlockLayout(rowContent, rowLayoutAreas, rowColumns));
+                var rowContentAndSettings = GetGridRowBlockContentAndSettings(row, context, dataTypeAlias);
+
+                block.ContentData.Add(rowContentAndSettings.Content);
+
+                if (rowContentAndSettings.Settings is not null)
+                {
+                    block.SettingsData.Add(rowContentAndSettings.Settings);
+                }
+                blockLayouts.Add(GetGridRowBlockLayout(rowContentAndSettings.Content, rowLayoutAreas, rowColumns));
             }
 
             // section 
@@ -207,19 +213,64 @@ internal class GridToBlockContentHelper
         }
     }
 
-    private BlockItemData GetGridRowBlockContent(GridValue.GridRow row, SyncMigrationContext context)
+    private BlockContentPair GetGridRowBlockContentAndSettings(GridValue.GridRow row, SyncMigrationContext context, string dataTypeAlias)
     {
-        var rowLayoutContentTypeAlias = _conventions.LayoutContentTypeAlias(row.Name!);
+        var rowLayoutContentTypeAlias = _conventions.LayoutContentTypeAlias(row.Name);
         var rowContentTypeKey = context.GetContentTypeKeyOrDefault(rowLayoutContentTypeAlias, rowLayoutContentTypeAlias.ToGuid()); 
 
-        return new BlockItemData
+        var contentData = new BlockItemData
         {
             Udi = Udi.Create(UmbConstants.UdiEntityType.Element, row.Id),
             ContentTypeKey = rowContentTypeKey,
             ContentTypeAlias = rowLayoutContentTypeAlias
         };
-    }
 
+        var settingsData = GetSettingsBlockItemDataFromRow(row, context, dataTypeAlias);
+
+        return new BlockContentPair(content: contentData, settings: settingsData);
+    }
+    private BlockItemData? GetSettingsBlockItemDataFromRow(GridValue.GridRow row, SyncMigrationContext context, string dataTypeAlias)
+    {
+        if (dataTypeAlias.IsNullOrWhiteSpace())
+        {
+            return null;
+        }
+
+        var settingsValues = new Dictionary<string, object?>();
+
+        var rowLayoutSettingsContentTypeAlias = _conventions.LayoutSettingsContentTypeAlias(dataTypeAlias);
+        var rowSettingsContentTypeKey = context.GetContentTypeKeyOrDefault(rowLayoutSettingsContentTypeAlias, rowLayoutSettingsContentTypeAlias.ToGuid());
+
+        if (row.Config is not null)
+        {
+            foreach (JProperty config in row.Config)
+            {
+                settingsValues.Add(_conventions.FormatGridSettingKey(config.Name), config.Value);
+            }
+        }
+
+        if (row.Styles is not null)
+        {
+            foreach (JProperty style in row.Styles)
+            {
+                // Dont overwrite values. If styles have same settings keys as config, what should happen?
+                // TODO: Figure out what to do here / what gets priority?##
+                var formattedKey = _conventions.FormatGridSettingKey(style.Name);
+                if (!settingsValues.ContainsKey(formattedKey))
+                {
+                    settingsValues.Add(formattedKey, style.Value);
+                }
+            }
+        }
+
+        return new BlockItemData
+        {
+            Udi = Udi.Create(UmbConstants.UdiEntityType.Element, Guid.NewGuid()),
+            ContentTypeKey = rowSettingsContentTypeKey,
+            ContentTypeAlias = rowLayoutSettingsContentTypeAlias,
+            RawPropertyValues = settingsValues
+        };
+    }
     private BlockGridLayoutItem GetGridRowBlockLayout(BlockItemData rowContent, List<BlockGridLayoutAreaItem> rowLayoutAreas, int? rowColumns)
     {
         return new BlockGridLayoutItem

--- a/uSync.Migrations/Migrators/BlockGrid/Extensions/GridConventions.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Extensions/GridConventions.cs
@@ -1,5 +1,5 @@
 ﻿using Umbraco.Cms.Core.Strings;
-
+using Umbraco.Extensions;
 namespace uSync.Migrations.Migrators.BlockGrid.Extensions;
 
 internal class GridConventions
@@ -31,4 +31,20 @@ internal class GridConventions
 
     public string LayoutContentTypeAlias(string layout)
         => layout.GetBlockGridLayoutContentTypeAlias(ShortStringHelper);
+    public string LayoutSettingsContentTypeAlias(string layout)
+        => layout.GetBlockGridLayoutSettingsContentTypeAlias(ShortStringHelper);
+
+    public string FormatGridSettingKey(string setting)
+    {
+        var splitString = setting.Split("-");
+        if (splitString.Length == 1)
+        {
+            return splitString[0];
+        }
+
+        return string.Join("", 
+                splitString.First().ToLower(), 
+                string.Join("", splitString.Skip(1).Select(s => s.ToFirstUpper())))
+            .ToString();
+    }
 }

--- a/uSync.Migrations/Migrators/BlockGrid/Extensions/GridToBlockGridNameExtensions.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Extensions/GridToBlockGridNameExtensions.cs
@@ -37,6 +37,7 @@ internal static class GridToBlockGridNameExtensions
         context.Content.AddKey(defaultKey, alias);
         return defaultKey;
     }
-
+    public static string GetBlockGridLayoutSettingsContentTypeAlias(this string name, IShortStringHelper shortStringHelper)
+        => name.GetContentTypeAlias("BlockGridLayoutSettings_", shortStringHelper);
 
 }

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -13,6 +13,7 @@ using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
 using uSync.Migrations.Migrators.BlockGrid.Config;
 using uSync.Migrations.Migrators.BlockGrid.Content;
 using uSync.Migrations.Migrators.BlockGrid.Extensions;
+using uSync.Migrations.Migrators.BlockGrid.SettingsMigrator;
 using uSync.Migrations.Migrators.Models;
 using GridConfiguration = uSync.Migrations.Migrators.BlockGrid.Models.GridConfiguration;
 
@@ -24,6 +25,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 {
 	private readonly ILegacyGridConfig _gridConfig;
 	private readonly SyncBlockMigratorCollection _blockMigrators;
+	private readonly GridSettingsViewMigratorCollection _gridSettingsMigrators;
 	private readonly ILoggerFactory _loggerFactory;
 	private readonly ILogger<GridToBlockGridMigrator> _logger;
 	private readonly IProfilingLogger _profilingLogger;
@@ -33,12 +35,14 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
     public GridToBlockGridMigrator(
         ILegacyGridConfig gridConfig,
         SyncBlockMigratorCollection blockMigrators,
+        GridSettingsViewMigratorCollection gridSettingsMigrators,
         IShortStringHelper shortStringHelper,
         ILoggerFactory loggerFactory,
         IProfilingLogger profilingLogger)
     {
         _gridConfig = gridConfig;
         _blockMigrators = blockMigrators;
+        _gridSettingsMigrators = gridSettingsMigrators;
         _conventions = new GridConventions(shortStringHelper);
         _loggerFactory = loggerFactory;
         _profilingLogger = profilingLogger;
@@ -76,9 +80,11 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 
 		var contentBlockHelper = new GridToBlockGridConfigBlockHelper(_blockMigrators, _loggerFactory.CreateLogger<GridToBlockGridConfigBlockHelper>());
 		var layoutBlockHelper = new GridToBlockGridConfigLayoutBlockHelper(_conventions, _loggerFactory.CreateLogger<GridToBlockGridConfigLayoutBlockHelper>());
-
+		var layoutSettingsBlockHelper = new GridToBlockGridConfigLayoutSettingsHelper(_conventions, _gridSettingsMigrators, _loggerFactory.CreateLogger<GridToBlockGridConfigLayoutSettingsHelper>());
 		// adds content types for the core elements (headline, rte, etc)
 		contentBlockHelper.AddConfigDataTypes(gridToBlockContext, context);
+// Add settings
+		layoutSettingsBlockHelper.AddGridSettings(gridToBlockContext, context, dataTypeProperty.DataTypeAlias);
 
 		// prep the layouts 
 		layoutBlockHelper.AddLayoutBlocks(gridToBlockContext, context);
@@ -112,6 +118,13 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 			return string.Empty;
 		}
 
+		var dataTypeAlias = context.ContentTypes.GetDataTypeAlias(contentProperty.ContentTypeAlias, contentProperty.PropertyAlias);
+		
+		
+		if (string.IsNullOrWhiteSpace(dataTypeAlias))
+		{
+			_logger.LogWarning("  Data type for grid could not be found when converting {alias}. Migration will run, but layout setting will not be migrated.", contentProperty.EditorAlias);
+		}
 		// has already been converted. 
 		if (contentProperty.Value.Contains("\"Umbraco.BlockGrid\""))
 		{
@@ -151,7 +164,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
 			_loggerFactory.CreateLogger<GridToBlockContentHelper>(), 
 			_profilingLogger);
 		
-		var blockValue = helper.ConvertToBlockValue(source, context);
+		var blockValue = helper.ConvertToBlockValue(source, context, dataTypeAlias ?? "");
 		if (blockValue == null)
 		{
 			_logger.LogDebug("  Converted value for {alias} is empty", contentProperty.EditorAlias);

--- a/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -128,13 +128,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
             dataTypeAlias = context.DataTypes.GetByDefinition(dataTypeGuid)?.DataTypeName;
         }
 
-/*        var gridDataTypeId = _contentTypeService.Get(contentProperty.ContentTypeAlias)?.PropertyTypes
-			.Where(propertyType => propertyType.PropertyEditorAlias == contentProperty.EditorAlias && propertyType.Alias == contentProperty.PropertyAlias)
-			.Select(propertyType => propertyType.DataTypeId)
-        .FirstOrDefault();*/
-
-/*        var test = _dataTypeService.GetDataType((int)gridDataTypeId)?.Name;
-*/      if (string.IsNullOrWhiteSpace(dataTypeAlias))
+		if (string.IsNullOrWhiteSpace(dataTypeAlias))
 		{
 			_logger.LogWarning("  Data type for grid could not be found when converting {alias}. Migration will run, but layout setting will not be migrated.", contentProperty.EditorAlias);
 		}

--- a/uSync.Migrations/Migrators/BlockGrid/Models/GridModels.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/Models/GridModels.cs
@@ -55,7 +55,31 @@ internal class GridAreaConfiguration
     public bool? AllowAll { get; set; }
     public string[]? Allowed { get; set; }
 }
+internal class GridSettingsConfiguration
+{
+    GridSettingsConfigurationItem[]? ConfigItems { get; set; }
+}
 
+internal class GridSettingsConfigurationItem
+{
+    [JsonProperty("label")]
+    public string? Label { get; set; }
+
+    [JsonProperty("description")]
+    public string? Description { get; set; }
+
+    [JsonProperty("key")]
+    public string? Key { get; set; }
+
+    [JsonProperty("view")]
+    public string? View { get; set; }
+
+    [JsonProperty("modifier")]
+    public string? Modifier { get; set; }
+
+    [JsonProperty("applyTo")]
+    public string? ApplyTo { get; set; }
+}
 /// <summary>
 ///  contains the data for a block (content and settings)
 /// </summary>

--- a/uSync.Migrations/Migrators/BlockGrid/SettingsMigrators/GridViewPropertyBooleanMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/SettingsMigrators/GridViewPropertyBooleanMigrator.cs
@@ -1,0 +1,13 @@
+﻿namespace uSync.Migrations.Migrators.BlockGrid.SettingsMigrator;
+
+public class GridViewPropertyBooleanMigrator : IGridSettingsViewMigrator
+{
+    public string ViewKey => "Boolean";
+
+    public string NewDataTypeAlias => "True/false";
+
+    public object ConvertContentString(string value)
+    {
+        return value;
+    }
+}

--- a/uSync.Migrations/Migrators/BlockGrid/SettingsMigrators/IGridSettingsViewMigrator.cs
+++ b/uSync.Migrations/Migrators/BlockGrid/SettingsMigrators/IGridSettingsViewMigrator.cs
@@ -1,0 +1,30 @@
+﻿using Umbraco.Cms.Core.Composing;
+using Umbraco.Extensions;
+
+namespace uSync.Migrations.Migrators.BlockGrid.SettingsMigrator;
+
+public interface IGridSettingsViewMigrator : IDiscoverable
+{
+    string ViewKey { get; }
+    string NewDataTypeAlias { get; }
+    public object ConvertContentString(string value);
+}
+
+public class GridSettingsViewMigratorCollectionBuilder
+    : LazyCollectionBuilderBase<GridSettingsViewMigratorCollectionBuilder, GridSettingsViewMigratorCollection, IGridSettingsViewMigrator>
+{
+    protected override GridSettingsViewMigratorCollectionBuilder This => this;
+}
+
+public class GridSettingsViewMigratorCollection
+    : BuilderCollectionBase<IGridSettingsViewMigrator>
+{
+    public GridSettingsViewMigratorCollection(Func<IEnumerable<IGridSettingsViewMigrator>> items) : base(items)
+    {}
+
+    public IGridSettingsViewMigrator? GetMigrator(string? viewKey)
+    {
+        if (viewKey == null) return null;
+        return this.FirstOrDefault(x => x.ViewKey.InvariantEquals(viewKey));
+    }
+}


### PR DESCRIPTION
Builds off of changes by @bielu (thank you!) 

Adds in some rough functionality to convert config and styles from the legacy grid to the BlockGrid & acts as a start for settings conversion. This implementation only handles the config/styles in the Layout layer (row) but perhaps similar implementations can be adopted for other layers.

It does this by:

Content Types

Reading config/styles & merging them (they have the same JSON data structure, afaik these are split up in the legacy grid for permissions based settings).
Create datatypes called BlockGridSettings_ for each grid.
Add the above block grid settings to each of the layouts for that grid. (It is safe to assume that all the layouts can have these as that is the behaviour of the legacy grid).
Nothing is done with modifier & prevalues as this is out of scope for me personally, but should definitely be included in a future update

Content
Converts content by simply porting the string over or using a process defined by anything that implements IGridSettingsMigrator. This is tied to each "datatype" (view) using the ViewKey property. The process for the conversion is defined in ConvertContentString. I would have liked to make this more customisable, but this seems to do the job for now. The NewDataTypeAlias should already be created in Umbraco but perhaps a way to do this automatically based off of a description in the IGridSettingsMigrator could be done to make this more programmatic?


Some more default GridViewPropertyMigrators will be needed (they may need more customisable interfaces?) for the following:

radiobuttonlist
mediapicker
imagepicker
booleantreepicker
treesource
multivalues