### PR TITLE
Fixes that PropertyType is not updated on contentTypes

### DIFF
--- a/uSync.Migrations.Core/Context/ContentTypeMigrationContext.cs
+++ b/uSync.Migrations.Core/Context/ContentTypeMigrationContext.cs
@@ -1,4 +1,5 @@
-﻿using uSync.Migrations.Core.Configuration.Models;
+﻿using Umbraco.Extensions;
+using uSync.Migrations.Core.Configuration.Models;
 using uSync.Migrations.Core.Models;
 
 namespace uSync.Migrations.Core.Context;
@@ -319,4 +320,21 @@ public class ContentTypeMigrationContext
     public string GetReplacementAlias(string alias)
         => _replacementAliases.TryGetValue(alias, out var replacement)
             ? replacement : alias;
+
+
+    public void UpdatePropertyEditorTargets(DataTypeMigrationContext dataTypeContext)
+    {
+        foreach (var property in _propertyTypes.Values)
+        {
+            var editorAlias = property.UpdatedEditorAlias;
+
+            var newEditorName = dataTypeContext.GetPropertyEditorReplacementName(editorAlias);
+
+            if (newEditorName.IsNullOrWhiteSpace() == true)
+            {
+                continue;
+            }
+            property.UpdatedEditorAlias = newEditorName;
+        }
+    }
 }

--- a/uSync.Migrations.Core/Context/DataTypeMigrationContext.cs
+++ b/uSync.Migrations.Core/Context/DataTypeMigrationContext.cs
@@ -22,6 +22,8 @@ public class DataTypeMigrationContext
     /// </summary>
     private Dictionary<Guid, string> _dataTypeVariations { get; set; } = new();
 
+    private Dictionary<string, string> _dataTypePropertyEditorsReplacements = new();
+
 
     /// <summary>
     ///  contains a lookup from defition (guid) to alias, so we can pass that along. 
@@ -97,4 +99,17 @@ public class DataTypeMigrationContext
         return dataTypeDefinition?.Key ?? null;
     }
 
+    public void AddPropertyEditorsReplacementNames(string editorAlias, string newEditorAlias)
+    {
+        if (editorAlias != newEditorAlias)
+            _dataTypePropertyEditorsReplacements.TryAdd(editorAlias, newEditorAlias);
+    }
+
+    public string? GetPropertyEditorReplacementName(string editorAlias)
+    {
+        if (_dataTypePropertyEditorsReplacements.TryGetValue(editorAlias, out var value))
+            return value;
+
+        return null;
+    }
 }

--- a/uSync.Migrations.Core/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -259,6 +259,7 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
         var messages = new List<MigrationMessage>();
         messages.AddRange(base.PreDoMigration(context));
         messages.AddRange(CreateAdditional(context));
+        messages.AddRange(UpdateDataTypePropertyReplacedEditors(context));
         return messages;
     }
 
@@ -324,4 +325,12 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
         }
     }
 
+    private IEnumerable<MigrationMessage> UpdateDataTypePropertyReplacedEditors(SyncMigrationContext context)
+    {
+        var messages = new List<MigrationMessage>();
+
+        context.ContentTypes.UpdatePropertyEditorTargets(context.DataTypes);
+
+        return messages;
+    }
 }

--- a/uSync.Migrations.Core/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedDataTypeHandler.cs
@@ -161,6 +161,8 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
         var newDatabaseType = GetNewDatabaseType(migrator, dataTypeProperty, context);
         var newConfig = GetDataTypeConfig(migrator, dataTypeProperty, context) ?? MakeEmptyLabelConfig(dataTypeProperty);
 
+        context.DataTypes.AddPropertyEditorsReplacementNames(editorAlias, newEditorAlias);
+
         return MakeMigratedXml(key, name, GetLevel(source, level), newEditorAlias, newDatabaseType, folder, newConfig);
     }
 

--- a/uSync.Migrations.Core/Models/EditorAliasInfo.cs
+++ b/uSync.Migrations.Core/Models/EditorAliasInfo.cs
@@ -11,7 +11,7 @@ public class EditorAliasInfo
 
     public string OriginalEditorAlias { get; }
 
-    public string UpdatedEditorAlias { get; }
+    public string UpdatedEditorAlias { get; set; }
 
     public Guid? DataTypeDefinition { get; set; }
 }


### PR DESCRIPTION
This pull request fixes a problem with property types are not updated on contentTypes (after they have been updated on datatypes).

Maybe not the most elegant solution, but it works. of course you are welcome to correct.