### PR TITLE
Allow lookup of entitytype to fix MultiNodeTreePicker for media

### DIFF
--- a/uSync.Migrations.Core/Context/SyncMigrationContext.cs
+++ b/uSync.Migrations.Core/Context/SyncMigrationContext.cs
@@ -50,6 +50,7 @@ public class SyncMigrationContext : IDisposable
 
     private HashSet<string> _blockedTypes = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<int, Guid> _idKeyMap { get; set; } = new();
+    private Dictionary<Guid, string> _keyToUdiEntityTypeMap { get; set; } = new();
 
     /// <summary>
     ///  is this item blocked based on alias and type. 
@@ -82,6 +83,22 @@ public class SyncMigrationContext : IDisposable
     /// <returns></returns>
     public int GetId(Guid key)
             => _idKeyMap?.FirstOrDefault(x => x.Value == key).Key ?? 0;
+
+    /// <summary>
+    /// Adds the reference from a guid key to find the entity type
+    /// </summary>
+    public void AddEntityMap(Guid key, string entityType)
+        => _keyToUdiEntityTypeMap.TryAdd(key, entityType);
+
+    /// <summary>
+    /// Get the entity type for the guid
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public string GetEntityType(Guid key)
+    {
+        return _keyToUdiEntityTypeMap.TryGetValue(key, out var entityType) == true ? entityType : UmbConstants.UdiEntityType.Document;
+    }
 
     public void Dispose()
     { }

--- a/uSync.Migrations.Core/Handlers/Eight/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/ContentBaseMigrationHandler.cs
@@ -41,6 +41,9 @@ internal class ContentBaseMigrationHandler<TEntity> : SharedContentBaseHandler<T
     protected override IEnumerable<XElement>? GetProperties(XElement source)
         => source.Element("Properties")?.Elements() ?? Enumerable.Empty<XElement>();
 
+    protected override string? GetEntityType()
+        => null;
+
     protected override XElement GetBaseXml(XElement source, Guid parent, string contentType, int level, SyncMigrationContext context)
     {
         var target = new XElement(source.Name.LocalName,

--- a/uSync.Migrations.Core/Handlers/Seven/ContentMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/ContentMigrationHandler.cs
@@ -21,4 +21,9 @@ internal class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, I
         ILogger<ContentMigrationHandler> logger)
         : base(eventAggregator, migrationFileService, shortStringHelper, logger)
     { }
+
+    protected override string? GetEntityType()
+    {
+        return UmbConstants.UdiEntityType.Document;
+    }
 }

--- a/uSync.Migrations.Core/Handlers/Seven/MediaMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/MediaMigrationHandler.cs
@@ -44,4 +44,9 @@ internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISync
             { "webm", UmbConstants.Conventions.MediaTypes.VideoAlias },
         });
     }
+
+    protected override string? GetEntityType()
+    {
+        return UmbConstants.UdiEntityType.Media;
+    }
 }

--- a/uSync.Migrations.Core/Handlers/Shared/SharedContentBaseHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedContentBaseHandler.cs
@@ -10,6 +10,7 @@ using Umbraco.Extensions;
 using uSync.Core;
 using uSync.Migrations.Core.Context;
 using uSync.Migrations.Core.Extensions;
+using uSync.Migrations.Core.Handlers.Seven;
 using uSync.Migrations.Core.Migrators;
 using uSync.Migrations.Core.Migrators.Models;
 using uSync.Migrations.Core.Models;
@@ -42,6 +43,12 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
 
         if (key != Guid.Empty)
         {
+            var entityType = this.GetEntityType();
+            if (entityType != null)
+            {
+                context.AddEntityMap(key, entityType);
+            }
+
             var id = GetId(source);
             if (id > 0)
             {
@@ -54,6 +61,8 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
             }
         }
     }
+
+    protected abstract string? GetEntityType();
 
     protected abstract XElement GetBaseXml(XElement source, Guid parent, string contentType, int level, SyncMigrationContext context);
 

--- a/uSync.Migrations.Migrators/Core/MultiNodeTreePickerMigrator.cs
+++ b/uSync.Migrations.Migrators/Core/MultiNodeTreePickerMigrator.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Extensions;
@@ -49,12 +49,21 @@ public class MultiNodeTreePickerMigrator : SyncPropertyMigratorBase
             {
                 if (Guid.TryParse(item, out var guid) == true)
                 {
-                    // TODO: Eeek! This might possibly be content, media or member! [LK]
-                    values.Add(Udi.Create(UmbConstants.UdiEntityType.Document, guid));
+                    values.Add(Udi.Create(context.GetEntityType(guid), guid));
                 }
                 else if (UdiParser.TryParse<GuidUdi>(item, out var udi) == true)
                 {
                     values.Add(udi);
+                } 
+                else if (int.TryParse(item, out var id) == true) 
+                {
+                    // Really old editors might have numeric ids
+                    var possibleGuid = context.GetKey(id);
+                    if (possibleGuid != Guid.Empty)
+                    {
+                        values.Add(Udi.Create(context.GetEntityType(possibleGuid), possibleGuid));
+                    }
+                    
                 }
             }
         }


### PR DESCRIPTION
Was having an issue where out MultiNodeTreePicker was looking at media, migrators assumes it's always document. 

Put a lookup for getting the entityType by guid.