### PR TITLE
Added check for cultured name or published values - to ensure no duplicates

### DIFF
--- a/uSync.Migrations.Core/Handlers/Shared/SharedContentBaseHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedContentBaseHandler.cs
@@ -295,13 +295,16 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
             var publishedNode = node.Element("Info")?.Element("Published");
             var publishedValue = publishedNode?.Attribute("Default").ValueOrDefault(false) ?? false;
 
+            var existingNodeNames = nodeNameNode.Elements("Name").Select(x => x.Attribute("Culture").ValueOrDefault(string.Empty)).ToList();
+            var existingPublished = publishedNode?.Elements("Published").Select(x => x.Attribute("Culture").ValueOrDefault(string.Empty)).ToList();
+
             foreach (var language in languages)
             {
-                nodeNameNode.Add(new XElement("Name",
-                    new XAttribute("Culture", language), defaultName));
+                if (!existingNodeNames.Contains(language))
+                    nodeNameNode.Add(new XElement("Name", new XAttribute("Culture", language), defaultName));
 
-                publishedNode?.Add(new XElement("Published",
-                        new XAttribute("Culture", language), publishedValue));
+                if (!(existingPublished?.Contains(language) == true))
+                    publishedNode!.Add(new XElement("Published", new XAttribute("Culture", language), publishedValue));
             }
         }
     }


### PR DESCRIPTION
In v8 usync files - most nodeName and published already have cultured values.
This request will ensure that there are no duplicates