### PR TITLE
Add Block Settings Directly To Layout Blocks

### DIFF
--- a/uSync.Migrations.Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
+++ b/uSync.Migrations.Migrators/BlockGrid/Content/GridToBlockContentHelper.cs
@@ -120,23 +120,10 @@ internal class GridToBlockContentHelper
 
                     if (settings is not null)
                     {
-                        var areaSettingsContentItem = new BlockItemData()
-                        {
-                            Udi = Udi.Create(UmbConstants.UdiEntityType.Element, Guid.NewGuid()),
-                            ContentTypeKey = context.ContentTypes.GetKeyByAlias(_conventions.AreaSettingsElementTypeAlias)
-                        };
-
-                        content.Add(areaSettingsContentItem);
-
-                        var areaSettingsItem = new BlockGridLayoutItem()
-                        {
-                            ContentUdi = areaSettingsContentItem.Udi,
-                            ColumnSpan = gridColumns,
-                            RowSpan = 1,
-                            SettingsUdi = settings.Udi
-                        };
-
-                        layouts.Insert(0, areaSettingsItem);
+                        // add the settings to the layout items
+                        foreach (var layoutItem in layouts) {
+                            layoutItem.SettingsUdi = settings.Udi;
+                        }
 
                         block.SettingsData.Add(settings);
                     }


### PR DESCRIPTION
When using areas that have settings, rather than add an additional "Area Settings Block" as the first block, this PR will add the respective settings and their content values to each layout area directly, so that you have a Block with the proper settings.