### PR TITLE
Fix broken inline macros

### DIFF
--- a/uSync.Migrations.Migrators/Core/RichTextBoxMigrator.cs
+++ b/uSync.Migrations.Migrators/Core/RichTextBoxMigrator.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using HtmlAgilityPack;
+using Newtonsoft.Json.Linq;
 
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Extensions;
@@ -9,6 +10,7 @@ namespace uSync.Migrations.Migrators.Core;
 
 [SyncMigrator(UmbEditors.Aliases.TinyMce, typeof(RichTextConfiguration), IsDefaultAlias = true)]
 [SyncMigrator("Umbraco.TinyMCEv3")]
+[SyncMigratorVersion(7, 8)]
 public class RichTextBoxMigrator : SyncPropertyMigratorBase
 {
     public override object? GetConfigValues(SyncMigrationDataTypeProperty dataTypeProperty, SyncMigrationContext context)
@@ -73,7 +75,31 @@ public class RichTextBoxMigrator : SyncPropertyMigratorBase
         var richTextValue = string.Empty;
 
         if (string.IsNullOrWhiteSpace(contentProperty.Value) == false)
+        {
             richTextValue = GuidExtensions.LocalLink2Udi(contentProperty.Value);
+
+            // Fix legacy inline macro format
+            var doc = new HtmlDocument();
+            doc.LoadHtml(richTextValue);
+            var wrappedMacros = doc.DocumentNode.SelectNodes("//div[contains(concat(' ', normalize-space(@class), ' '), ' umb-macro-holder ') and contains(concat(' ', normalize-space(@class), ' '), ' mceNonEditable ')]");
+            if (wrappedMacros is not null)
+            {
+                foreach (var wrappedMacro in wrappedMacros)
+                {
+                    // Find macro inside the comment
+                    var macroCode = wrappedMacro.ChildNodes.FirstOrDefault(x => x.NodeType == HtmlNodeType.Comment)?.InnerHtml;
+                    macroCode = macroCode?.Replace("<!--", "").Replace("-->", "");
+
+                    if (macroCode is null)
+                    {
+                        continue;
+                    }
+
+                    // Replace the div with the raw macro code (using string replacement here as the HTML is not strictly valid!)
+                    richTextValue = richTextValue.ReplaceFirst(wrappedMacro.OuterHtml, macroCode);
+                }
+            }
+        }
 
         return richTextValue;
     }


### PR DESCRIPTION
I've had plenty of macros in the DB with the rendering wrapper (`<div class="umb-macro-holder mceNonEditable">`) stored in the value. This is no longer expected to be stored and is added/removed by the editor. This change migrates this legacy format into the new value expected, without the wrapper.