### PR TITLE
WIP: Public all the migrators

### DIFF
--- a/uSync.Migrations.Core/Context/ContentTypeMigrationContext.cs
+++ b/uSync.Migrations.Core/Context/ContentTypeMigrationContext.cs
@@ -8,21 +8,20 @@ namespace uSync.Migrations.Core.Context;
 /// </summary>
 public class ContentTypeMigrationContext
 {
+    public Dictionary<Guid, string> ContentTypeAliases { get; } = new();
+    public Dictionary<string, Guid> ContentTypeKeys { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, HashSet<string>> ContentTypeCompositions { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, EditorAliasInfo> PropertyTypes { get; } = new(StringComparer.OrdinalIgnoreCase);
 
-    private Dictionary<Guid, string> _contentTypeAliases { get; set; } = new();
-    private Dictionary<string, Guid> _contentTypeKeys { get; set; } = new(StringComparer.OrdinalIgnoreCase);
-    private Dictionary<string, HashSet<string>> _contentTypeCompositions { get; set; } = new(StringComparer.OrdinalIgnoreCase);
-    private Dictionary<string, EditorAliasInfo> _propertyTypes { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    public HashSet<string> IgnoredProperties { get; } = new(StringComparer.OrdinalIgnoreCase);
 
-    private HashSet<string> _ignoredProperties = new(StringComparer.OrdinalIgnoreCase);
-
-    private Dictionary<string, NewContentTypeInfo> _newDocTypes
+    public Dictionary<string, NewContentTypeInfo> NewDocTypes { get; }
             = new Dictionary<string, NewContentTypeInfo>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     ///  allows you to map property aliases in a content type to the specific datatype
     /// </summary>
-    private Dictionary<string, string> _dataTypeAliases = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, string> DataTypeAliases { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     // tabs that are to be changed
     private List<TabOptions> _changedTabs { get; set; } = new List<TabOptions>();
@@ -30,10 +29,13 @@ public class ContentTypeMigrationContext
     /// <summary>
     ///  list of content types that need to be set as element types. 
     /// </summary>
-    private HashSet<Guid> _elementContentTypes = new HashSet<Guid>();
+    public HashSet<Guid> ElementContentTypes { get; } = new HashSet<Guid>();
 
-    private Dictionary<string, string> _replacementAliases =
+    public Dictionary<string, string> ReplacementAliases { get; } =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    public Dictionary<string, string> BlockAliases { get; }
+        = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     ///  Add a content type key to the context.
@@ -44,8 +46,8 @@ public class ContentTypeMigrationContext
     {
         _ = string.IsNullOrWhiteSpace(contentTypeAlias) == false &&
             contentTypeKey.HasValue == true &&
-            _contentTypeAliases.TryAdd(contentTypeKey.Value, contentTypeAlias) &&
-            _contentTypeKeys.TryAdd(contentTypeAlias, contentTypeKey.Value);
+            ContentTypeAliases.TryAdd(contentTypeKey.Value, contentTypeAlias) &&
+            ContentTypeKeys.TryAdd(contentTypeAlias, contentTypeKey.Value);
     }
 
     /// <summary>
@@ -54,21 +56,21 @@ public class ContentTypeMigrationContext
     /// <param name="contentTypeKey"></param>
     /// <returns>alias of a content type</returns>
     public string GetAliasByKey(Guid contentTypeKey)
-        => _contentTypeAliases?.TryGetValue(contentTypeKey, out var alias) == true ? alias : string.Empty;
+        => ContentTypeAliases?.TryGetValue(contentTypeKey, out var alias) == true ? alias : string.Empty;
 
     /// <summary>
     ///  get the key for a given content type alias from the context.
     /// </summary>
     /// <returns>GUID Key value for a content type</returns>
     public Guid GetKeyByAlias(string contentTypeAlias)
-        => _contentTypeKeys?.TryGetValue(contentTypeAlias, out var key) == true ? key : Guid.Empty;
+        => ContentTypeKeys?.TryGetValue(contentTypeAlias, out var key) == true ? key : Guid.Empty;
 
     /// <summary>
     ///  return all the content aliases we have loaded in the context.
     /// </summary>
     /// <returns>array of aliases</returns>
     public string[] GetAllAliases()
-        => _contentTypeAliases?.Values?.ToArray() ?? Array.Empty<string>();
+        => ContentTypeAliases?.Values?.ToArray() ?? Array.Empty<string>();
 
     /// <summary>
     ///  add content type compositions to the context
@@ -77,7 +79,7 @@ public class ContentTypeMigrationContext
     {
         _ = string.IsNullOrWhiteSpace(contentTypeAlias) == false &&
             compositionAliases?.Any() == true &&
-            _contentTypeCompositions.TryAdd(contentTypeAlias, compositionAliases.ToHashSet());
+            ContentTypeCompositions.TryAdd(contentTypeAlias, compositionAliases.ToHashSet());
     }
 
     /// <summary>
@@ -90,14 +92,13 @@ public class ContentTypeMigrationContext
     {
         compositionAliases = null;
 
-        if (contentTypeAlias != null && _contentTypeCompositions.TryGetValue(contentTypeAlias, out var compositions))
+        if (contentTypeAlias != null && ContentTypeCompositions.TryGetValue(contentTypeAlias, out var compositions))
         {
             compositionAliases = compositions?.ToArray();
         }
 
         return compositionAliases != null;
     }
-
 
     /// <summary>
     ///  Add a editorAlias mapping for a property mapping to the context.
@@ -112,7 +113,7 @@ public class ContentTypeMigrationContext
             string.IsNullOrWhiteSpace(propertyAlias) == false &&
             string.IsNullOrWhiteSpace(originalAlias) == false &&
             string.IsNullOrWhiteSpace(newAlias) == false &&
-            _propertyTypes.TryAdd($"{contentTypeAlias}_{propertyAlias}",
+            PropertyTypes.TryAdd($"{contentTypeAlias}_{propertyAlias}",
             new EditorAliasInfo(originalAlias, newAlias, dataTypeDefinition));
     }
 
@@ -129,7 +130,7 @@ public class ContentTypeMigrationContext
     /// </remarks>
     public EditorAliasInfo? GetEditorAliasByTypeAndProperty(string contentType, string propertyAlias)
     {
-        if (_propertyTypes?.TryGetValue($"{contentType}_{propertyAlias}", out var alias) == true)
+        if (PropertyTypes?.TryGetValue($"{contentType}_{propertyAlias}", out var alias) == true)
         {
             return alias;
         }
@@ -146,11 +147,11 @@ public class ContentTypeMigrationContext
     /// </summary>
     private bool TryGetEditorAliasByComposition(string compositionKey, string propertyAlias, out EditorAliasInfo? editorAliasInfo)
     {
-        if (_contentTypeCompositions?.TryGetValue(compositionKey, out var compositions) == true)
+        if (ContentTypeCompositions?.TryGetValue(compositionKey, out var compositions) == true)
         {
             foreach (var composition in compositions)
             {
-                if (_propertyTypes?.TryGetValue($"{composition}_{propertyAlias}", out var alias) == true)
+                if (PropertyTypes?.TryGetValue($"{composition}_{propertyAlias}", out var alias) == true)
                 {
                     editorAliasInfo = alias;
                     return true;
@@ -170,14 +171,14 @@ public class ContentTypeMigrationContext
     /// <summary>
     ///  tells us if a content type is an element type
     /// </summary>
-    public bool IsElementType(Guid key) => _elementContentTypes.Contains(key);
+    public bool IsElementType(Guid key) => ElementContentTypes.Contains(key);
 
     /// <summary>
     ///  add an element type to the list of element types.
     /// </summary>
     public void AddElementType(Guid key)
     {
-        if (!_elementContentTypes.Contains(key)) _elementContentTypes.Add(key);
+        if (!ElementContentTypes.Contains(key)) ElementContentTypes.Add(key);
     }
 
     /// <summary>
@@ -214,7 +215,6 @@ public class ContentTypeMigrationContext
         }
     }
 
-
     /// <summary>
     ///  ignore a property on a specific content type. 
     /// </summary>
@@ -222,20 +222,20 @@ public class ContentTypeMigrationContext
     ///  note this is the final content type, will not calculate compositions.
     /// </remarks>
     public void AddIgnoredProperty(string contentType, string alias)
-        => _ = _ignoredProperties.Add($"{contentType}_{alias}");
+        => _ = IgnoredProperties.Add($"{contentType}_{alias}");
 
     /// <summary>
     ///  add a property to ignore for all content types.
     /// </summary>
     public void AddIgnoredProperty(string alias)
-    => _ = _ignoredProperties.Add($"{alias}");
+    => _ = IgnoredProperties.Add($"{alias}");
 
     /// <summary>
     ///  returns true if a property is to be ignored 
     /// </summary>
     public bool IsIgnoredProperty(string contentType, string alias)
-        => _ignoredProperties.Contains($"{contentType}_{alias}")
-        || _ignoredProperties.Contains(alias);
+        => IgnoredProperties.Contains($"{contentType}_{alias}")
+        || IgnoredProperties.Contains(alias);
 
     /// <summary>
     ///  add a new content type - will then be processed as part of the 
@@ -243,8 +243,8 @@ public class ContentTypeMigrationContext
     /// </summary>
     public void AddNewContentType(NewContentTypeInfo newDocTypeInfo)
     {
-        if (!_newDocTypes.ContainsKey(newDocTypeInfo.Alias))
-            _newDocTypes.Add(newDocTypeInfo.Alias, newDocTypeInfo);
+        if (!NewDocTypes.ContainsKey(newDocTypeInfo.Alias))
+            NewDocTypes.Add(newDocTypeInfo.Alias, newDocTypeInfo);
     }
 
     /// <summary>
@@ -252,11 +252,7 @@ public class ContentTypeMigrationContext
     /// </summary>
     /// <returns></returns>
     public IList<NewContentTypeInfo> GetNewContentTypes()
-        => _newDocTypes.Values.ToList();
-
-
-    private Dictionary<string, string> _blockAliases
-        = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        => NewDocTypes.Values.ToList();
 
     /// <summary>
     ///  add a block editor to by name
@@ -264,7 +260,7 @@ public class ContentTypeMigrationContext
     /// <param name="name"></param>
     /// <param name="alias"></param>
     public void AddBlockEditor(string name, string alias)
-        => _blockAliases.TryAdd(name, alias);
+        => BlockAliases.TryAdd(name, alias);
 
     /// <summary>
     ///  get the block editor alias from the name.
@@ -272,7 +268,7 @@ public class ContentTypeMigrationContext
     /// <param name="name"></param>
     /// <returns></returns>
     public string GetBlockEditorAliasByName(string name)
-        => _blockAliases.TryGetValue(name, out var alias) == true
+        => BlockAliases.TryGetValue(name, out var alias) == true
             ? alias
             : name;
 
@@ -293,7 +289,7 @@ public class ContentTypeMigrationContext
     ///  add a mapping for a content types property to the named datatype.
     /// </summary>
     public void AddDataTypeAlias(string contentTypeAlias, string propertyAlias, string dataTypeAlias)
-        => _ = _dataTypeAliases.TryAdd($"{contentTypeAlias}_{propertyAlias}", dataTypeAlias);
+        => _ = DataTypeAliases.TryAdd($"{contentTypeAlias}_{propertyAlias}", dataTypeAlias);
 
     /// <summary>
     ///  get the datatype alias for a property on a content type.
@@ -302,14 +298,14 @@ public class ContentTypeMigrationContext
     /// <param name="propertyAlias"></param>
     /// <returns></returns>
     public string GetDataTypeAlias(string contentTypeAlias, string propertyAlias)
-        => _dataTypeAliases.TryGetValue($"{contentTypeAlias}_{propertyAlias}", out var alias) == true
+        => DataTypeAliases.TryGetValue($"{contentTypeAlias}_{propertyAlias}", out var alias) == true
             ? alias : string.Empty;
 
     /// <summary>
     /// Add a replacement alias for a content type alias
     /// </summary>
     public void AddReplacementAlias(string original, string replacement)
-        => _replacementAliases.TryAdd(original, replacement);
+        => ReplacementAliases.TryAdd(original, replacement);
 
     /// <summary>
     ///  get the replacement alias for an property based on the current alias.
@@ -317,6 +313,6 @@ public class ContentTypeMigrationContext
     /// <param name="alias"></param>
     /// <returns></returns>
     public string GetReplacementAlias(string alias)
-        => _replacementAliases.TryGetValue(alias, out var replacement)
+        => ReplacementAliases.TryGetValue(alias, out var replacement)
             ? replacement : alias;
 }

--- a/uSync.Migrations.Core/Context/DataTypeMigrationContext.cs
+++ b/uSync.Migrations.Core/Context/DataTypeMigrationContext.cs
@@ -10,23 +10,23 @@ public class DataTypeMigrationContext
     /// <summary>
     ///  list of keys to editor aliases used to lookup datatypes in content types !
     /// </summary>
-    private Dictionary<Guid, DataTypeInfo> _dataTypeDefinitions { get; set; } = new();
+    public Dictionary<Guid, DataTypeInfo> DataTypeDefinitions { get; } = new();
 
     /// <summary>
     ///  when we replace an datatype with something else .
     /// </summary>
-    private Dictionary<Guid, Guid> _dataTypeReplacements { get; set; } = new();
+    public Dictionary<Guid, Guid> DataTypeReplacements { get; } = new();
 
     /// <summary>
     ///  datatypes that vary by something (e.g culture)
     /// </summary>
-    private Dictionary<Guid, string> _dataTypeVariations { get; set; } = new();
+    public Dictionary<Guid, string> DataTypeVariations { get; } = new();
 
 
     /// <summary>
     ///  contains a lookup from defition (guid) to alias, so we can pass that along. 
     /// </summary>
-    private Dictionary<Guid, string> _dataTypeAliases { get; set; } = new();
+    public Dictionary<Guid, string> DataTypeAliases { get; } = new();
 
     /// <summary>
     ///  add a datatype alias to the lookup
@@ -34,7 +34,7 @@ public class DataTypeMigrationContext
     /// <param name="dtd"></param>
     /// <param name="alias"></param>
     public void AddAlias(Guid dtd, string alias)
-        => _ = _dataTypeAliases.TryAdd(dtd, alias);
+        => _ = DataTypeAliases.TryAdd(dtd, alias);
 
     /// <summary>
     ///  get the alias based on the DTD value (which we have in contenttype).
@@ -42,20 +42,20 @@ public class DataTypeMigrationContext
     /// <param name="dtd"></param>
     /// <returns></returns>
     public string GetAlias(Guid dtd)
-        => _dataTypeAliases?.TryGetValue(dtd, out var alias) == true
+        => DataTypeAliases?.TryGetValue(dtd, out var alias) == true
             ? alias : string.Empty;
 
     /// <summary>
     ///  add a datatypedefinion (aka datatype key) to the context.
     /// </summary>
     public void AddDefinition(Guid dtd, DataTypeInfo def)
-        => _ = _dataTypeDefinitions.TryAdd(dtd, def);
+        => _ = DataTypeDefinitions.TryAdd(dtd, def);
 
     /// <summary>
     ///  get a datatype definiton from the context.
     /// </summary>
     public DataTypeInfo? GetByDefinition(Guid guid)
-        => _dataTypeDefinitions?.TryGetValue(guid, out var def) == true
+        => DataTypeDefinitions?.TryGetValue(guid, out var def) == true
             ? def
             : null;
 
@@ -63,13 +63,13 @@ public class DataTypeMigrationContext
     ///  add the key that replaces a datatype to the context.
     /// </summary>
     public void AddReplacement(Guid original, Guid replacement)
-        => _ = _dataTypeReplacements.TryAdd(original, replacement);
+        => _ = DataTypeReplacements.TryAdd(original, replacement);
 
     /// <summary>
     ///  get any replacement key values for a given datatype key
     /// </summary>
     public Guid GetReplacement(Guid original)
-        => _dataTypeReplacements?.TryGetValue(original, out var replacement) == true
+        => DataTypeReplacements?.TryGetValue(original, out var replacement) == true
             ? replacement
             : original;
 
@@ -77,13 +77,13 @@ public class DataTypeMigrationContext
     ///  add a variation (e.g culture, segment or nothing) value for a datatype to the context.
     /// </summary>
     public void AddVariation(Guid guid, string variation)
-        => _ = _dataTypeVariations?.TryAdd(guid, variation);
+        => _ = DataTypeVariations?.TryAdd(guid, variation);
 
     /// <summary>
     ///  retrieve the variation that a datatype will ask a doctype property to perform.
     /// </summary>
     public string GetVariation(Guid guid, string defaultValue)
-        => _dataTypeVariations?.TryGetValue(guid, out var variation) == true
+        => DataTypeVariations?.TryGetValue(guid, out var variation) == true
             ? variation : defaultValue;
 
     /// <summary>
@@ -93,7 +93,7 @@ public class DataTypeMigrationContext
     /// <returns></returns>
     public Guid? GetFirstDefinition(string alias)
     {
-        var dataTypeDefinition = _dataTypeDefinitions?.FirstOrDefault(x => x.Value.EditorAlias == alias);
+        var dataTypeDefinition = DataTypeDefinitions?.FirstOrDefault(x => x.Value.EditorAlias == alias);
         return dataTypeDefinition?.Key ?? null;
     }
 

--- a/uSync.Migrations.Core/Handlers/Eight/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/ContentBaseMigrationHandler.cs
@@ -14,7 +14,8 @@ using uSync.Migrations.Core.Handlers.Shared;
 using uSync.Migrations.Core.Services;
 
 namespace uSync.Migrations.Core.Handlers.Eight;
-internal class ContentBaseMigrationHandler<TEntity> : SharedContentBaseHandler<TEntity>
+
+public class ContentBaseMigrationHandler<TEntity> : SharedContentBaseHandler<TEntity>
     where TEntity : ContentBase
 {
     public ContentBaseMigrationHandler(

--- a/uSync.Migrations.Core/Handlers/Eight/ContentMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/ContentMigrationHandler.cs
@@ -12,7 +12,7 @@ namespace uSync.Migrations.Core.Handlers.Eight;
     SourceVersion = 8,
     SourceFolderName = "Content",
     TargetFolderName = "Content")]
-internal class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, ISyncMigrationHandler
+public class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, ISyncMigrationHandler
 {
     public ContentMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/ContentTypeBaseMigrationHandler.cs
@@ -16,7 +16,8 @@ using uSync.Migrations.Core.Handlers.Shared;
 using uSync.Migrations.Core.Services;
 
 namespace uSync.Migrations.Core.Handlers.Eight;
-internal class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseHandler<TEntity>
+
+public class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseHandler<TEntity>
     where TEntity : ContentTypeBase
 {
     public ContentTypeBaseMigrationHandler(

--- a/uSync.Migrations.Core/Handlers/Eight/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/ContentTypeMigrationHandler.cs
@@ -13,7 +13,7 @@ namespace uSync.Migrations.Core.Handlers.Eight;
     SourceVersion = 8,
     SourceFolderName = "ContentTypes",
     TargetFolderName = "ContentTypes")]
-internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<ContentType>, ISyncMigrationHandler
+public class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<ContentType>, ISyncMigrationHandler
 {
     public ContentTypeMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Eight/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/DataTypeMigrationHandler.cs
@@ -19,11 +19,12 @@ using uSync.Migrations.Core.Services;
 using uSync.Migrations.Core.Validation;
 
 namespace uSync.Migrations.Core.Handlers.Eight;
+
 [SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.DataTypes,
     SourceVersion = 8,
     SourceFolderName = "DataTypes",
     TargetFolderName = "DataTypes")]
-internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationHandler, ISyncMigrationValidator
+public class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationHandler, ISyncMigrationValidator
 {
     private readonly SyncPropertyMigratorCollection _migrators;
 

--- a/uSync.Migrations.Core/Handlers/Eight/DictionaryMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/DictionaryMigrationHandler.cs
@@ -12,7 +12,7 @@ namespace uSync.Migrations.Core.Handlers.Eight;
     SourceVersion = 8,
     SourceFolderName = "Dictionary",
     TargetFolderName = "Dictionary")]
-internal class DictionaryMigrationHandler : SharedHandlerBase<DictionaryItem>, ISyncMigrationHandler
+public class DictionaryMigrationHandler : SharedHandlerBase<DictionaryItem>, ISyncMigrationHandler
 {
     public DictionaryMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Eight/LanguageMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/LanguageMigrationHandler.cs
@@ -12,7 +12,7 @@ namespace uSync.Migrations.Core.Handlers.Eight;
     SourceVersion = 8,
     SourceFolderName = "Languages",
     TargetFolderName = "Languages")]
-internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigrationHandler
+public class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigrationHandler
 {
     public LanguageMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Eight/MacroMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/MacroMigrationHandler.cs
@@ -12,7 +12,7 @@ namespace uSync.Migrations.Core.Handlers.Eight;
     SourceVersion = 8,
     SourceFolderName = "Macros",
     TargetFolderName = "Macros")]
-internal class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationHandler
+public class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationHandler
 {
     public MacroMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Eight/MediaMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/MediaMigrationHandler.cs
@@ -12,7 +12,7 @@ namespace uSync.Migrations.Core.Handlers.Eight;
     SourceVersion = 8,
     SourceFolderName = "Media",
     TargetFolderName = "Media")]
-internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISyncMigrationHandler
+public class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISyncMigrationHandler
 {
     public MediaMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Eight/MediaTypeMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/MediaTypeMigrationHandler.cs
@@ -13,7 +13,7 @@ namespace uSync.Migrations.Core.Handlers.Eight;
     SourceVersion = 8,
     SourceFolderName = "MediaTypes",
     TargetFolderName = "MediaTypes")]
-internal class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<MediaType>, ISyncMigrationHandler
+public class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<MediaType>, ISyncMigrationHandler
 {
     public MediaTypeMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Eight/TemplateMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/TemplateMigrationHandler.cs
@@ -12,7 +12,7 @@ namespace uSync.Migrations.Core.Handlers.Eight;
     SourceVersion = 8,
     SourceFolderName = "Templates",
     TargetFolderName = "Templates")]
-internal class TemplateMigrationHandler : SharedTemplateHandler, ISyncMigrationHandler
+public class TemplateMigrationHandler : SharedTemplateHandler, ISyncMigrationHandler
 {
     public TemplateMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/MigrationHandlerBase.cs
+++ b/uSync.Migrations.Core/Handlers/MigrationHandlerBase.cs
@@ -16,7 +16,8 @@ using uSync.Migrations.Core.Notifications;
 using uSync.Migrations.Core.Services;
 
 namespace uSync.Migrations.Core.Handlers;
-internal abstract class MigrationHandlerBase<TObject>
+
+public abstract class MigrationHandlerBase<TObject>
     where TObject : IEntity
 {
     protected readonly IEventAggregator _eventAggregator;

--- a/uSync.Migrations.Core/Handlers/Seven/ContentBaseMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/ContentBaseMigrationHandler.cs
@@ -14,7 +14,7 @@ using uSync.Migrations.Core.Services;
 
 namespace uSync.Migrations.Core.Handlers.Seven;
 
-internal abstract class ContentBaseMigrationHandler<TEntity> : SharedContentBaseHandler<TEntity>
+public abstract class ContentBaseMigrationHandler<TEntity> : SharedContentBaseHandler<TEntity>
     where TEntity : ContentBase
 {
     public ContentBaseMigrationHandler(

--- a/uSync.Migrations.Core/Handlers/Seven/ContentMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/ContentMigrationHandler.cs
@@ -12,7 +12,7 @@ namespace uSync.Migrations.Core.Handlers.Seven;
     SourceVersion = 7,
     SourceFolderName = "Content",
     TargetFolderName = "Content")]
-internal class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, ISyncMigrationHandler
+public class ContentMigrationHandler : ContentBaseMigrationHandler<Content>, ISyncMigrationHandler
 {
     public ContentMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/ContentTypeBaseMigrationHandler.cs
@@ -19,7 +19,7 @@ using uSync.Migrations.Core.Services;
 
 namespace uSync.Migrations.Core.Handlers.Seven;
 
-internal abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseHandler<TEntity>
+public abstract class ContentTypeBaseMigrationHandler<TEntity> : SharedContentTypeBaseHandler<TEntity>
     where TEntity : ContentTypeBase
 {
 

--- a/uSync.Migrations.Core/Handlers/Seven/ContentTypeMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/ContentTypeMigrationHandler.cs
@@ -14,7 +14,7 @@ namespace uSync.Migrations.Core.Handlers.Seven;
     SourceVersion = 7,
     SourceFolderName = "DocumentType",
     TargetFolderName = "ContentTypes")]
-internal class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<ContentType>, ISyncMigrationHandler
+public class ContentTypeMigrationHandler : ContentTypeBaseMigrationHandler<ContentType>, ISyncMigrationHandler
 {
     public ContentTypeMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Seven/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/DataTypeMigrationHandler.cs
@@ -25,7 +25,7 @@ namespace uSync.Migrations.Core.Handlers.Seven;
     SourceVersion = 7,
     SourceFolderName = "DataType",
     TargetFolderName = "DataTypes")]
-internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationHandler, ISyncMigrationValidator
+public class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationHandler, ISyncMigrationValidator
 {
     private readonly SyncPropertyMigratorCollection _migrators;
 

--- a/uSync.Migrations.Core/Handlers/Seven/DictionaryMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/DictionaryMigrationHandler.cs
@@ -20,7 +20,7 @@ namespace uSync.Migrations.Core.Handlers.Seven;
     SourceVersion = 7,
     SourceFolderName = "DictionaryItem",
     TargetFolderName = "Dictionary")]
-internal class DictionaryMigrationHandler : SharedHandlerBase<DictionaryItem>, ISyncMigrationHandler
+public class DictionaryMigrationHandler : SharedHandlerBase<DictionaryItem>, ISyncMigrationHandler
 {
     public DictionaryMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Seven/LanguageMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/LanguageMigrationHandler.cs
@@ -17,7 +17,7 @@ namespace uSync.Migrations.Core.Handlers.Seven;
 [SyncMigrationHandler(BackOfficeConstants.Groups.Settings, uSyncMigrations.Priorities.Languages,
     SourceVersion = 7,
     SourceFolderName = "Languages", TargetFolderName = "Languages")]
-internal class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigrationHandler
+public class LanguageMigrationHandler : SharedHandlerBase<Language>, ISyncMigrationHandler
 {
     private readonly ILocalizationService _localizationService;
 

--- a/uSync.Migrations.Core/Handlers/Seven/MacroMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/MacroMigrationHandler.cs
@@ -16,7 +16,7 @@ namespace uSync.Migrations.Core.Handlers.Seven;
     SourceVersion = 7,
     SourceFolderName = "Macro",
     TargetFolderName = "Macros")]
-internal class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationHandler
+public class MacroMigrationHandler : SharedHandlerBase<Macro>, ISyncMigrationHandler
 {
     public MacroMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Seven/MediaMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/MediaMigrationHandler.cs
@@ -12,7 +12,7 @@ namespace uSync.Migrations.Core.Handlers.Seven;
     SourceVersion = 7,
     SourceFolderName = "Media",
     TargetFolderName = "Media")]
-internal class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISyncMigrationHandler
+public class MediaMigrationHandler : ContentBaseMigrationHandler<Media>, ISyncMigrationHandler
 {
     public MediaMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Seven/MediaTypeMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/MediaTypeMigrationHandler.cs
@@ -14,7 +14,7 @@ namespace uSync.Migrations.Core.Handlers.Seven;
     SourceVersion = 7,
     SourceFolderName = "MediaType",
     TargetFolderName = "MediaTypes")]
-internal class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<MediaType>, ISyncMigrationHandler
+public class MediaTypeMigrationHandler : ContentTypeBaseMigrationHandler<MediaType>, ISyncMigrationHandler
 {
     public MediaTypeMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Seven/TemplateMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Seven/TemplateMigrationHandler.cs
@@ -16,7 +16,7 @@ namespace uSync.Migrations.Core.Handlers.Seven;
     SourceVersion = 7,
     SourceFolderName = "Template",
     TargetFolderName = "Templates")]
-internal class TemplateMigrationHandler : SharedTemplateHandler, ISyncMigrationHandler
+public class TemplateMigrationHandler : SharedTemplateHandler, ISyncMigrationHandler
 {
     public TemplateMigrationHandler(
         IEventAggregator eventAggregator,

--- a/uSync.Migrations.Core/Handlers/Shared/SharedContentBaseHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedContentBaseHandler.cs
@@ -17,7 +17,8 @@ using uSync.Migrations.Core.Models;
 using uSync.Migrations.Core.Services;
 
 namespace uSync.Migrations.Core.Handlers.Shared;
-internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TEntity>
+
+public abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TEntity>
     where TEntity : ContentBase
 {
     protected readonly IShortStringHelper _shortStringHelper;

--- a/uSync.Migrations.Core/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -17,7 +17,8 @@ using uSync.Migrations.Core.Notifications;
 using uSync.Migrations.Core.Services;
 
 namespace uSync.Migrations.Core.Handlers.Shared;
-internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBase<TEntity>
+
+public abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBase<TEntity>
     where TEntity : ContentTypeBase
 {
     private readonly IDataTypeService _dataTypeService;

--- a/uSync.Migrations.Core/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedDataTypeHandler.cs
@@ -16,7 +16,8 @@ using uSync.Migrations.Core.Serialization;
 using uSync.Migrations.Core.Services;
 
 namespace uSync.Migrations.Core.Handlers.Shared;
-internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
+
+public abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
 {
     protected readonly IDataTypeService _dataTypeService;
     protected readonly JsonSerializerSettings _jsonSerializerSettings;

--- a/uSync.Migrations.Core/Handlers/Shared/SharedHandlerBase.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedHandlerBase.cs
@@ -20,7 +20,7 @@ namespace uSync.Migrations.Core.Handlers.Shared;
 ///  
 ///  v7 migrators override the default behavors, to do the migrations.
 /// </remarks>
-internal abstract class SharedHandlerBase<TObject> : MigrationHandlerBase<TObject>
+public abstract class SharedHandlerBase<TObject> : MigrationHandlerBase<TObject>
     where TObject : IEntity
 {
     protected SharedHandlerBase(

--- a/uSync.Migrations.Core/Handlers/Shared/SharedTemplateHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedTemplateHandler.cs
@@ -14,7 +14,7 @@ namespace uSync.Migrations.Core.Handlers.Shared;
 /// <summary>
 ///  stuff that is the same in v7 and v8 template migrations.
 /// </summary>
-internal abstract class SharedTemplateHandler : SharedHandlerBase<Template>
+public abstract class SharedTemplateHandler : SharedHandlerBase<Template>
 {
     protected readonly IFileService _fileService;
 

--- a/uSync.Migrations.Core/Handlers/SyncMigrationHandlerAttribute.cs
+++ b/uSync.Migrations.Core/Handlers/SyncMigrationHandlerAttribute.cs
@@ -1,5 +1,6 @@
 ﻿namespace uSync.Migrations.Core.Handlers;
-internal class SyncMigrationHandlerAttribute : Attribute
+
+public class SyncMigrationHandlerAttribute : Attribute
 {
     public SyncMigrationHandlerAttribute(string group, int priority)
     {

--- a/uSync.Migrations.Core/uSyncMigrations.cs
+++ b/uSync.Migrations.Core/uSyncMigrations.cs
@@ -18,7 +18,7 @@ public static class uSyncMigrations
 
     public const string MigrationFolder = "uSync/Migrations";
 
-    internal static class Priorities
+    public static class Priorities
     {
         public const int Templates = 5;
 


### PR DESCRIPTION
I'm doing very custom things with a replacement for Vorto.  
It is impossible without making the actual migration handlers replacable and preferably inheritable.  
(Maybe Vorto shouldn't be so tightly coupled through `ISyncReplacablePropertyMigrator`?)

For now this is WIP and possibly way to hacky to mandate pulling, but wanted to make the PR for visibility and possible discussion.

Will update when my PoC works. 🙃