### PR TITLE
Prevents adding language titles unnecessarily

### DIFF
--- a/uSync.Migrations.Core/Context/ContentTypeMigrationContext.cs
+++ b/uSync.Migrations.Core/Context/ContentTypeMigrationContext.cs
@@ -36,6 +36,9 @@ public class ContentTypeMigrationContext
     private Dictionary<string, string> _replacementAliases =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+    private Dictionary<string, string> _contentTypeVariations =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>
     ///  Add a content type key to the context.
     /// </summary>
@@ -320,6 +323,29 @@ public class ContentTypeMigrationContext
     public string GetReplacementAlias(string alias)
         => _replacementAliases.TryGetValue(alias, out var replacement)
             ? replacement : alias;
+
+    /// <summary>
+    /// Add variation info for a content type (e.g., "Nothing", "Culture", "Segment", "CultureAndSegment")
+    /// </summary>
+    public void AddVariation(string contentTypeAlias, string variation)
+        => _contentTypeVariations.TryAdd(contentTypeAlias, variation);
+
+    /// <summary>
+    /// Get the variation setting for a content type
+    /// </summary>
+    public string GetVariation(string contentTypeAlias)
+        => _contentTypeVariations.TryGetValue(contentTypeAlias, out var variation)
+            ? variation : "Nothing";
+
+    /// <summary>
+    /// Check if a content type varies by culture
+    /// </summary>
+    public bool VariesByCulture(string contentTypeAlias)
+    {
+        var variation = GetVariation(contentTypeAlias);
+        return variation.Equals("Culture", StringComparison.OrdinalIgnoreCase)
+            || variation.Equals("CultureAndSegment", StringComparison.OrdinalIgnoreCase);
+    }
 
 
     public void UpdatePropertyEditorTargets(DataTypeMigrationContext dataTypeContext)

--- a/uSync.Migrations.Core/Handlers/Shared/SharedContentBaseHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedContentBaseHandler.cs
@@ -121,7 +121,7 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
         target.Add(propertiesList);
 
         // check we have language title / and published statuses
-        EnsureLanguageTitles(target);
+        EnsureLanguageTitles(target, contentType, context);
 
         return target;
     }
@@ -266,8 +266,14 @@ internal abstract class SharedContentBaseHandler<TEntity> : SharedHandlerBase<TE
     ///  something was missing.
     /// </remarks>
 
-    protected virtual void EnsureLanguageTitles(XElement node)
+    protected virtual void EnsureLanguageTitles(XElement node, string contentType, SyncMigrationContext context)
     {
+        // Don't add language titles if the content type doesn't vary by culture
+        if (!context.ContentTypes.VariesByCulture(contentType))
+        {
+            return;
+        }
+
         var propertiesNode = node.Element("Properties");
         if (propertiesNode == null) return;
 

--- a/uSync.Migrations.Core/Handlers/Shared/SharedContentTypeBaseHandler.cs
+++ b/uSync.Migrations.Core/Handlers/Shared/SharedContentTypeBaseHandler.cs
@@ -129,6 +129,10 @@ internal abstract class SharedContentTypeBaseHandler<TEntity> : SharedHandlerBas
         if (ItemType == nameof(ContentType))
         {
             CheckVariations(target);
+
+            // Store variation info in context for use by content handlers
+            var variations = target.Element("Info")?.Element("Variations")?.Value ?? "Nothing";
+            context.ContentTypes.AddVariation(alias, variations);
         }
 
         return target;


### PR DESCRIPTION
Prevents adding language titles to content types that do not vary by culture.

This change ensures that language titles are only added when the content type is configured to vary by culture, avoiding unnecessary data and potential issues.

It introduces:

- A method to determine if a content type varies by culture based on its variation setting.
- Context storage of content type variation info.
- A check in the `EnsureLanguageTitles` method to prevent adding titles for non-culture variant content types.