### PR TITLE
Make it so we can migrate variant properties, (for v8 -> v.x migrations.

### DIFF
--- a/uSync.Migrations.Client/wwwroot/App_Plugins/uSyncMigrations/backoffice/uSyncMigrations/dashboard.controller.js
+++ b/uSync.Migrations.Client/wwwroot/App_Plugins/uSyncMigrations/backoffice/uSyncMigrations/dashboard.controller.js
@@ -138,6 +138,7 @@
                     vm.step = 'migrated';
                     vm.migrationResults = result.data;
                     vm.migrationStatus.migrated = true;
+                    vm.migrationStatus.success = result.success;
                     vm.working = false;
                 }, function (error) {
                     vm.state = 'error';

--- a/uSync.Migrations.Client/wwwroot/App_Plugins/uSyncMigrations/backoffice/uSyncMigrations/dashboard.html
+++ b/uSync.Migrations.Client/wwwroot/App_Plugins/uSyncMigrations/backoffice/uSyncMigrations/dashboard.html
@@ -227,12 +227,17 @@
 
                         ({{vm.migrationResults.messages.length}} messages returned)
                     </umb-box-content>
+
                 </umb-box>
+
+                <div class="alert alert-danger" ng-if="vm.migrationResults.success == false">
+                    There where one or more errors during the migration.
+                </div>
 
                 <usync-migration-results results="vm.migrationResults"
                                          action="Migration"
                                          is-valid="vm.resultValid"
-                                         show-all="true">
+                                         show-all="vm.migrationResults.success">
                 </usync-migration-results>
             </div>
 

--- a/uSync.Migrations.Core/Handlers/Eight/DataTypeMigrationHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Eight/DataTypeMigrationHandler.cs
@@ -103,6 +103,9 @@ internal class DataTypeMigrationHandler : SharedDataTypeHandler, ISyncMigrationH
             try
             {
                 var source = XElement.Load(file);
+                // don't validate the empties
+                if (source.IsEmptyItem()) continue;
+
                 var alias = source.GetAlias();
                 var key = source.GetKey();
                 var editorAlias = GetEditorAlias(source);

--- a/uSync.Migrations.Core/Migrators/Models/SyncMigrationContentProperty.cs
+++ b/uSync.Migrations.Core/Migrators/Models/SyncMigrationContentProperty.cs
@@ -32,7 +32,7 @@ public sealed class SyncMigrationContentProperty : SyncMigrationPropertyBase
         PropertyAlias = propertyAlias;
     }
 
-    public string? Value { get; private set; }
+    public string? Value { get; set; }
 
 }
 

--- a/uSync.Migrations.Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -138,12 +138,13 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
             return contentProperty.Value;
         }
 
-        var source = JsonConvert.DeserializeObject<GridValue>(contentProperty.Value);
+        var source = GetGridValueFromString(contentProperty.EditorAlias, contentProperty.Value);
         if (source == null)
         {
             _logger.LogDebug("  Property {alias} is empty", contentProperty.EditorAlias);
             return string.Empty;
         }
+
 
         // For some reason, DTGEs can sometimes end up without a view specified. This should fix it.
         foreach (var section in source.Sections)
@@ -180,6 +181,20 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
         _logger.LogDebug("<< {method}", nameof(GetContentValue));
 
         return JsonConvert.SerializeObject(blockValue, Formatting.Indented);
+    }
+
+
+    private GridValue? GetGridValueFromString(string editorAlias, string value)
+    {
+        try
+        {
+            return JsonConvert.DeserializeObject<GridValue>(value);
+        }
+        catch(Exception ex) 
+        {
+            _logger.LogError(ex, "Error getting grid {alias}", editorAlias);
+            throw;
+        }
     }
 }
 


### PR DESCRIPTION
This adds some logic in the Content migrator for v8 (and above). so we can actually migrate variant content. 

Variant content can't be migrated, if you want to also use a splitting, or merging migrator, but as at the moment, vorto is the only real splitting migrator, and that's v7, we are going to live with this restriction. 