### PR TITLE
Looser guard for macros to account for JSON encoding

### DIFF
--- a/src/uSync.Migrations.Migrators/Macros/MacroToBlockRteMigrator.cs
+++ b/src/uSync.Migrations.Migrators/Macros/MacroToBlockRteMigrator.cs
@@ -37,7 +37,7 @@ internal class MacroToBlockRteMigrator : SyncValueMapperBase, ISyncMapper
     public override async Task<string?> GetImportValueAsync(string value, string editorAlias, SyncSerializerOptions options)
     {
         // it is the responsiblity of the mapper to know if the import has happened before. 
-        if (value.Contains("<?UMBRACO_MACRO") is false) return value;
+        if (value.Contains("UMBRACO_MACRO") is false) return value;
 
         // see if this has been converted to the new block style. 
         if (value.TryDeserialize<RichTextEditorValue>(out var richTextEditorValue) is false || richTextEditorValue is null)


### PR DESCRIPTION
A JSON encoded value contains "\\u003C?UMBRACO_MACRO" and not "<?UMBRACO_MACRO" so JSON encoded macros won't get migrated.

Loosening the guard here to just "UMBRACO_MACRO" (the same as below) fixes this.