### PR TITLE
Setting default version to both 7 and 8

### DIFF
--- a/uSync.Migrations.Core/Migrators/SyncPropertyMigratorBase.cs
+++ b/uSync.Migrations.Core/Migrators/SyncPropertyMigratorBase.cs
@@ -53,7 +53,7 @@ public abstract class SyncPropertyMigratorBase : ISyncPropertyMigrator
         }
         else
         {
-            Versions = new[] { 7 };
+            Versions = new[] { 7, 8 };
         }
     }
 


### PR DESCRIPTION
I changed the "default" version to support both 7 and 8. Because the version is set to 7 - most of the converteres are not used.

I am aware that this may not be the desired logic - alternatively, the version must be set on all migrators that are desired for 7 or 8.