### PR TITLE
New grid view property migrators, migrate column settings from grid to block grid

### DIFF
--- a/uSync.Migrations.Core/Context/DataTypeMigrationContext.cs
+++ b/uSync.Migrations.Core/Context/DataTypeMigrationContext.cs
@@ -30,6 +30,9 @@ public class DataTypeMigrationContext
     /// </summary>
     private Dictionary<Guid, string> _dataTypeAliases { get; set; } = new();
 
+    private Dictionary<string, NewDataTypeInfo> _newDataTypes
+            = new Dictionary<string, NewDataTypeInfo>(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>
     ///  add a datatype alias to the lookup
     /// </summary>
@@ -87,6 +90,30 @@ public class DataTypeMigrationContext
     public string GetVariation(Guid guid, string defaultValue)
         => _dataTypeVariations?.TryGetValue(guid, out var variation) == true
             ? variation : defaultValue;
+
+    /// <summary>
+    ///  add a new data type - will then be processed as part of the 
+    ///  migration process.
+    /// </summary>
+    public void AddNewDataType(NewDataTypeInfo newDataType)
+    {
+        if (!_newDataTypes.ContainsKey(newDataType.Alias))
+            _newDataTypes.Add(newDataType.Alias, newDataType);
+    }
+
+    /// <summary>
+    ///  list of all the new data types to be created. 
+    /// </summary>
+    /// <returns></returns>
+    public IList<NewDataTypeInfo> GetNewDataTypes()
+        => _newDataTypes.Values.ToList();
+
+    /// <summary>
+    ///  get new datatype by alias
+    /// </summary>
+    /// <returns></returns>
+    public NewDataTypeInfo? GetNewDataType(string alias)
+        => _newDataTypes.Values.FirstOrDefault(dt => dt.Alias == alias);
 
     /// <summary>
     ///  return the first definition that we find matching the editorAlias

--- a/uSync.Migrations.Core/Extensions/ContentTypeExtensions.cs
+++ b/uSync.Migrations.Core/Extensions/ContentTypeExtensions.cs
@@ -41,17 +41,21 @@ internal static class ContentTypeExtensions
                 index++;
 
                 var dataType = dataTypeService.GetDataType(property.DataTypeAlias);
-                if (dataType == null) continue;
+                var newDataType = dataType == null ?
+                                  context.DataTypes.GetNewDataType(property.DataTypeAlias) :
+                                  null;
+
+                if (dataType == null && newDataType == null) continue;
 
                 var propNode = new XElement("GenericProperty",
                 new XElement("Key", $"{newDocType.Alias}_{property.Alias}".ToGuid()),
                     new XElement("Name", property.Name),
                     new XElement("Alias", property.Alias),
-                    new XElement("Definition", dataType.Key),
-                    new XElement("Type", dataType.EditorAlias),
+                    new XElement("Definition", dataType == null ? newDataType!.Key : dataType.Key),
+                    new XElement("Type", dataType == null ? newDataType!.EditorAlias : dataType.EditorAlias),
                     new XElement("Mandatory", false),
                     new XElement("Validation", ""),
-                    new XElement("Description", new XCData("")),
+                    new XElement("Description", new XCData(property.Description ?? "")),
                     new XElement("SortOrder", index),
                     GetTabElement(property, newDocType),
                     new XElement("Variations", "Nothing"),

--- a/uSync.Migrations.Core/Extensions/DataTypeExtensions.cs
+++ b/uSync.Migrations.Core/Extensions/DataTypeExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+using System.Xml.Linq;
+using Umbraco.Extensions;
+
+using uSync.Core;
+using uSync.Migrations.Core.Context;
+using uSync.Migrations.Core.Models;
+
+namespace uSync.Migrations.Core.Extensions;
+internal static class DataTypeExtensions
+{
+    public static XElement MakeXMLFromNewDataType(this NewDataTypeInfo newDataType, 
+        JsonSerializerSettings _jsonSerializerSettings)
+    {
+        var source = new XElement("DataType",
+                     new XAttribute(uSyncConstants.Xml.Key, newDataType.Alias.ToGuid()),
+                     new XAttribute(uSyncConstants.Xml.Alias, newDataType.Alias),
+                     new XAttribute(uSyncConstants.Xml.Level, 1),
+                     new XElement(uSyncConstants.Xml.Info,
+                         new XElement(uSyncConstants.Xml.Name, newDataType.Name),
+                         new XElement("EditorAlias", newDataType.EditorAlias),
+                         new XElement("DatabaseType", newDataType.DatabaseType)));
+
+        if (newDataType.Config != null)
+        {
+            source.Add(new XElement("Config",
+                new XCData(JsonConvert.SerializeObject(newDataType.Config, _jsonSerializerSettings))));
+        }
+
+        return source;
+    }
+}

--- a/uSync.Migrations.Core/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -316,11 +316,17 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
         foreach (var property in contentType.Properties)
         {
             var dataType = _dataTypeService.GetDataType(property.DataTypeAlias);
+            var newDataType = dataType == null ?
+                              context.DataTypes.GetNewDataType(property.DataTypeAlias) :
+                              null;
 
-            if (dataType != null)
+            if (dataType != null || newDataType != null)
             {
+                var editorAlias = dataType == null ? newDataType!.EditorAlias : dataType.EditorAlias;
+                var key = dataType == null ? newDataType!.Key : dataType.Key;
+
                 context.ContentTypes.AddProperty(contentType.Alias, property.Alias,
-                    property.OriginalEditorAlias ?? dataType.EditorAlias, dataType.EditorAlias, dataType.Key);
+                    property.OriginalEditorAlias ?? editorAlias, editorAlias, key);
             }
         }
     }

--- a/uSync.Migrations.Core/Handlers/Shared/SharedDataTypeHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedDataTypeHandler.cs
@@ -10,8 +10,10 @@ using Umbraco.Cms.Core.Services;
 
 using uSync.Core;
 using uSync.Migrations.Core.Context;
+using uSync.Migrations.Core.Extensions;
 using uSync.Migrations.Core.Migrators;
 using uSync.Migrations.Core.Migrators.Models;
+using uSync.Migrations.Core.Models;
 using uSync.Migrations.Core.Serialization;
 using uSync.Migrations.Core.Services;
 
@@ -193,6 +195,40 @@ internal abstract class SharedDataTypeHandler : SharedHandlerBase<DataType>
         }
 
         return target;
+    }
+
+    /// <summary>
+    ///  hook into the DoMigration loop so we can add additional datatypes
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns></returns>
+	protected override IEnumerable<MigrationMessage> PostDoMigration(SyncMigrationContext context)
+    {
+        var messages = new List<MigrationMessage>();
+        messages.AddRange(base.PostDoMigration(context));
+        messages.AddRange(CreateAdditional(context));
+        return messages;
+    }
+
+    /// <summary>
+    ///  Add additional data types that might have been added by datatypes during the 
+    ///  first part of the migration (i.e BlockGrid conversion)
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    protected IEnumerable<MigrationMessage> CreateAdditional(SyncMigrationContext context)
+    {
+        var messages = new List<MigrationMessage>();
+
+        foreach (var dataType in context.DataTypes.GetNewDataTypes())
+        {
+            // if this has been blocked don't add it. 
+            if (context.IsBlocked(ItemType, dataType.Alias)) continue;
+
+            var source = dataType.MakeXMLFromNewDataType(_jsonSerializerSettings);
+            messages.Add(SaveTargetXml(context.Metadata.MigrationId, source));
+        }
+        return messages;
     }
 
 }

--- a/uSync.Migrations.Core/Models/NewContentTypeProperty.cs
+++ b/uSync.Migrations.Core/Models/NewContentTypeProperty.cs
@@ -9,16 +9,23 @@ public class NewContentTypeProperty
         DataTypeAlias = dataTypeAlias ?? throw new ArgumentNullException(nameof(dataTypeAlias));
     }
 
-    public NewContentTypeProperty(string name, string alias, string dataTypeAlias, string orginalEditorAlias)
+    public NewContentTypeProperty(string name, string alias, string dataTypeAlias, string? orginalEditorAlias)
         : this(name, alias, dataTypeAlias)
     {
         OriginalEditorAlias = orginalEditorAlias;
+    }
+
+    public NewContentTypeProperty(string name, string alias, string dataTypeAlias, string? orginalEditorAlias, string? description)
+        : this(name, alias, dataTypeAlias, orginalEditorAlias)
+    {
+        Description = description;
     }
 
 
     public string Name { get; set; }
     public string Alias { get; set; }
     public string DataTypeAlias { get; set; }
+    public string? Description { get; set; }
 
     public string? OriginalEditorAlias { get; set; }
     public string TabAlias { get; set; } = "block";

--- a/uSync.Migrations.Core/Models/NewDataTypeInfo.cs
+++ b/uSync.Migrations.Core/Models/NewDataTypeInfo.cs
@@ -1,0 +1,26 @@
+﻿namespace uSync.Migrations.Core.Models;
+
+public class NewDataTypeInfo
+{
+    public NewDataTypeInfo(Guid key, string alias, string name, string editorAlias, string databaseType, object? config)
+    {
+        Key = key;
+        Alias = alias ?? throw new ArgumentNullException(nameof(alias));
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        EditorAlias = editorAlias ?? throw new ArgumentNullException(nameof(editorAlias));
+        DatabaseType = databaseType ?? throw new ArgumentNullException(nameof(databaseType));
+        Config = config;
+    }
+
+    public Guid Key { get; set; } = Guid.Empty;
+
+    public string Alias { get; set; }
+
+    public string Name { get; set; }
+
+    public string EditorAlias { get; set; }
+
+    public string DatabaseType { get; set; }
+
+    public object? Config { get; set; }
+}

--- a/uSync.Migrations.Migrators/BlockGrid/BlockMigrators/GridBlockMigratorSimpleBase.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/BlockMigrators/GridBlockMigratorSimpleBase.cs
@@ -37,7 +37,7 @@ public abstract class GridBlockMigratorSimpleBase
             $"{editor.Icon ?? "icon-book"} color-purple",
             "BlockGrid/Elements")
         {
-            Description = $"Converted from Grid {editor.Name} element",
+            //Description = $"Converted from Grid {editor.Name} element",
             IsElement = true,
             Properties = new List<NewContentTypeProperty>
             {

--- a/uSync.Migrations.Migrators/BlockGrid/Config/GridToBlockGridConfigContext.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Config/GridToBlockGridConfigContext.cs
@@ -23,6 +23,7 @@ internal class GridToBlockGridConfigContext
     public List<BlockGridConfiguration.BlockGridGroupConfiguration> BlockGroups { get; } = new();
     public Dictionary<string, BlockGridConfiguration.BlockGridBlockConfiguration> LayoutBlocks { get; } = new();
     public List<BlockGridConfiguration.BlockGridBlockConfiguration> ContentBlocks { get; } = new();
+    public List<BlockGridConfiguration.BlockGridBlockConfiguration> AreaSettingsBlocks { get; } = new();
 
     public BlockGridConfiguration.BlockGridAreaConfiguration RootArea { get; } = new();
     public Dictionary<BlockGridConfiguration.BlockGridAreaConfiguration, IEnumerable<string>> AllowedEditors { get; } = new();
@@ -39,6 +40,12 @@ internal class GridToBlockGridConfigContext
         Name = "Grid Blocks"
     };
 
+    public BlockGridConfiguration.BlockGridGroupConfiguration AreaSettingsGroup { get; } = new()
+    {
+        Key = $"group_{nameof(AreaSettingsGroup)}".ToGuid(),
+        Name = "Area Settings"
+    };
+
 
     public GridToBlockGridConfigContext(GridConfiguration gridConfiguration, ILegacyGridEditorsConfig gridConfig)
     {
@@ -48,6 +55,7 @@ internal class GridToBlockGridConfigContext
 
         BlockGroups.Add(LayoutsGroup);
         BlockGroups.Add(GridBlocksGroup);
+        BlockGroups.Add(AreaSettingsGroup);
     }
 
     public IEnumerable<string> GetAllowedLayouts(BlockGridConfiguration.BlockGridAreaConfiguration area)
@@ -97,6 +105,7 @@ internal class GridToBlockGridConfigContext
 
         result.Blocks = ContentBlocks
             .Union(LayoutBlocks.Values)
+            .Union(AreaSettingsBlocks)
             .Where(x => x.ContentElementTypeKey != Guid.Empty)
             .ToArray();
 
@@ -110,6 +119,7 @@ internal class GridToBlockGridConfigContext
             .Where(x => referencedGroupKeys.Contains(x.Key))
             .ToArray();
 
+        result.MaxPropertyWidth = "100%";
 
         return result;
 

--- a/uSync.Migrations.Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutSettingsHelper.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Config/GridToBlockGridConfigLayoutSettingsHelper.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 
 using Newtonsoft.Json.Linq;
-
+using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Extensions;
 
 using uSync.Migrations.Migrators.BlockGrid.Extensions;
@@ -94,5 +94,23 @@ internal class GridToBlockGridConfigLayoutSettingsHelper
             IsElement = true,
             Properties = contentTypeProperties.ToList()
         });
+
+        if (isArea)
+        {
+            var areaSettingsBlock = new BlockGridConfiguration.BlockGridBlockConfiguration
+            {
+                Label = _conventions.AreaSettingsElementTypeName,
+                AllowAtRoot = false,
+                ContentElementTypeKey = context.GetContentTypeKeyOrDefault(_conventions.AreaSettingsElementTypeAlias, _conventions.AreaSettingsElementTypeAlias.ToGuid()),
+                SettingsElementTypeKey = context.GetContentTypeKeyOrDefault(alias, alias.ToGuid()),
+                GroupKey = gridBlockContext.AreaSettingsGroup.Key.ToString(),
+                BackgroundColor = Grid.LayoutBlocks.Background,
+                IconColor = Grid.LayoutBlocks.Icon,
+                ForceHideContentEditorInOverlay = true
+            };
+
+            gridBlockContext.AreaSettingsBlocks.Add(areaSettingsBlock);
+
+        }
     }
 }

--- a/uSync.Migrations.Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -2,16 +2,18 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
+using System.Text.RegularExpressions;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 using uSync.Migrations.Migrators.BlockGrid.BlockMigrators;
 using uSync.Migrations.Migrators.BlockGrid.Extensions;
 using uSync.Migrations.Migrators.BlockGrid.Models;
+using uSync.Migrations.Migrators.BlockGrid.SettingsMigrators;
 
 namespace uSync.Migrations.Migrators.BlockGrid.Content;
 
@@ -24,17 +26,20 @@ internal class GridToBlockContentHelper
     private readonly GridConventions _conventions;
     private readonly ILogger<GridToBlockContentHelper> _logger;
     private readonly IProfilingLogger _profilingLogger;
+    private readonly IMediaService _mediaService;
 
     public GridToBlockContentHelper(
         GridConventions gridConventions,
         SyncBlockMigratorCollection blockMigrators,
         ILogger<GridToBlockContentHelper> logger,
-        IProfilingLogger profilingLogger)
+        IProfilingLogger profilingLogger,
+        IMediaService mediaService)
     {
         _blockMigrators = blockMigrators;
         _conventions = gridConventions;
         _logger = logger;
         _profilingLogger = profilingLogger;
+        _mediaService = mediaService;
     }
 
     /// <summary>
@@ -104,14 +109,16 @@ internal class GridToBlockContentHelper
                     var areaIsFullWidth = rowIsFullWidth && area.value.Grid.GetIntOrDefault(0) == gridColumns;
 
                     // get the content
-                    var contentAndSettings = GetGridAreaBlockContent(area.value, context).ToList();
-                    if (!contentAndSettings.Any()) continue;
+                    var content = GetGridAreaBlockContent(area.value, context).ToList();
+                    if (!content.Any()) continue;
+
+                    var settings = GetSettingsBlockItemDataFromArea(area.value, context, dataTypeAlias);
 
                     // get the layouts 
-                    var layouts = GetGridAreaBlockLayouts(area.value, contentAndSettings).ToList();
+                    var layouts = GetGridAreaBlockLayouts(area.value, content).ToList();
                     if (!layouts.Any()) continue;
 
-                    if (areaIsFullWidth)
+                    if (settings is null && areaIsFullWidth)
                     {
                         blockLayouts.AddRange(layouts);
                     }
@@ -123,18 +130,49 @@ internal class GridToBlockContentHelper
                             Items = layouts.ToArray()
                         };
 
+                        if (settings is not null)
+                        {
+                            // create a container that we can add the settings to, put the content in the container, and put the container in areaItem
+
+                            var childAreaItem = new BlockGridLayoutAreaItem
+                            {
+                                Key = _conventions.SettingsContainerLayoutBlockLabel.ToGuid(),
+                                Items = layouts.ToArray()
+                            };
+
+                            var settingsContainerLayoutItem = new BlockGridLayoutItem()
+                            {
+                                ContentUdi = settings.Udi,
+                                ColumnSpan = gridColumns,
+                                RowSpan = 1,
+                                SettingsUdi = settings.Udi,
+                                Areas = new BlockGridLayoutAreaItem[] { childAreaItem }
+                            };
+
+                            var childContentData = new BlockItemData
+                            {
+                                Udi = settings.Udi,
+                                ContentTypeKey = _conventions.SettingsContainerLayoutBlockLabel.ToGuid(),
+                            };
+
+                            content.Add(childContentData);
+
+                            areaItem.Items = new BlockGridLayoutItem[] { settingsContainerLayoutItem };
+                        }
+
                         rowLayoutAreas.Add(areaItem);
                     }
 
-                    // add the content and settings to the block. 
-                    contentAndSettings.ForEach(x =>
+                    // add the content to the block. 
+                    content.ForEach(x =>
                     {
-                        block.ContentData.Add(x.Content);
-                        if (x.Settings != null)
-                        {
-                            block.SettingsData.Add(x.Settings);
-                        }
+                        block.ContentData.Add(x);
                     });
+
+                    if (settings is not null)
+                    {
+                        block.SettingsData.Add(settings);
+                    }
                 }
 
                 // row 
@@ -181,28 +219,70 @@ internal class GridToBlockContentHelper
         return block;
     }
 
-    private IEnumerable<BlockContentPair> GetGridAreaBlockContent(GridValue.GridArea area, SyncMigrationContext context)
+    private IEnumerable<BlockItemData> GetGridAreaBlockContent(GridValue.GridArea area, SyncMigrationContext context)
     {
         foreach (var control in area.Controls)
         {
             var content = GetBlockItemDataFromGridControl(control, context);
             if (content == null) continue;
 
-            BlockItemData? settings = null;
-            // TODO Settings ? 
-
-            yield return new BlockContentPair(content, settings);
+            yield return content;
         }
     }
 
-    private IEnumerable<BlockGridLayoutItem> GetGridAreaBlockLayouts(GridValue.GridArea area, IEnumerable<BlockContentPair> contentAndSettings)
+    private BlockItemData? GetSettingsBlockItemDataFromArea(GridValue.GridArea area, SyncMigrationContext context, string dataTypeAlias)
     {
-        foreach (var item in contentAndSettings)
+        if (dataTypeAlias.IsNullOrWhiteSpace())
+        {
+            return null;
+        }
+
+        if ((area.Config is null || area.Config.Count() == 0) &&
+            (area.Styles is null || area.Styles.Count() == 0))
+        {
+            // avoid adding a settings container if there aren't any settings
+            return null;
+        }
+
+        var settingsValues = new Dictionary<string, object?>();
+
+        var areaLayoutSettingsContentTypeAlias = _conventions.LayoutAreaSettingsContentTypeAlias(dataTypeAlias);
+        var areaSettingsContentTypeKey = context.GetContentTypeKeyOrDefault(areaLayoutSettingsContentTypeAlias, areaLayoutSettingsContentTypeAlias.ToGuid());
+        var areaSettingsContentType = context.ContentTypes.GetNewContentTypes().FirstOrDefault(t => t.Alias == areaLayoutSettingsContentTypeAlias);
+
+        if (area.Config is not null)
+        {
+            foreach (JProperty config in area.Config)
+            {
+                AddPropertyValue(context, areaSettingsContentType, settingsValues, config);
+            }
+        }
+
+        if (area.Styles is not null)
+        {
+            foreach (JProperty style in area.Styles)
+            {
+                AddPropertyValue(context, areaSettingsContentType, settingsValues, style);
+            }
+        }
+
+        return new BlockItemData
+        {
+            Udi = Udi.Create(UmbConstants.UdiEntityType.Element, Guid.NewGuid()),
+            ContentTypeKey = areaSettingsContentTypeKey,
+            ContentTypeAlias = areaLayoutSettingsContentTypeAlias,
+            RawPropertyValues = settingsValues
+        };
+    }
+
+    private IEnumerable<BlockGridLayoutItem> GetGridAreaBlockLayouts(GridValue.GridArea area, IEnumerable<BlockItemData> content)
+    {
+        foreach (var item in content)
         {
             var layout = new BlockGridLayoutItem
             {
-                ContentUdi = item.Content.Udi,
-                SettingsUdi = item.Settings?.Udi,
+                ContentUdi = item.Udi,
+                SettingsUdi = null,
                 ColumnSpan = area.Grid.GetIntOrDefault(0),
                 RowSpan = 1
             };
@@ -238,12 +318,13 @@ internal class GridToBlockContentHelper
 
         var rowLayoutSettingsContentTypeAlias = _conventions.LayoutSettingsContentTypeAlias(dataTypeAlias);
         var rowSettingsContentTypeKey = context.GetContentTypeKeyOrDefault(rowLayoutSettingsContentTypeAlias, rowLayoutSettingsContentTypeAlias.ToGuid());
+        var rowSettingsContentType = context.ContentTypes.GetNewContentTypes().FirstOrDefault(t => t.Alias == rowLayoutSettingsContentTypeAlias);
 
         if (row.Config is not null)
         {
             foreach (JProperty config in row.Config)
             {
-                settingsValues.Add(_conventions.FormatGridSettingKey(config.Name), config.Value);
+                AddPropertyValue(context, rowSettingsContentType, settingsValues, config);
             }
         }
 
@@ -251,13 +332,7 @@ internal class GridToBlockContentHelper
         {
             foreach (JProperty style in row.Styles)
             {
-                // Dont overwrite values. If styles have same settings keys as config, what should happen?
-                // TODO: Figure out what to do here / what gets priority?##
-                var formattedKey = _conventions.FormatGridSettingKey(style.Name);
-                if (!settingsValues.ContainsKey(formattedKey))
-                {
-                    settingsValues.Add(formattedKey, style.Value);
-                }
+                AddPropertyValue(context, rowSettingsContentType, settingsValues, style);
             }
         }
 
@@ -269,6 +344,62 @@ internal class GridToBlockContentHelper
             RawPropertyValues = settingsValues
         };
     }
+
+    private void AddPropertyValue(SyncMigrationContext context, NewContentTypeInfo? rowSettingsContentType, Dictionary<string, object?> settingsValues, JProperty config)
+    {
+        var formattedKey = _conventions.FormatGridSettingKey(config.Name);
+
+        if (settingsValues.ContainsKey(formattedKey))
+        {
+            // Dont overwrite values. If styles have same settings keys as config, what should happen?
+            // TODO: Figure out what to do here / what gets priority?##
+            return;
+        }
+
+        var configValue = config.Value;
+
+        // For radio button list data types, replace the value with the label, since Umbraco radio button lists don't have separate labels and values.
+        // The new value (the old label) will need to be translated to the old value in the presentation code.
+        if (rowSettingsContentType != null)
+        {
+            var property = rowSettingsContentType.Properties.FirstOrDefault(p => p.Alias == config.Name);
+
+            if (property != null)
+            {
+                var dataType = context.DataTypes.GetNewDataType(property.DataTypeAlias);
+
+                if (dataType != null &&
+                    dataType.Config is RadioButtonListConfig)
+                {
+                    var radioButtonListConfig = (dataType.Config as RadioButtonListConfig)!;
+                    var configItem = radioButtonListConfig.Items.FirstOrDefault(i => i.OldValue == configValue.Value<string>());
+                    if (configItem != null)
+                    {
+                        configValue = JToken.Parse(string.Format("'{0}'", configItem.Value));
+                    }
+                }
+                else if (property.DataTypeAlias == "Image Media Picker")
+                {
+                    Match match = (new Regex(@"^url\((.*)\)$")).Match(config.Value.ToString());
+                    
+                    if (match.Success)
+                    {
+                        string path = match.Groups[1].Value;
+                        IMedia? media = _mediaService.GetMediaByPath(config.Value.ToString().Replace("url(", "").Replace(")", ""));
+
+                        if (media is not null)
+                        {
+                            configValue = JToken.Parse(string.Format("[{0}]", JsonConvert.SerializeObject(new { key = Guid.NewGuid(), mediaKey = media.Key })));
+                        }
+                    }
+                }
+            }
+        }
+
+        settingsValues.Add(formattedKey, configValue);
+    }
+
+
     private BlockGridLayoutItem GetGridRowBlockLayout(BlockContentPair rowContentAndSettings, List<BlockGridLayoutAreaItem> rowLayoutAreas, int? rowColumns)
     {
         return new BlockGridLayoutItem
@@ -279,7 +410,6 @@ internal class GridToBlockContentHelper
             ColumnSpan = rowColumns,
             RowSpan = 1,
         };
-
     }
 
     private BlockItemData? GetBlockItemDataFromGridControl(GridValue.GridControl control, SyncMigrationContext context)

--- a/uSync.Migrations.Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -118,7 +118,30 @@ internal class GridToBlockContentHelper
                     var layouts = GetGridAreaBlockLayouts(area.value, content).ToList();
                     if (!layouts.Any()) continue;
 
-                    if (settings is null && areaIsFullWidth)
+                    if (settings is not null)
+                    {
+                        var areaSettingsContentItem = new BlockItemData()
+                        {
+                            Udi = Udi.Create(UmbConstants.UdiEntityType.Element, Guid.NewGuid()),
+                            ContentTypeKey = context.ContentTypes.GetKeyByAlias(_conventions.AreaSettingsElementTypeAlias)
+                        };
+
+                        content.Add(areaSettingsContentItem);
+
+                        var areaSettingsItem = new BlockGridLayoutItem()
+                        {
+                            ContentUdi = areaSettingsContentItem.Udi,
+                            ColumnSpan = gridColumns,
+                            RowSpan = 1,
+                            SettingsUdi = settings.Udi
+                        };
+
+                        layouts.Insert(0, areaSettingsItem);
+
+                        block.SettingsData.Add(settings);
+                    }
+
+                    if (areaIsFullWidth)
                     {
                         blockLayouts.AddRange(layouts);
                     }
@@ -130,36 +153,6 @@ internal class GridToBlockContentHelper
                             Items = layouts.ToArray()
                         };
 
-                        if (settings is not null)
-                        {
-                            // create a container that we can add the settings to, put the content in the container, and put the container in areaItem
-
-                            var childAreaItem = new BlockGridLayoutAreaItem
-                            {
-                                Key = _conventions.SettingsContainerLayoutBlockLabel.ToGuid(),
-                                Items = layouts.ToArray()
-                            };
-
-                            var settingsContainerLayoutItem = new BlockGridLayoutItem()
-                            {
-                                ContentUdi = settings.Udi,
-                                ColumnSpan = gridColumns,
-                                RowSpan = 1,
-                                SettingsUdi = settings.Udi,
-                                Areas = new BlockGridLayoutAreaItem[] { childAreaItem }
-                            };
-
-                            var childContentData = new BlockItemData
-                            {
-                                Udi = settings.Udi,
-                                ContentTypeKey = _conventions.SettingsContainerLayoutBlockLabel.ToGuid(),
-                            };
-
-                            content.Add(childContentData);
-
-                            areaItem.Items = new BlockGridLayoutItem[] { settingsContainerLayoutItem };
-                        }
-
                         rowLayoutAreas.Add(areaItem);
                     }
 
@@ -168,16 +161,10 @@ internal class GridToBlockContentHelper
                     {
                         block.ContentData.Add(x);
                     });
-
-                    if (settings is not null)
-                    {
-                        block.SettingsData.Add(settings);
-                    }
                 }
 
                 // row 
                 if (!rowLayoutAreas.Any()) continue;
-
 
                 var rowContentAndSettings = GetGridRowBlockContentAndSettings(row, context, dataTypeAlias);
 

--- a/uSync.Migrations.Migrators/BlockGrid/Extensions/GridConfigurationExtensions.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Extensions/GridConfigurationExtensions.cs
@@ -67,17 +67,19 @@ internal static class GridConfigurationExtensions
             foreach (var elementKey in keys)
             {
                 var label = editorConfig.GetBlockname();
-                if (keys.Count > 0)
+                /*if (keys.Count > 0)
                 {
                     label = $"{label} ({context.ContentTypes.GetAliasByKey(elementKey)})";
-                }
+                }*/
                 yield return new BlockGridConfiguration.BlockGridBlockConfiguration
                 {
                     Label = label,
                     ContentElementTypeKey = elementKey,
                     GroupKey = groupKey != Guid.Empty ? groupKey.ToString() : null,
                     BackgroundColor = Grid.GridBlocks.Background,
-                    IconColor = Grid.GridBlocks.Icon
+                    IconColor = Grid.GridBlocks.Icon,
+                    View = Grid.GridBlocks.View,
+                    AllowAtRoot = false
                 };
             }
         }
@@ -92,7 +94,10 @@ internal static class GridConfigurationExtensions
     {
         if (editorConfig?.Config.TryGetValue("nameTemplate", out var nameTemplateValue) == true)
         {
-            return nameTemplateValue as string ?? editorConfig?.Name ?? string.Empty;
+            if (!string.IsNullOrEmpty(nameTemplateValue as string))
+            {
+                return (nameTemplateValue as string)!;
+            }
         }
 
         // 

--- a/uSync.Migrations.Migrators/BlockGrid/Extensions/GridConventions.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Extensions/GridConventions.cs
@@ -31,8 +31,14 @@ internal class GridConventions
 
     public string LayoutContentTypeAlias(string layout)
         => layout.GetBlockGridLayoutContentTypeAlias(ShortStringHelper);
+
     public string LayoutSettingsContentTypeAlias(string layout)
         => layout.GetBlockGridLayoutSettingsContentTypeAlias(ShortStringHelper);
+
+    public string LayoutAreaSettingsContentTypeAlias(string layout)
+        => layout.GetBlockGridLayoutAreaSettingsContentTypeAlias(ShortStringHelper);
+
+    public string SettingsContainerLayoutBlockLabel => "Settings container";
 
     public string FormatGridSettingKey(string setting)
     {

--- a/uSync.Migrations.Migrators/BlockGrid/Extensions/GridConventions.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Extensions/GridConventions.cs
@@ -38,7 +38,10 @@ internal class GridConventions
     public string LayoutAreaSettingsContentTypeAlias(string layout)
         => layout.GetBlockGridLayoutAreaSettingsContentTypeAlias(ShortStringHelper);
 
-    public string SettingsContainerLayoutBlockLabel => "Settings container";
+    public string AreaSettingsElementTypeName => "Area Settings";
+
+    public string AreaSettingsElementTypeAlias 
+        => AreaSettingsElementTypeName.ToSafeAlias(ShortStringHelper);
 
     public string FormatGridSettingKey(string setting)
     {

--- a/uSync.Migrations.Migrators/BlockGrid/Extensions/GridToBlockGridNameExtensions.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Extensions/GridToBlockGridNameExtensions.cs
@@ -34,6 +34,6 @@ internal static class GridToBlockGridNameExtensions
         => name.GetContentTypeAlias("BlockGridLayoutSettings_", shortStringHelper);
 
     public static string GetBlockGridLayoutAreaSettingsContentTypeAlias(this string name, IShortStringHelper shortStringHelper)
-    => name.GetContentTypeAlias("BlockGridLayoutAreaSettings_", shortStringHelper);
+        => name.GetContentTypeAlias("BlockGridLayoutAreaSettings_", shortStringHelper);
 
 }

--- a/uSync.Migrations.Migrators/BlockGrid/Extensions/GridToBlockGridNameExtensions.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Extensions/GridToBlockGridNameExtensions.cs
@@ -33,4 +33,7 @@ internal static class GridToBlockGridNameExtensions
     public static string GetBlockGridLayoutSettingsContentTypeAlias(this string name, IShortStringHelper shortStringHelper)
         => name.GetContentTypeAlias("BlockGridLayoutSettings_", shortStringHelper);
 
+    public static string GetBlockGridLayoutAreaSettingsContentTypeAlias(this string name, IShortStringHelper shortStringHelper)
+    => name.GetContentTypeAlias("BlockGridLayoutAreaSettings_", shortStringHelper);
+
 }

--- a/uSync.Migrations.Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 
 using uSync.Migrations.Core.Legacy.Grid;
@@ -31,6 +32,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
     private readonly ILogger<GridToBlockGridMigrator> _logger;
     private readonly IProfilingLogger _profilingLogger;
     private readonly GridConventions _conventions;
+    private readonly IMediaService _mediaService;
 
     public GridToBlockGridMigrator(
         ILegacyGridConfig gridConfig,
@@ -38,7 +40,8 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
         GridSettingsViewMigratorCollection gridSettingsMigrators,
         IShortStringHelper shortStringHelper,
         ILoggerFactory loggerFactory,
-        IProfilingLogger profilingLogger)
+        IProfilingLogger profilingLogger,
+        IMediaService mediaService)
     {
         _gridConfig = gridConfig;
         _blockMigrators = blockMigrators;
@@ -47,6 +50,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
         _loggerFactory = loggerFactory;
         _profilingLogger = profilingLogger;
         _logger = loggerFactory.CreateLogger<GridToBlockGridMigrator>();
+        _mediaService = mediaService;
     }
 
     public override string GetEditorAlias(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
@@ -87,7 +91,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
         layoutSettingsBlockHelper.AddGridSettings(gridToBlockContext, context, dataTypeProperty.DataTypeAlias);
 
         // prep the layouts 
-        layoutBlockHelper.AddLayoutBlocks(gridToBlockContext, context, dataTypeProperty.DataTypeAlias);
+        layoutBlockHelper.AddLayoutBlocks(gridToBlockContext, context, dataTypeProperty.DataTypeAlias, addAreaSettingsLayout: layoutSettingsBlockHelper.AnyAreaSettings);
 
         // Add the content blocks
         contentBlockHelper.AddContentBlocks(gridToBlockContext, context);
@@ -169,7 +173,8 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
             _conventions,
             _blockMigrators,
             _loggerFactory.CreateLogger<GridToBlockContentHelper>(),
-            _profilingLogger);
+            _profilingLogger,
+            _mediaService);
 
         var blockValue = helper.ConvertToBlockValue(source, context, dataTypeAlias ?? "");
         if (blockValue == null)

--- a/uSync.Migrations.Migrators/BlockGrid/GridToBlockGridMigrator.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/GridToBlockGridMigrator.cs
@@ -91,7 +91,7 @@ public class GridToBlockGridMigrator : SyncPropertyMigratorBase
         layoutSettingsBlockHelper.AddGridSettings(gridToBlockContext, context, dataTypeProperty.DataTypeAlias);
 
         // prep the layouts 
-        layoutBlockHelper.AddLayoutBlocks(gridToBlockContext, context, dataTypeProperty.DataTypeAlias, addAreaSettingsLayout: layoutSettingsBlockHelper.AnyAreaSettings);
+        layoutBlockHelper.AddLayoutBlocks(gridToBlockContext, context, dataTypeProperty.DataTypeAlias, addAreaSettings: layoutSettingsBlockHelper.AnyAreaSettings);
 
         // Add the content blocks
         contentBlockHelper.AddContentBlocks(gridToBlockContext, context);

--- a/uSync.Migrations.Migrators/BlockGrid/Models/GridModels.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Models/GridModels.cs
@@ -17,6 +17,7 @@ internal static class Grid
     {
         public const string Background = "#fce5cd";
         public const string Icon = "#ce7e00";
+        public const string View = "~/App_Plugins/Umbraco.Community.BlockPreview/views/block-preview.html";
     }
 }
 

--- a/uSync.Migrations.Migrators/BlockGrid/Models/GridModels.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Models/GridModels.cs
@@ -60,7 +60,7 @@ internal class GridSettingsConfiguration
     GridSettingsConfigurationItem[]? ConfigItems { get; set; }
 }
 
-internal class GridSettingsConfigurationItem
+public class GridSettingsConfigurationItem
 {
     [JsonProperty("label")]
     public string? Label { get; set; }
@@ -79,6 +79,18 @@ internal class GridSettingsConfigurationItem
 
     [JsonProperty("applyTo")]
     public string? ApplyTo { get; set; }
+
+    [JsonProperty("prevalues")]
+    public IEnumerable<GridSettingsConfigurationItemPrevalue>? Prevalues { get; set; }
+
+}
+public class GridSettingsConfigurationItemPrevalue
+{
+    [JsonProperty("label")]
+    public string? Label { get; set; }
+
+    [JsonProperty("value")]
+    public string? Value { get; set; }
 }
 /// <summary>
 ///  contains the data for a block (content and settings)

--- a/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/GridViewPropertyImageMigrator.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/GridViewPropertyImageMigrator.cs
@@ -2,11 +2,11 @@
 
 namespace uSync.Migrations.Migrators.BlockGrid.SettingsMigrators;
 
-public class GridViewPropertyBooleanMigrator : IGridSettingsViewMigrator
+public class GridViewPropertyImageMigrator : IGridSettingsViewMigrator
 {
-    public string ViewKey => "Boolean";
+    public string ViewKey => "ImagePicker";
 
-    public string GetNewDataTypeAlias(string gridAlias, string? configItemLabel) => "True/false";
+    public string GetNewDataTypeAlias(string gridAlias, string? configItemLabel) => "Image Media Picker";
 
     public object ConvertContentString(string value)
     {

--- a/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/GridViewPropertyNumberMigrator.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/GridViewPropertyNumberMigrator.cs
@@ -2,11 +2,11 @@
 
 namespace uSync.Migrations.Migrators.BlockGrid.SettingsMigrators;
 
-public class GridViewPropertyBooleanMigrator : IGridSettingsViewMigrator
+public class GridViewPropertyNumberMigrator : IGridSettingsViewMigrator
 {
-    public string ViewKey => "Boolean";
+    public string ViewKey => "Number";
 
-    public string GetNewDataTypeAlias(string gridAlias, string? configItemLabel) => "True/false";
+    public string GetNewDataTypeAlias(string gridAlias, string? configItemLabel) => "Numeric";
 
     public object ConvertContentString(string value)
     {

--- a/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/GridViewPropertyNumberMigrator.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/GridViewPropertyNumberMigrator.cs
@@ -13,7 +13,7 @@ public class GridViewPropertyNumberMigrator : IGridSettingsViewMigrator
         return value;
     }
 
-    public NewDataTypeInfo? GetAdditionalDataType(string dataTypeAlias, IEnumerable<string>? preValues)
+    public NewDataTypeInfo? GetAdditionalDataType(string dataTypeAlias, IEnumerable<GridSettingsConfigurationItemPrevalue>? preValues)
     {
         return null;
     }

--- a/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/GridViewPropertyRadioButtonListMigrator.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/GridViewPropertyRadioButtonListMigrator.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Extensions;
+using uSync.Migrations.Migrators.BlockGrid.Models;
 
 namespace uSync.Migrations.Migrators.BlockGrid.SettingsMigrators;
 
@@ -26,7 +27,7 @@ public class GridViewPropertyRadioButtonListMigrator : IGridSettingsViewMigrator
         return value;
     }
 
-    public NewDataTypeInfo? GetAdditionalDataType(string dataTypeAlias, IEnumerable<string>? preValues)
+    public NewDataTypeInfo? GetAdditionalDataType(string dataTypeAlias, IEnumerable<GridSettingsConfigurationItemPrevalue>? preValues)
     {
         if (preValues is null)
         {
@@ -47,9 +48,9 @@ public class GridViewPropertyRadioButtonListMigrator : IGridSettingsViewMigrator
 
 public class RadioButtonListConfig
 {
-    public RadioButtonListConfig(IEnumerable<string> preValues) 
+    public RadioButtonListConfig(IEnumerable<GridSettingsConfigurationItemPrevalue> preValues) 
     {
-        Items = preValues.Select((value, ix) => new RadioButtonListConfigItem() { Id = ix, Value = value });
+        Items = preValues.Select((preValue, ix) => new RadioButtonListConfigItem() { Id = ix, Value = preValue.Label, OldValue = preValue.Value });
     }
 
     [JsonProperty("items")]
@@ -63,4 +64,7 @@ public class RadioButtonListConfigItem
 
     [JsonProperty("value")]
     public string? Value { get; set; }
+
+    [JsonIgnore]
+    public string? OldValue { get; set; }
 }

--- a/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/GridViewPropertyRadioButtonListMigrator.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/GridViewPropertyRadioButtonListMigrator.cs
@@ -1,0 +1,66 @@
+﻿using Newtonsoft.Json;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Extensions;
+
+namespace uSync.Migrations.Migrators.BlockGrid.SettingsMigrators;
+
+public class GridViewPropertyRadioButtonListMigrator : IGridSettingsViewMigrator
+{
+    public string ViewKey => "RadioButtonList";
+
+    public string GetNewDataTypeAlias(string gridAlias, string? configItemLabel)
+    {
+        string newDataTypeAlias = gridAlias;
+        if (!string.IsNullOrEmpty(configItemLabel))
+        {
+            newDataTypeAlias += " - " + configItemLabel;
+        }
+        newDataTypeAlias += " - Radio Button List";
+
+        return newDataTypeAlias;
+    }
+
+
+    public object ConvertContentString(string value)
+    {
+        return value;
+    }
+
+    public NewDataTypeInfo? GetAdditionalDataType(string dataTypeAlias, IEnumerable<string>? preValues)
+    {
+        if (preValues is null)
+        {
+            return null;
+        }
+
+        NewDataTypeInfo newDataTypeInfo = 
+            new NewDataTypeInfo(dataTypeAlias.ToGuid(), 
+                                dataTypeAlias, 
+                                dataTypeAlias, 
+                                "Umbraco.RadioButtonList", 
+                                nameof(ValueStorageType.Nvarchar), 
+                                new RadioButtonListConfig(preValues));
+
+        return newDataTypeInfo;
+    }
+}
+
+public class RadioButtonListConfig
+{
+    public RadioButtonListConfig(IEnumerable<string> preValues) 
+    {
+        Items = preValues.Select((value, ix) => new RadioButtonListConfigItem() { Id = ix, Value = value });
+    }
+
+    [JsonProperty("items")]
+    public IEnumerable<RadioButtonListConfigItem> Items { get; set; }
+}
+
+public class RadioButtonListConfigItem
+{
+    [JsonProperty("id")]
+    public int Id { get; set; }
+
+    [JsonProperty("value")]
+    public string? Value { get; set; }
+}

--- a/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/IGridSettingsViewMigrator.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/IGridSettingsViewMigrator.cs
@@ -6,8 +6,10 @@ namespace uSync.Migrations.Migrators.BlockGrid.SettingsMigrators;
 public interface IGridSettingsViewMigrator : IDiscoverable
 {
     string ViewKey { get; }
-    string NewDataTypeAlias { get; }
+    string GetNewDataTypeAlias(string gridAlias, string? configItemLabel);
     public object ConvertContentString(string value);
+
+    public NewDataTypeInfo? GetAdditionalDataType(string dataTypeAlias, IEnumerable<string>? preValues);
 }
 
 public class GridSettingsViewMigratorCollectionBuilder

--- a/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/IGridSettingsViewMigrator.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/SettingsMigrators/IGridSettingsViewMigrator.cs
@@ -1,5 +1,6 @@
 ﻿using Umbraco.Cms.Core.Composing;
 using Umbraco.Extensions;
+using uSync.Migrations.Migrators.BlockGrid.Models;
 
 namespace uSync.Migrations.Migrators.BlockGrid.SettingsMigrators;
 
@@ -9,7 +10,7 @@ public interface IGridSettingsViewMigrator : IDiscoverable
     string GetNewDataTypeAlias(string gridAlias, string? configItemLabel);
     public object ConvertContentString(string value);
 
-    public NewDataTypeInfo? GetAdditionalDataType(string dataTypeAlias, IEnumerable<string>? preValues);
+    public NewDataTypeInfo? GetAdditionalDataType(string dataTypeAlias, IEnumerable<GridSettingsConfigurationItemPrevalue>? preValues);
 }
 
 public class GridSettingsViewMigratorCollectionBuilder

--- a/uSync.Migrations.Migrators/Optional/NestedToBlockListMigrator.cs
+++ b/uSync.Migrations.Migrators/Optional/NestedToBlockListMigrator.cs
@@ -78,6 +78,8 @@ public class NestedToBlockListMigrator : SyncPropertyMigratorBase
                 Max = nestedConfig.MaxItems == 0 ? null : nestedConfig.MaxItems,
                 Min = nestedConfig.MinItems == 0 ? null : nestedConfig.MinItems
             },
+            MaxPropertyWidth = "100%",
+            UseInlineEditingAsDefault = true
         };
 
         if (nestedConfig.ContentTypes != null)


### PR DESCRIPTION
Added new settings migrators for:

- imagepicker
- number
- radiobuttonlist

The radio button list requires a new data type, so it's more complex than the others. The grid allows labels and values in a radio button list setting to be different, but that's not possible in a standard Umbraco radio button list, so I'm only keeping the labels. You'd need to add some code to convert from labels to values before outputting in a view.

Also added migration of column settings from grid to block grid. There's no way to add settings to a block grid area, so if there are settings present on a column they are added to an "Area Settings" component which is added as the first component in the area.
