### PR TITLE
Fixes a typo in the project folder name in package build script & fixes a bug with migrations causes by recent changes

### DIFF
--- a/dist/build-package.ps1
+++ b/dist/build-package.ps1
@@ -60,7 +60,7 @@ dotnet build ..\uSyncMigrations.sln -c $env /p:$buildParams
 ""; "##### Packaging"; "----------------------------------" ; ""
 
 dotnet pack ..\uSync.Migrations.Core\uSync.Migrations.Core.csproj --no-restore --no-build -c $env -o $outFolder -p:$buildParams
-dotnet pack ..\uSync.Migrations.Clients\uSync.Migrations.Client.csproj --no-restore --no-build -c $env -o $outFolder -p:$buildParams
+dotnet pack ..\uSync.Migrations.Client\uSync.Migrations.Client.csproj --no-restore --no-build -c $env -o $outFolder -p:$buildParams
 dotnet pack ..\uSync.Migrations.Migrators\uSync.Migrations.Migrators.csproj --no-restore --no-build -c $env -o $outFolder -p:$buildParams
 dotnet pack ..\uSync.Migrations\uSync.Migrations.csproj --no-restore --no-build -c $env -o $outFolder -p:$buildParams
 

--- a/uSync.Migrations.Core/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedDataTypeHandler.cs
@@ -92,8 +92,8 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
             context.DataTypes.GetByDefinition(dtd)!.OriginalEditorAlias = editorAlias;
         }
     }
-
-    public void PrePrepareFiles(XElement source, SyncMigrationContext context)
+    
+    protected override void PrePrepareFile(XElement source, SyncMigrationContext context)
     {
         var editorAlias = GetEditorAlias(source);
         var (alias, dtd) = GetAliasAndKey(source, context);


### PR DESCRIPTION
Fixes a typo in the project folder name which will prevent the nuget package from being built