### PR TITLE
Feature/numeric ids in pickers

### DIFF
--- a/uSync.Migrations.Migrators/Community/GibeLinkPicker/GibeLinkPickerToMultiUrlPickerMigrator.cs
+++ b/uSync.Migrations.Migrators/Community/GibeLinkPicker/GibeLinkPickerToMultiUrlPickerMigrator.cs
@@ -10,9 +10,18 @@ namespace uSync.Migrations.Migrators.Community.GibeLinkPicker
 	public class GibeLinkPickerToMultiUrlPickerMigrator : SyncPropertyMigratorBase
 	{
 		public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-				=> Constants.PropertyEditors.Aliases.MultiUrlPicker;
+				=> UmbConstants.PropertyEditors.Aliases.MultiUrlPicker;
 
-		public override string GetContentValue(SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
+        public override object? GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+        {
+            var config = new MultiUrlPickerConfiguration
+            {
+                MaxNumber = 1
+            };
+            return config;
+        }
+
+        public override string GetContentValue(SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
 		{
 			if (contentProperty?.Value == null)
 			{
@@ -34,6 +43,7 @@ namespace uSync.Migrations.Migrators.Community.GibeLinkPicker
 				{
 					Name = picker?.Name ?? string.Empty,
 					Url = picker?.Url ?? string.Empty,
+					Udi = picker?.Uid != null ? new GuidUdi(UmbConstants.UdiEntityType.Document, Guid.Parse(picker.Uid)) : null,
 				};
 
 				if (picker?.Target == "_blank")

--- a/uSync.Migrations.Migrators/Community/GibeLinkPicker/GibeLinkPickerToMultiUrlPickerMigrator.cs
+++ b/uSync.Migrations.Migrators/Community/GibeLinkPicker/GibeLinkPickerToMultiUrlPickerMigrator.cs
@@ -6,11 +6,11 @@ using uSync.Migrations.Migrators.Community.GibeLinkPicker.Models;
 
 namespace uSync.Migrations.Migrators.Community.GibeLinkPicker
 {
-	[SyncMigrator("Gibe.LinkPicker")]
-	public class GibeLinkPickerToMultiUrlPickerMigrator : SyncPropertyMigratorBase
-	{
-		public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
-				=> UmbConstants.PropertyEditors.Aliases.MultiUrlPicker;
+    [SyncMigrator("Gibe.LinkPicker")]
+    public class GibeLinkPickerToMultiUrlPickerMigrator : SyncPropertyMigratorBase
+    {
+        public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
+                => UmbConstants.PropertyEditors.Aliases.MultiUrlPicker;
 
         public override object? GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
         {
@@ -22,55 +22,55 @@ namespace uSync.Migrations.Migrators.Community.GibeLinkPicker
         }
 
         public override string GetContentValue(SyncMigrationContentProperty contentProperty, SyncMigrationContext context)
-		{
-			if (contentProperty?.Value == null)
-			{
-				return contentProperty?.Value;
-			}
+        {
+            if (contentProperty?.Value == null)
+            {
+                return contentProperty?.Value;
+            }
 
-			var gibeLinkPickers = GetPickerValues(contentProperty.Value).ToArray();
-			
-			if (!gibeLinkPickers.Any())
-			{
-				return contentProperty.Value;
-			}
+            var gibeLinkPickers = GetPickerValues(contentProperty.Value).ToArray();
 
-			var links = new List<MultiUrlPickerValueEditor.LinkDto>();
+            if (!gibeLinkPickers.Any())
+            {
+                return contentProperty.Value;
+            }
 
-			foreach (var picker in gibeLinkPickers)
-			{
-				var link = new MultiUrlPickerValueEditor.LinkDto
-				{
-					Name = picker?.Name ?? string.Empty,
-					Url = picker?.Url ?? string.Empty,
-					Udi = picker?.Uid != null ? new GuidUdi(UmbConstants.UdiEntityType.Document, Guid.Parse(picker.Uid)) : null,
-				};
+            var links = new List<MultiUrlPickerValueEditor.LinkDto>();
 
-				if (picker?.Target == "_blank")
-				{
-					link.Target = picker.Target;
-				}
+            foreach (var picker in gibeLinkPickers)
+            {
+                var link = new MultiUrlPickerValueEditor.LinkDto
+                {
+                    Name = picker?.Name ?? string.Empty,
+                    Url = picker?.Url ?? string.Empty,
+                    Udi = picker?.Uid != null ? new GuidUdi(UmbConstants.UdiEntityType.Document, Guid.Parse(picker.Uid)) : null,
+                };
 
-				links.Add(link);
-			}
-			return JsonConvert.SerializeObject(links, Formatting.Indented);
-		}
-		
-		private IEnumerable<GibeLinkPickerData> GetPickerValues(string? contentValue)
-		{
-			if (contentValue == null)
-			{
-				return Enumerable.Empty<GibeLinkPickerData>();
-			}
+                if (picker?.Target == "_blank")
+                {
+                    link.Target = picker.Target;
+                }
 
-			if (contentValue.StartsWith("["))
-			{
-				return JsonConvert.DeserializeObject<IEnumerable<GibeLinkPickerData>>(contentValue) 
-				       ?? Enumerable.Empty<GibeLinkPickerData>();
-			}
-			return JsonConvert.DeserializeObject<GibeLinkPickerData>(contentValue)?.AsEnumerableOfOne() 
-			       ?? Enumerable.Empty<GibeLinkPickerData>();
-		}
-	}
+                links.Add(link);
+            }
+            return JsonConvert.SerializeObject(links, Formatting.Indented);
+        }
+
+        private IEnumerable<GibeLinkPickerData> GetPickerValues(string? contentValue)
+        {
+            if (contentValue == null)
+            {
+                return Enumerable.Empty<GibeLinkPickerData>();
+            }
+
+            if (contentValue.StartsWith("["))
+            {
+                return JsonConvert.DeserializeObject<IEnumerable<GibeLinkPickerData>>(contentValue)
+                       ?? Enumerable.Empty<GibeLinkPickerData>();
+            }
+            return JsonConvert.DeserializeObject<GibeLinkPickerData>(contentValue)?.AsEnumerableOfOne()
+                   ?? Enumerable.Empty<GibeLinkPickerData>();
+        }
+    }
 }
 

--- a/uSync.Migrations.Migrators/Core/ContentPickerMigrator.cs
+++ b/uSync.Migrations.Migrators/Core/ContentPickerMigrator.cs
@@ -34,6 +34,16 @@ public class ContentPicker1Migrator : SyncPropertyMigratorBase
         if (Guid.TryParse(contentProperty.Value, out var guid))
         {
             return new GuidUdi(UmbConstants.UdiEntityType.Document, guid).ToString();
+        } 
+        
+        // Really old pickers might have numeric ids
+        if (int.TryParse(contentProperty.Value, out var id))
+        {
+            var possibleGuid = context.GetKey(id);
+            if (possibleGuid != Guid.Empty)
+            {
+                return new GuidUdi(UmbConstants.UdiEntityType.Document, possibleGuid).ToString();
+            }
         }
 
         return base.GetContentValue(contentProperty, context);

--- a/uSync.Migrations.Migrators/Core/MediaPickerMigrator.cs
+++ b/uSync.Migrations.Migrators/Core/MediaPickerMigrator.cs
@@ -63,6 +63,12 @@ public class MediaPickerMigrator : SyncPropertyMigratorBase
                 guid = udi.Guid;
             }
 
+            // Really old pickers might have numeric ids
+            if (guid.Equals(Guid.Empty) && int.TryParse(image, out var id))
+            {
+                guid = context.GetKey(id);
+            }
+
             if (guid.Equals(Guid.Empty) == false)
             {
                 media.Add(new MediaWithCropsDto

--- a/uSync.Migrations.Migrators/Core/MultiNodeTreePickerMigrator.cs
+++ b/uSync.Migrations.Migrators/Core/MultiNodeTreePickerMigrator.cs
@@ -55,6 +55,16 @@ public class MultiNodeTreePickerMigrator : SyncPropertyMigratorBase
                 else if (UdiParser.TryParse<GuidUdi>(item, out var udi) == true)
                 {
                     values.Add(udi);
+                } 
+                else if (int.TryParse(item, out var id) == true) 
+                {
+                    // Really old editors might have numeric ids
+                    var possibleGuid = context.GetKey(id);
+                    if (possibleGuid != Guid.Empty)
+                    {
+                        // TODO: Eeek! This might possibly be content, media or member! [LK]
+                        values.Add(Udi.Create(UmbConstants.UdiEntityType.Document, possibleGuid));
+                    }
                 }
             }
         }


### PR DESCRIPTION
In one of the sites I've been working on it was a v6 site at one point and the data types are still using numeric ids.

This allows them to be migrated over to Udis as part of the migration

Also tidied up the Gibe.LinkPicker one to support later versions and set matching config